### PR TITLE
feat(cli): forge init

### DIFF
--- a/assets/ContractTemplate.sol
+++ b/assets/ContractTemplate.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.10;
+
+contract Contract {}

--- a/assets/ContractTemplate.t.sol
+++ b/assets/ContractTemplate.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.10;
+
+contract ContractTest {
+    function setUp() public {}
+}

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -266,31 +266,17 @@ fn main() -> eyre::Result<()> {
 
                 // make the dirs
                 let src = root.join("src");
-                std::fs::create_dir(&src)?;
                 let test = src.join("test");
-                std::fs::create_dir(&test)?;
+                std::fs::create_dir_all(&test)?;
                 let lib = root.join("lib");
                 std::fs::create_dir(&lib)?;
 
-                // write the files
+                // write the contract file
                 let contract_path = src.join("Contract.sol");
-                let contents = r#"// SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.10;
-
-contract Contract {}
-"#;
-                std::fs::write(contract_path, contents)?;
-
+                std::fs::write(contract_path, include_str!("../../assets/ContractTemplate.sol"))?;
                 // write the tests
                 let contract_path = test.join("Contract.t.sol");
-                let contents = r#"// SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.10;
-
-contract ContractTest {
-    function setUp() public {}
-}
-"#;
-                std::fs::write(contract_path, contents)?;
+                std::fs::write(contract_path, include_str!("../../assets/ContractTemplate.t.sol"))?;
 
                 // sets up git
                 std::process::Command::new("git").arg("init").current_dir(&root).spawn()?.wait()?;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -245,6 +245,69 @@ fn main() -> eyre::Result<()> {
                 .collect();
             remappings.iter().for_each(|x| println!("{}", x));
         }
+        Subcommands::Init { root, template } => {
+            let root = root.unwrap_or_else(|| std::env::current_dir().unwrap());
+            // create the root dir if it does not exist
+            if !root.exists() {
+                std::fs::create_dir_all(&root)?;
+            }
+            let root = std::fs::canonicalize(root)?;
+
+            // if a template is provided, then this command is just an alias to `git clone <url>
+            // <path>`
+            if let Some(ref template) = template {
+                println!("Initializing {} from {}...", root.display(), template);
+                std::process::Command::new("git")
+                    .args(&["clone", template, &root.display().to_string()])
+                    .spawn()?
+                    .wait()?;
+            } else {
+                println!("Initializing {}...", root.display());
+
+                // make the dirs
+                let src = root.join("src");
+                std::fs::create_dir(&src)?;
+                let test = src.join("test");
+                std::fs::create_dir(&test)?;
+                let lib = root.join("lib");
+                std::fs::create_dir(&lib)?;
+
+                // write the files
+                let contract_path = src.join("Contract.sol");
+                let contents = r#"// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.10;
+
+contract Contract {}
+"#;
+                std::fs::write(contract_path, contents)?;
+
+                // write the tests
+                let contract_path = test.join("Contract.t.sol");
+                let contents = r#"// SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.10;
+
+contract ContractTest {
+    function setUp() public {}
+}
+"#;
+                std::fs::write(contract_path, contents)?;
+
+                // sets up git
+                std::process::Command::new("git").arg("init").current_dir(&root).spawn()?.wait()?;
+                std::process::Command::new("git")
+                    .args(&["add", "."])
+                    .current_dir(&root)
+                    .spawn()?
+                    .wait()?;
+                std::process::Command::new("git")
+                    .args(&["commit", "-m", "chore: forge init"])
+                    .current_dir(&root)
+                    .spawn()?
+                    .wait()?;
+            }
+
+            println!("Done.");
+        }
     }
 
     Ok(())

--- a/cli/src/forge_opts.rs
+++ b/cli/src/forge_opts.rs
@@ -122,6 +122,13 @@ pub enum Subcommands {
         #[structopt(long, help = "verify on Etherscan")]
         verify: bool,
     },
+    #[structopt(alias = "i", about = "initializes a new forge repository")]
+    Init {
+        #[structopt(help = "the project's root path, default being the current directory")]
+        root: Option<PathBuf>,
+        #[structopt(help = "optional solidity template to start from", long, short)]
+        template: Option<String>,
+    },
 }
 
 /// Represents the common dapp argument pattern for `<path>:<contractname>` where `<path>:` is


### PR DESCRIPTION
Adds a new CLI command, `init` (alias `forge i`)

`forge init`: If no args are provided, it instantiates an empty project inside the current directory.
`forge init ./my-repo`: instantiates an empty project at `./my-repo`
`forge init ./my-repo --template https://github.com/transmissions11/dapptools-template/`: clones dapptols-template at `./my-repo