### PR TITLE
feat: add solang injector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,11 +59,29 @@ checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "arrayvec"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
 ]
 
 [[package]]
@@ -130,12 +148,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
+name = "base58"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
 name = "base58check"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee2fe4c9a0c84515f136aaae2466744a721af6d63339c18689d9e995d74d99b"
 dependencies = [
- "base58",
+ "base58 0.1.0",
  "sha2 0.8.2",
 ]
 
@@ -205,6 +229,18 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium 0.5.3",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
@@ -224,6 +260,16 @@ dependencies = [
  "crypto-mac 0.8.0",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+dependencies = [
+ "arrayvec 0.4.12",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -475,6 +521,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "contract-metadata"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6ebbaeb7c25c27c6dec510353f8c2ac7da40ac5a291ff34aceda3c9977809f"
+dependencies = [
+ "semver 1.0.4",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +693,7 @@ dependencies = [
  "glob",
  "rayon",
  "semver 1.0.4",
+ "solang",
  "svm-rs",
  "tokio",
  "tracing",
@@ -671,6 +736,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "der"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +801,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -772,6 +874,15 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -974,7 +1085,7 @@ name = "ethers-core"
 version = "0.5.4"
 source = "git+https://github.com/gakonst/ethers-rs?branch=master#0c94b58cd5e0d3214daa13b4691664e5a35ac287"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.1",
  "bytes",
  "convert_case",
  "ecdsa",
@@ -1160,7 +1271,7 @@ name = "evmodin"
 version = "0.1.0"
 source = "git+https://github.com/vorot93/evmodin#ef1bee33aeee962421e32bf23cfb0bb4903a3125"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.1",
  "bytes",
  "derive_more",
  "educe",
@@ -1219,6 +1330,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fnv"
@@ -1463,6 +1580,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b09e2322d20d14bc2572401ce7c1d60b4748580a76c230ed9c1f8938f0c833"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error 2.0.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1835,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkwell"
+version = "0.1.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3b605692df6dfbbaf596f7f15b7e3a629a32bd32e5dc28400fcb8bd07e6ad8"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "parking_lot",
+ "regex",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185190cd08999fdedf30920ba83ab9c05c786c27b657865422caf51a11e31a8a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1923,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "lalrpop"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +1965,19 @@ name = "libc"
 version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+
+[[package]]
+name = "llvm-sys"
+version = "120.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a810627ac62b396f5fd2214ba9bbd8748d4d6efdc4d2c1c1303ea7a75763ce"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex",
+ "semver 0.11.0",
+]
 
 [[package]]
 name = "lock_api"
@@ -1794,6 +1996,25 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "lsp-types"
+version = "0.89.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e0dedfd52cc32325598b2631e0eba31b7b708959676a9f837042f276b09a2"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -1872,6 +2093,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec 0.19.5",
+ "funty",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +2148,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,6 +2175,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2005,7 +2273,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.1",
  "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
@@ -2024,6 +2292,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parking_lot"
@@ -2090,6 +2364,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pharos"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2416,65 @@ dependencies = [
  "futures",
  "rustc_version 0.4.0",
 ]
+
+[[package]]
+name = "phf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -2152,6 +2529,12 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primitive-types"
@@ -2296,6 +2679,12 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
+name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
@@ -2381,6 +2770,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -2559,6 +2958,12 @@ dependencies = [
  "sct",
  "webpki",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "rusty-fork"
@@ -2740,6 +3145,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,6 +3178,18 @@ dependencies = [
  "eyre",
  "rustc-hex",
  "serde_json",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -2849,6 +3277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
 name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +3302,46 @@ checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "solang"
+version = "0.1.8"
+source = "git+https://github.com/hyperledger-labs/solang#14fe041c0e6cc02afd39abcbd5eb51b745dd6585"
+dependencies = [
+ "base58 0.2.0",
+ "bitvec 0.20.4",
+ "blake2-rfc",
+ "cc",
+ "clap",
+ "contract-metadata",
+ "funty",
+ "handlebars",
+ "hex",
+ "inkwell",
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "libc",
+ "num-bigint",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+ "parity-wasm",
+ "phf",
+ "regex",
+ "ripemd160",
+ "semver 1.0.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.9.8",
+ "tempfile",
+ "tiny-keccak",
+ "tokio",
+ "tower-lsp",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2948,6 +3422,19 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
+name = "string_cache"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
+dependencies = [
+ "lazy_static",
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.8.0",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -3061,6 +3548,17 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
  "winapi",
 ]
 
@@ -3260,6 +3758,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-lsp"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701465c44f9e5655785b1420f3dea1d33d15f2fea2e0a65d25c4fd91ec0e6238"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "log",
+ "lsp-types",
+ "nom",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower-lsp-macros",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb72acc00b574cffa151d0725b3b26404554b371b4c6e059c58eb23f9f097140"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,6 +3971,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/solc/Cargo.toml
+++ b/solc/Cargo.toml
@@ -19,6 +19,9 @@ tracing = "0.1.28"
 glob = "0.3.0"
 tokio = "1.12.0"
 rayon = "1.5.1"
+solang = { git = "https://github.com/hyperledger-labs/solang" }
 
 [features]
+#default = ["solang"]
 sync = []
+#solang-parse = ["solang"]

--- a/solc/src/lib.rs
+++ b/solc/src/lib.rs
@@ -10,6 +10,9 @@ use std::{
     time::Instant,
 };
 
+// #[cfg(feature = "solang-parse")]
+pub mod solang;
+
 #[cfg(any(test, feature = "sync"))]
 use std::sync::Mutex;
 #[cfg(any(test, feature = "sync"))]

--- a/solc/src/solang.rs
+++ b/solc/src/solang.rs
@@ -1,0 +1,352 @@
+//! [solang](https://github.com/hyperledger-labs/solang) support used to inject statements into solidity files
+
+use std::{
+    fs,
+    io::{self, Cursor, Read, Write},
+    path::Path,
+};
+
+use solang::parser::{self, pt::*};
+
+/// A trait that is invoked while traversing the  solidity AST.
+///
+/// Each method of the `Visitor` trait is a hook that can be potentially overriden.
+pub trait Visitor {
+    fn visit_stmt(&mut self, stmt: Statement, injector: &mut SolInjector) {
+        match stmt {
+            Statement::Block { statements, .. } => {
+                statements.into_iter().for_each(|stmt| self.visit_stmt(stmt, injector))
+            }
+            Statement::Assembly { assembly, .. } => {
+                assembly.into_iter().for_each(|stmt| self.visit_assembly(stmt, injector))
+            }
+            Statement::Args(_, args) => {
+                args.into_iter().for_each(|stmt| self.visit_arg(stmt, injector))
+            }
+            Statement::If(loc, expr, stmt, other) => {
+                self.visit_if(IfStmt { loc, expr, stmt, other }, injector)
+            }
+            Statement::While(loc, expr, stmt) => self.visit_while(loc, expr, *stmt, injector),
+            Statement::Expression(_, expr) => self.visit_expr(expr, injector),
+            Statement::VariableDefinition(loc, v, expr) => {
+                self.visit_var_def(loc, v, expr, injector)
+            }
+            Statement::For(a, b, c, d, e) => self.visit_for(a, b, c, d, e, injector),
+            Statement::DoWhile(loc, stmt, expr) => self.visit_do_while(loc, *stmt, expr, injector),
+            Statement::Continue(loc) => self.visit_continue(loc, injector),
+            Statement::Break(loc) => self.visit_break(loc, injector),
+            Statement::Return(loc, r) => self.visit_return(loc, r, injector),
+            Statement::Emit(loc, expr) => self.visit_emit(loc, expr, injector),
+            Statement::Try(a, b, c, d, e) => self.visit_try(a, b, c, d, e, injector),
+        }
+    }
+
+    fn visit_assembly(&mut self, _stmt: AssemblyStatement, _injector: &mut SolInjector) {}
+
+    fn visit_arg(&mut self, _stmt: NamedArgument, _injector: &mut SolInjector) {}
+
+    fn visit_if(&mut self, _stmt: IfStmt, _injector: &mut SolInjector) {}
+
+    fn visit_expr(&mut self, _expr: Expression, _injector: &mut SolInjector) {}
+
+    fn visit_emit(&mut self, _loc: Loc, _stmt: Expression, _injector: &mut SolInjector) {}
+
+    fn visit_var_def(
+        &mut self,
+        _loc: Loc,
+        _v: VariableDeclaration,
+        _expr: Option<Expression>,
+        _injector: &mut SolInjector,
+    ) {
+    }
+
+    fn visit_return(&mut self, _loc: Loc, _expr: Option<Expression>, _injector: &mut SolInjector) {}
+
+    fn visit_break(&mut self, _loc: Loc, _injector: &mut SolInjector) {}
+
+    fn visit_continue(&mut self, _loc: Loc, _injector: &mut SolInjector) {}
+
+    fn visit_do_while(
+        &mut self,
+        _loc: Loc,
+        _stmt: Statement,
+        _expr: Expression,
+        _injector: &mut SolInjector,
+    ) {
+    }
+
+    fn visit_while(
+        &mut self,
+        _loc: Loc,
+        _expr: Expression,
+        _stmt: Statement,
+        _injector: &mut SolInjector,
+    ) {
+    }
+
+    fn visit_for(
+        &mut self,
+        _: Loc,
+        _: Option<Box<Statement>>,
+        _: Option<Box<Expression>>,
+        _: Option<Box<Statement>>,
+        _: Option<Box<Statement>>,
+        _injector: &mut SolInjector,
+    ) {
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn visit_try(
+        &mut self,
+        _: Loc,
+        _: Expression,
+        _: Option<(Vec<(Loc, Option<Parameter>)>, Box<Statement>)>,
+        _: Option<Box<(Identifier, Parameter, Statement)>>,
+        _: Box<(Option<Parameter>, Statement)>,
+        _injector: &mut SolInjector,
+    ) {
+    }
+
+    fn visit_function(&mut self, fun: FunctionDefinition, injector: &mut SolInjector) {
+        if let Some(stmt) = fun.body {
+            self.visit_stmt(stmt, injector)
+        }
+    }
+
+    fn visit_contract(&mut self, contract: ContractDefinition, injector: &mut SolInjector) {
+        for part in contract.parts {
+            if let ContractPart::FunctionDefinition(fun) = part {
+                self.visit_function(*fun, injector)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IfStmt {
+    pub loc: Loc,
+    pub expr: Expression,
+    pub stmt: Box<Statement>,
+    pub other: Option<Box<Statement>>,
+}
+
+/// The container type that keeps track of all injections
+#[derive(Debug, Clone)]
+pub struct SolInjector {
+    /// The content of the solidity source file
+    content: String,
+    /// injections into the source content
+    injections: Vec<Injection>,
+}
+
+impl SolInjector {
+    pub fn new(content: impl Into<String>) -> Self {
+        Self { content: content.into(), injections: vec![] }
+    }
+
+    /// Traverses the solidity AST with the given visitor and pipes the modified source code into
+    /// the given output
+    pub fn inject<V, O>(mut self, visitor: &mut V, mut output: O) -> eyre::Result<()>
+    where
+        V: Visitor,
+        O: Write,
+    {
+        let sol = parser::parse(&self.content, 1).map_err(|err| eyre::eyre!("{:?}", err))?;
+
+        for unit in sol.0 {
+            if let SourceUnitPart::ContractDefinition(contract) = unit {
+                visitor.visit_contract(*contract, &mut self);
+            }
+        }
+        let lookup = LineIdentLookup::new(&self.content);
+        let mut buf = Cursor::new(self.content);
+        // sort injections
+        self.injections.sort_by(|a, b| a.loc().1.cmp(&b.loc().1));
+
+        for injection in self.injections {
+            match injection.location {
+                InjectLocation::Before(loc) => {
+                    // write everything before
+                    let num = loc.1 as u64 - buf.position();
+                    io::copy(&mut buf.by_ref().take(num), &mut output)?;
+                    let ident = lookup.line(loc.1).1;
+                    output.write_all(b"\n")?;
+                    for _ in 0..ident {
+                        output.write_all(b" ")?;
+                    }
+                    output.write_all(injection.content.as_bytes())?;
+                    output.write_all(b"\n")?;
+                    for _ in 0..ident {
+                        output.write_all(b" ")?;
+                    }
+                    // write the statement
+                    let num = loc.2 as u64 - buf.position();
+                    io::copy(&mut buf.by_ref().take(num), &mut output)?;
+                }
+                InjectLocation::After(loc) => {
+                    // write the statement
+                    let num = loc.2 as u64 - buf.position();
+                    io::copy(&mut buf.by_ref().take(num), &mut output)?;
+                    let ident = lookup.line(loc.1).1;
+                    output.write_all(b"\n")?;
+                    for _ in 0..ident {
+                        output.write_all(b" ")?;
+                    }
+                    output.write_all(injection.content.as_bytes())?;
+                    output.write_all(b"\n")?;
+                    for _ in 0..ident {
+                        output.write_all(b" ")?;
+                    }
+                }
+            }
+        }
+        io::copy(&mut buf, &mut output)?;
+
+        Ok(())
+    }
+
+    /// Inject content after the given location
+    pub fn after(&mut self, loc: Loc, content: impl Into<String>) {
+        self.injections
+            .push(Injection { content: content.into(), location: InjectLocation::After(loc) })
+    }
+
+    /// Inject content before the given location
+    pub fn before(&mut self, loc: Loc, content: impl Into<String>) {
+        self.injections
+            .push(Injection { content: content.into(), location: InjectLocation::Before(loc) })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Injection {
+    pub content: String,
+    pub location: InjectLocation,
+}
+
+impl Injection {
+    fn loc(&self) -> &Loc {
+        match self.location {
+            InjectLocation::Before(ref loc) => loc,
+            InjectLocation::After(ref loc) => loc,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum InjectLocation {
+    Before(Loc),
+    After(Loc),
+}
+
+/// Helper type to keep track of the lines and their ident
+#[derive(Debug, Clone)]
+struct LineIdentLookup {
+    lines: Vec<usize>,
+    ws: Vec<usize>,
+}
+
+impl LineIdentLookup {
+    fn new(input: &str) -> Self {
+        let mut iter = input.chars().enumerate();
+        let mut lines = vec![0];
+        let mut ws = vec![0];
+
+        while let Some((pos, c)) = iter.next() {
+            if c == '\n' {
+                let mut ident = 0;
+                for (_, s) in iter.by_ref().take_while(|(_, s)| *s != '\n') {
+                    match s {
+                        '\t' => ident += 2,
+                        ' ' | '\x0C' => ident += 1,
+                        _ => break,
+                    }
+                }
+                lines.push(pos);
+                ws.push(ident);
+            }
+        }
+        Self { lines, ws }
+    }
+
+    /// Returns the line number of the given index and the number of white space ident of the line
+    fn line(&self, idx: usize) -> (u64, u64) {
+        let mut line_range = 0..self.lines.len();
+        while line_range.end - line_range.start > 1 {
+            let range_middle = line_range.start + (line_range.end - line_range.start) / 2;
+            let (left, right) = (line_range.start..range_middle, range_middle..line_range.end);
+            if (self.lines[left.start]..self.lines[left.end]).contains(&idx) {
+                line_range = left;
+            } else {
+                line_range = right;
+            }
+        }
+        let line = line_range.start + 1;
+        (line as u64, self.ws[line_range.start] as u64)
+    }
+}
+
+/// Returns the injected solidity file content
+pub fn injected_sol<V: Visitor>(path: impl AsRef<Path>, visitor: &mut V) -> eyre::Result<Vec<u8>> {
+    let content = fs::read_to_string(path.as_ref())?;
+    let mut output = Vec::with_capacity(content.len());
+    SolInjector::new(content).inject(visitor, &mut output)?;
+    Ok(output)
+}
+
+/// Writes the injected solidity file to the given file
+pub fn write_injected_sol<V: Visitor>(
+    path: impl AsRef<Path>,
+    visitor: &mut V,
+    output: impl AsRef<Path>,
+) -> eyre::Result<Vec<u8>> {
+    let injected = injected_sol(path, visitor)?;
+    fs::write(output.as_ref(), &injected)?;
+    Ok(injected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Visitor for () {
+        fn visit_expr(&mut self, expr: Expression, injector: &mut SolInjector) {
+            if let Expression::Assign(_, var, val) = expr {
+                injector.before(var.loc(), "// The Statement begins:");
+                injector.after(val.loc(), "// The Statement ended");
+            }
+        }
+    }
+
+    #[test]
+    fn can_inject() {
+        let contract = r#"// SPDX-License-Identifier: UNLICENSED
+pragma abicoder v2;
+pragma solidity =0.7.6;
+
+contract Greeter {
+    string public greeting;
+
+    function greet(string memory _greeting) public {
+        greeting = _greeting;
+    }
+
+    function gm() public {
+        greeting = "gm";
+    }
+}"#;
+
+        let mut output = Vec::with_capacity(contract.len());
+        SolInjector::new(contract).inject(&mut (), &mut output).unwrap();
+        println!("{}", String::from_utf8_lossy(&output));
+    }
+
+    #[test]
+    fn line_look_up_works() {
+        let text = "x\nxy\n    xyz";
+        let lookup = LineIdentLookup::new(text);
+        dbg!(lookup.clone());
+        assert_eq!(lookup.line(0), (1, 0));
+        assert_eq!(lookup.line(5), (3, 4));
+    }
+}


### PR DESCRIPTION
mvc for solidity injector

How it works:

The `Visitor` trait's function get invoked while traversing the solidity AST (parsed with `solang`), the given `Injector` type stores the content that should be injected (before/after) a location.
Finally the `Injector` pipes the source content to the output destination but injects all `injections`

What should be improved:
* better context awareness during injecting, (e.g. after trailing comma)
* more ergonomic vistior functions