### PR TITLE
deal + prank cheat codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Benchmarks TBD in the future, but:
       - [x] store: Sets address storage slot
       - [x] load: Loads address storage slot
       - [x] deal: Sets account balance
-      - [x] prank: Performs a call as another address (changes tx.origin & msg.sender)
+      - [x] prank: Performs a call as another address (changes msg.sender for a call)
       - [x] sign: Signs data
       - [x] addr: Gets address for a private key
       - [ ] makeEOA

--- a/README.md
+++ b/README.md
@@ -137,13 +137,15 @@ Benchmarks TBD in the future, but:
     - [ ] Symbolic execution
     - [ ] Coverage
     - [ ] HEVM-style Solidity cheatcodes
-      - [x] roll
-      - [x] warp
-      - [x] ffi
-      - [x] store
-      - [x] load
-      - [ ] sign
-      - [ ] addr
+      - [x] roll: Sets block.number
+      - [x] warp: Sets block.timestamp
+      - [x] ffi: Perform foreign function call to terminal
+      - [x] store: Sets address storage slot
+      - [x] load: Loads address storage slot
+      - [x] deal: Sets account balance
+      - [x] prank: Performs a call as another address (changes tx.origin & msg.sender)
+      - [x] sign: Signs data
+      - [x] addr: Gets address for a private key
       - [ ] makeEOA
       - ...?
     - [ ] Structured tracing with abi decoding

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -340,7 +340,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 let input = inner.2;
 
                 let value = if let Some(ref transfer) = transfer {
-                    transfer.value.clone()
+                    transfer.value
                 } else {
                     U256::zero()
                 };

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1,6 +1,6 @@
 use super::{
     backend::CheatcodeBackend, memory_stackstate_owned::MemoryStackStateOwned, HEVMCalls,
-    HevmConsoleEvents, BackendExt
+    HevmConsoleEvents,
 };
 use crate::{
     sputnik::{Executor, SputnikExecutor},
@@ -232,7 +232,12 @@ fn evm_error(retdata: &str) -> Capture<(ExitReason, Vec<u8>), Infallible> {
 
 impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> {
     /// Decodes the provided calldata as a
-    fn apply_cheatcode(&mut self, input: Vec<u8>, transfer: Option<Transfer>, target_gas: Option<u64>) -> Capture<(ExitReason, Vec<u8>), Infallible> {
+    fn apply_cheatcode(
+        &mut self,
+        input: Vec<u8>,
+        transfer: Option<Transfer>,
+        target_gas: Option<u64>,
+    ) -> Capture<(ExitReason, Vec<u8>), Infallible> {
         let mut res = vec![];
 
         // Get a mutable ref to the state so we can apply the cheats
@@ -263,7 +268,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 if !self.enable_ffi {
                     return evm_error(
                         "ffi disabled: run again with --ffi if you want to allow tests to call external scripts",
-                    )
+                    );
                 }
 
                 // execute the command & get the stdout
@@ -351,23 +356,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     context,
                 );
                 res = match ret {
-                    Capture::Exit((successful, v)) => {
-                        match successful {
-                            ExitReason::Succeed(_) => {
-                                ethers::abi::encode(&[
-                                    Token::Bool(true),
-                                    Token::Bytes(v.to_vec()),
-                                ])
-                            }
-                            _ => {
-                                ethers::abi::encode(&[
-                                    Token::Bool(false),
-                                    Token::Bytes(v.to_vec()),
-                                ])
-                            }
+                    Capture::Exit((successful, v)) => match successful {
+                        ExitReason::Succeed(_) => {
+                            ethers::abi::encode(&[Token::Bool(true), Token::Bytes(v.to_vec())])
                         }
-                    }
-                    _ => vec![]
+                        _ => ethers::abi::encode(&[Token::Bool(false), Token::Bytes(v.to_vec())]),
+                    },
+                    _ => vec![],
                 };
             }
             HEVMCalls::Deal(inner) => {
@@ -376,7 +371,6 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 state.reset_balance(who);
                 state.deposit(who, value);
             }
-
         };
 
         // TODO: Add more cheat codes.

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -18,6 +18,12 @@ pub struct MemoryStackStateOwned<'config, B> {
 }
 
 impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
+    pub fn deposit(&mut self, address: H160, value: U256) {
+        self.substate.deposit(address, value, &self.backend);
+    }
+}
+
+impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
     pub fn new(metadata: StackSubstateMetadata<'config>, backend: B) -> Self {
         Self { backend, substate: MemoryStackSubstate::new(metadata) }
     }

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -42,6 +42,8 @@ ethers::contract::abigen!(
             ffi(string[])(bytes)
             addr(uint256)(address)
             sign(uint256,bytes32)(uint8,bytes32,bytes32)
+            prank(address,address,bytes)(bool,bytes)
+            deal(address,uint256)
     ]"#,
 );
 pub use hevm_mod::HEVMCalls;

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -163,7 +163,6 @@ contract Prank is DSTest {
     function checksOriginAndSender(string calldata input) external returns (string memory) {
         string memory expectedInput = "And his name is JOHN CENA!";
         assertEq(input, expectedInput);
-        assertEq(address(1337), tx.origin);
         assertEq(address(1337), msg.sender);
         string memory expectedRetString = "SUPER SLAM!";
         return expectedRetString;


### PR DESCRIPTION
deal: sets an address's balance
spoof: perform a call to another address from a different address, 
i.e. current tx.origin && msg.sender == address(1) -> hevm.spoof(address(2), address(3), bytes([0000]) calls address(3) from address(2) with the bytes data. note this changes tx.origin. some debate could be had as to if thats the correct functionality. I believe it is

this is WIP as there are some issues rn and no tests
