### PR TITLE
fix(dapptools): explicitly set lib_paths as allowed paths

### DIFF
--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -208,10 +208,8 @@ impl std::convert::TryFrom<&BuildOpts> for Project {
         remappings.dedup();
 
         // build the path
-        let mut paths_builder = ProjectPathsConfig::builder()
-            .root(&root)
-            .sources(contracts)
-            .artifacts(artifacts);
+        let mut paths_builder =
+            ProjectPathsConfig::builder().root(&root).sources(contracts).artifacts(artifacts);
 
         if !remappings.is_empty() {
             paths_builder = paths_builder.remappings(remappings);

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -218,7 +218,7 @@ impl std::convert::TryFrom<&BuildOpts> for Project {
         let paths = paths_builder.build()?;
 
         // build the project w/ allowed paths = root and all the libs
-        let mut builder = 
+        let mut builder =
             Project::builder().paths(paths).allowed_path(root).allowed_paths(lib_paths);
 
         if opts.no_auto_detect {

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -208,8 +208,11 @@ impl std::convert::TryFrom<&BuildOpts> for Project {
         remappings.dedup();
 
         // build the path
-        let mut paths_builder =
-            ProjectPathsConfig::builder().root(&root).sources(contracts).artifacts(artifacts);
+        let mut paths_builder = ProjectPathsConfig::builder()
+            .root(&root)
+            .sources(contracts)
+            .artifacts(artifacts)
+            .libs(lib_paths);
 
         if !remappings.is_empty() {
             paths_builder = paths_builder.remappings(remappings);

--- a/dapptools/src/dapp_opts.rs
+++ b/dapptools/src/dapp_opts.rs
@@ -211,8 +211,7 @@ impl std::convert::TryFrom<&BuildOpts> for Project {
         let mut paths_builder = ProjectPathsConfig::builder()
             .root(&root)
             .sources(contracts)
-            .artifacts(artifacts)
-            .libs(lib_paths);
+            .artifacts(artifacts);
 
         if !remappings.is_empty() {
             paths_builder = paths_builder.remappings(remappings);
@@ -221,7 +220,8 @@ impl std::convert::TryFrom<&BuildOpts> for Project {
         let paths = paths_builder.build()?;
 
         // build the project w/ allowed paths = root and all the libs
-        let mut builder = Project::builder().paths(paths).allowed_path(root);
+        let mut builder = 
+            Project::builder().paths(paths).allowed_path(root).allowed_paths(lib_paths);
 
         if opts.no_auto_detect {
             builder = builder.no_auto_detect();


### PR DESCRIPTION
Solc wasn't compiling library contracts outside of `root` for me w.o. this. Lmk if there's anything i'm missing. 
EDIT: WIP, going to confirm this soon
EDIT 2: ok, updated the change a bit