### PR TITLE
Packaging, take 2

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,15 @@
+name: Bump Homebrew version
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create homebrew-core PR
+        uses: mislav/bump-homebrew-formula-action@v1.12
+        with:
+          formula-name: dapptools-rs
+        env:
+          COMMITTER_TOKEN: ${{ secrets.G_TOKEN }}

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Create homebrew-core PR
         uses: mislav/bump-homebrew-formula-action@v1.12
         with:
-          formula-name: dapptools-rs
+          formula-name: foundry
         env:
           COMMITTER_TOKEN: ${{ secrets.G_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,10 @@ jobs:
        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
      - name: Restore artifacts
        uses: actions/download-artifact@v2
+     - name: Archive binaries
+       run: |
+         tar zcvf macos-bins.tar.gz ./target-macos-latest
+         tar zcvf linux-bins.tar.gz ./target-ubuntu-latest
      - name: Build Changelog
        id: github_release
        uses: mikepenz/release-changelog-builder-action@v2.4.2
@@ -103,15 +107,15 @@ jobs:
          files: |
            ./linux-packages/*.deb
            ./linux-packages/*.rpm
-           ./target-macos-latest/*
-           ./target-linux-latest/*
+           ./macos-bins.tar.gz
+           ./linux-bins.tar.gz
      - name: Copy binaries to the server
        uses: appleboy/scp-action@master
        with:
          host: ${{ secrets.REPOSITORY_HOST }}
          username: ${{ secrets.REPOSITORY_HOST_USERNAME }}
          key: ${{ secrets. REPOSITORY_HOST_KEY }}
-         source: "./*.deb"
+         source: "./linux-packages/*.deb"
          target: "/tmp"
      - name: Add binaries to the repository
        uses: appleboy/ssh-action@master
@@ -121,7 +125,7 @@ jobs:
         key: ${{ secrets. REPOSITORY_HOST_KEY }}
         script_stop: true
         script: |
-           cd /tmp
+           cd /tmp/linux-packages
            codename=$( cat /var/repositories/conf/distributions | grep Codename | awk '{print $2}')
            sudo reprepro -b /var/repositories -C main includedeb ${codename} *.deb
-           rm /tmp/*.deb
+           rm -rf /tmp/linux-packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release version
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  build-artifacts:
+    runs-on:  ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - uses: Swatinem/rust-cache@v1
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - name: Upload production artifacts
+        uses: actions/upload-artifact@v2
+        with:
+            name: target-ubuntu-latest
+            path: |
+              ./target/release/seth
+              ./target/release/dapp
+  build-linux-packages:
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set output
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Create target directories
+        run:  mkdir -p ./target/release/
+      - name: Download production artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ./target/release/
+          name: target-ubuntu-latest
+      - uses: kentik/pkg@v1.0.0-rc7
+        name: Build RPM package
+        id: build_rpm
+        with:
+          name: dapptools-rs
+          version: ${{ steps.vars.outputs.tag }}
+          arch: x86_64
+          format: rpm
+          package: packaging/package.yml
+      - uses: kentik/pkg@v1.0.0-rc7
+        name: Build DEB package
+        id: build_deb
+        with:
+          name: dapptools-rs
+          version: ${{ steps.vars.outputs.tag }}
+          arch: x86_64
+          format: deb
+          package: packaging/package.yml
+      - name: Save artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-packages
+          path: |
+            ./${{ steps.build_deb.outputs.package }}
+            ./${{ steps.build_rpm.outputs.package }}
+  create-release:
+    runs-on: ubuntu-latest
+    needs:  [build-linux-packages, build-artifacts]
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v2
+       with:
+        fetch-depth: 1000
+     - name: Set output
+       id: vars
+       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+     - name: Restore artifacts
+       uses: actions/download-artifact@v2
+       with:
+        name: linux-packages
+     - name: Build Changelog
+       id: github_release
+       uses: mikepenz/release-changelog-builder-action@v2.4.2
+       env:
+        GITHUB_TOKEN: ${{ secrets.G_TOKEN }}
+     - name: Create Release
+       id: create-release
+       uses: softprops/action-gh-release@v0.1.13
+       env:
+        GITHUB_TOKEN: ${{ secrets.G_TOKEN }}
+       with:
+         tag_name:  ${{ steps.vars.outputs.tag }}
+         release_name: ${{ github.ref }}
+         body: ${{steps.build_changelog.outputs.changelog}}
+         files: |
+           ./*.deb
+           ./*.rpm
+     - name: Copy binaries to the server
+       uses: appleboy/scp-action@master
+       with:
+         host: ${{ secrets.REPOSITORY_HOST }}
+         username: ${{ secrets.REPOSITORY_HOST_USERNAME }}
+         key: ${{ secrets. REPOSITORY_HOST_KEY }}
+         source: "./*.deb"
+         target: "/tmp"
+     - name: Add binaries to the repository
+       uses: appleboy/ssh-action@master
+       with:
+        host: ${{ secrets.REPOSITORY_HOST }}
+        username: ${{ secrets.REPOSITORY_HOST_USERNAME }}
+        key: ${{ secrets. REPOSITORY_HOST_KEY }}
+        script_stop: true
+        script: |
+           cd /tmp
+           codename=$( cat /var/repositories/conf/distributions | grep Codename | awk '{print $2}')
+           sudo reprepro -b /var/repositories -C main includedeb ${codename} *.deb
+           rm /tmp/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,10 @@ on:
       - 'v*.*.*'
 jobs:
   build-artifacts:
-    runs-on:  ubuntu-latest
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -13,7 +16,11 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
+          override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:
@@ -22,7 +29,7 @@ jobs:
       - name: Upload production artifacts
         uses: actions/upload-artifact@v2
         with:
-            name: target-ubuntu-latest
+            name: target-${{ matrix.os }}
             path: |
               ./target/release/forge
               ./target/release/cast
@@ -79,8 +86,6 @@ jobs:
        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
      - name: Restore artifacts
        uses: actions/download-artifact@v2
-       with:
-        name: linux-packages
      - name: Build Changelog
        id: github_release
        uses: mikepenz/release-changelog-builder-action@v2.4.2
@@ -96,8 +101,10 @@ jobs:
          release_name: ${{ github.ref }}
          body: ${{steps.build_changelog.outputs.changelog}}
          files: |
-           ./*.deb
-           ./*.rpm
+           ./linux-packages/*.deb
+           ./linux-packages/*.rpm
+           ./target-macos-latest/*
+           ./target-linux-latest/*
      - name: Copy binaries to the server
        uses: appleboy/scp-action@master
        with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
         with:
             name: target-ubuntu-latest
             path: |
-              ./target/release/seth
-              ./target/release/dapp
+              ./target/release/forge
+              ./target/release/cast
   build-linux-packages:
     runs-on: ubuntu-latest
     needs: build-artifacts
@@ -45,7 +45,7 @@ jobs:
         name: Build RPM package
         id: build_rpm
         with:
-          name: dapptools-rs
+          name: foundry
           version: ${{ steps.vars.outputs.tag }}
           arch: x86_64
           format: rpm
@@ -54,7 +54,7 @@ jobs:
         name: Build DEB package
         id: build_deb
         with:
-          name: dapptools-rs
+          name: foundry
           version: ${{ steps.vars.outputs.tag }}
           arch: x86_64
           format: deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,30 +49,70 @@ jobs:
           path: ./target/release/
           name: target-ubuntu-latest
       - uses: kentik/pkg@v1.0.0-rc7
-        name: Build RPM package
-        id: build_rpm
+        name: Build foundry RPM package
+        id: build_rpm_foundry
         with:
           name: foundry
           version: ${{ steps.vars.outputs.tag }}
           arch: x86_64
           format: rpm
-          package: packaging/package.yml
+          package: packaging/foundry.yml
       - uses: kentik/pkg@v1.0.0-rc7
-        name: Build DEB package
-        id: build_deb
+        name: Build cast RPM package
+        id: build_rpm_cast
+        with:
+          name: cast
+          version: ${{ steps.vars.outputs.tag }}
+          arch: x86_64
+          format: rpm
+          package: packaging/cast.yml
+      - uses: kentik/pkg@v1.0.0-rc7
+        name: Build forge RPM package
+        id: build_rpm_forge
+        with:
+          name: forge
+          version: ${{ steps.vars.outputs.tag }}
+          arch: x86_64
+          format: rpm
+          package: packaging/forge.yml
+      - uses: kentik/pkg@v1.0.0-rc7
+        name: Build cast DEB package
+        id: build_deb_cast
+        with:
+          name: cast
+          version: ${{ steps.vars.outputs.tag }}
+          arch: x86_64
+          format: deb
+          package: packaging/cast.yml
+      - uses: kentik/pkg@v1.0.0-rc7
+        name: Build foundry DEB package
+        id: build_foundry_cast
         with:
           name: foundry
           version: ${{ steps.vars.outputs.tag }}
           arch: x86_64
           format: deb
-          package: packaging/package.yml
+          package: packaging/foundry.yml
+      - uses: kentik/pkg@v1.0.0-rc7
+        name: Build forge DEB package
+        id: build_deb_forge
+        with:
+          name: forge
+          version: ${{ steps.vars.outputs.tag }}
+          arch: x86_64
+          format: deb
+          package: packaging/forge.yml
       - name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
           name: linux-packages
           path: |
-            ./${{ steps.build_deb.outputs.package }}
-            ./${{ steps.build_rpm.outputs.package }}
+            ./${{ steps.build_deb_cast.outputs.package }}
+            ./${{ steps.build_rpm_cast.outputs.package }}
+            ./${{ steps.build_deb_forge.outputs.package }}
+            ./${{ steps.build_rpm_forge.outputs.package }}
+            ./${{ steps.build_deb_foundry.outputs.package }}
+            ./${{ steps.build_rpm_foundry.outputs.package }}
   create-release:
     runs-on: ubuntu-latest
     needs:  [build-linux-packages, build-artifacts]
@@ -126,6 +166,8 @@ jobs:
         script_stop: true
         script: |
            cd /tmp/linux-packages
-           codename=$( cat /var/repositories/conf/distributions | grep Codename | awk '{print $2}')
-           sudo reprepro -b /var/repositories -C main includedeb ${codename} *.deb
+           codename=$( cat /var/repositories/conf/distributions | grep Codename | awk 'NR==1{print $2}')
+           sudo reprepro -b /var/repositories -C main includedeb bullseye-cast $(ls | grep cast)
+           sudo reprepro -b /var/repositories -C main includedeb bullseye-forge $(ls | grep forge)
+           sudo reprepro -b /var/repositories -C main includedeb bullseye-foundry $(ls | grep foundry)
            rm -rf /tmp/linux-packages

--- a/packaging/cast.yml
+++ b/packaging/cast.yml
@@ -1,0 +1,8 @@
+meta:
+  description: Cast is a swiss army knife for interacting with Ethereum applications from the command line.
+  maintainer: Odysseas Lamtzidis
+files:
+  "/usr/bin/cast":
+    file: target/release/cast
+    mode: "0755"
+    user: "root"

--- a/packaging/forge.yml
+++ b/packaging/forge.yml
@@ -1,0 +1,8 @@
+meta:
+  description: Forge is a fast and flexible Ethereum testing framework, inspired by Dapp.
+  maintainer: Odysseas Lamtzidis
+files:
+  "/usr/bin/forge":
+    file: target/release/forge
+    mode: "0755"
+    user: "root"

--- a/packaging/foundry.yml
+++ b/packaging/foundry.yml
@@ -1,5 +1,5 @@
 meta:
-  description: A drop-in replacement for Dapptools, written in Rust.
+  description: Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.
   maintainer: Odysseas Lamtzidis
 files:
   "/usr/bin/forge":

--- a/packaging/package.yml
+++ b/packaging/package.yml
@@ -1,0 +1,12 @@
+meta:
+  description: A drop-in replacement for Dapptools, written in Rust.
+  maintainer: Odysseas Lamtzidis
+files:
+  "/usr/bin/forge":
+    file: target/release/forge
+    mode: "0755"
+    user: "root"
+  "/usr/bin/cast":
+    file: target/release/cast
+    mode: "0755"
+    user: "root"


### PR DESCRIPTION
After iterating on a private repo, I re-open a more clean PR about packaging. 

Workflows kickstart when a new tagged commit is pushed. Tags should follow `semver.

### Release workflow
- Build Linux binaries
- Build .deb, .rpm packages
-Create release + changelog
- Copy packages to `apt.dapptools.rs` and add them to the repository

### Homebrew workflow
- Create a pr in Homebrew/homebrew-core that bumps the version of dapptools-rs to the latest release. The PR has to be merged by the maintainers.

## Release steps:

- Merge this PR
- Add required GitHub secrets to repository
- Push the first tag
- Release will work. Homebrew will fail (cause there is no homebrew. package yet)
- Make PR with dapptools formula to` homebrew/homebrew-core`