### PR TITLE
fix(cli): install with Command vs libgit2

### DIFF
--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -19,7 +19,7 @@ mod forge_opts;
 use forge_opts::{EvmType, Opts, Subcommands};
 
 use crate::forge_opts::FullContractInfo;
-use std::{collections::HashMap, convert::TryFrom, path::Path, sync::Arc};
+use std::{collections::HashMap, convert::TryFrom, sync::Arc};
 
 mod cmd;
 mod utils;
@@ -167,7 +167,6 @@ fn main() -> eyre::Result<()> {
         }
         // TODO: Make it work with updates?
         Subcommands::Install { dependencies } => {
-            let repo = git2::Repository::open(".")?;
             let libs = std::path::Path::new("lib");
 
             dependencies.iter().try_for_each(|dep| -> eyre::Result<_> {
@@ -177,58 +176,46 @@ fn main() -> eyre::Result<()> {
                     dep.name, path, dep.url, dep.tag
                 );
 
-                // get the submodule and clone it
-                let mut submodule = repo.submodule(&dep.url, &path, true)?;
-                submodule.clone(None)?;
-
-                // get the repo & checkout the provided tag if necessary
-                // ref: https://stackoverflow.com/a/67240436
-                let submodule = submodule.open()?;
-                if let Some(ref tag) = dep.tag {
-                    let (object, reference) = submodule.revparse_ext(tag)?;
-                    submodule.checkout_tree(&object, None).expect("Failed to checkout");
-
-                    match reference {
-                        // gref is an actual reference like branches or tags
-                        Some(gref) => submodule.set_head(gref.name().unwrap()),
-                        // this is a commit, not a reference
-                        None => submodule.set_head_detached(object.id()),
-                    }
-                    .expect("Failed to set HEAD");
-                }
-
+                // install the dep
                 std::process::Command::new("git")
-                    .args(&["submodule", "update", "--init", "--recursive"])
+                    .args(&["submodule", "add", &dep.url, &path.display().to_string()])
                     .spawn()?
                     .wait()?;
 
-                // commit the submodule's installation
-                let sig = repo.signature()?;
-                let mut index = repo.index()?;
-                // stage `.gitmodules` and the lib
-                index.add_path(Path::new(".gitmodules"))?;
-                index.add_path(&path)?;
-                // need to write the index back to disk
-                index.write()?;
+                // call update on it
+                std::process::Command::new("git")
+                    .args(&[
+                        "submodule",
+                        "update",
+                        "--init",
+                        "--recursive",
+                        &path.display().to_string(),
+                    ])
+                    .spawn()?
+                    .wait()?;
 
-                let id = index.write_tree().unwrap();
-                let tree = repo.find_tree(id).unwrap();
-
+                // checkout the tag if necessary
                 let message = if let Some(ref tag) = dep.tag {
+                    std::process::Command::new("git")
+                        .args(&["checkout", "--recurse-submodules", &tag])
+                        .current_dir(&path)
+                        .spawn()?
+                        .wait()?;
+
+                    std::process::Command::new("git")
+                        .args(&["add", &path.display().to_string()])
+                        .spawn()?
+                        .wait()?;
+
                     format!("forge install: {}\n\n{}", dep.name, tag)
                 } else {
                     format!("forge install: {}", dep.name)
                 };
 
-                // committing to the parent may make running the installation step
-                // in parallel challenging..
-                let parent = repo
-                    .head()?
-                    .resolve()?
-                    .peel(git2::ObjectType::Commit)?
-                    .into_commit()
-                    .map_err(|err| eyre::eyre!("cannot get parent commit: {:?}", err))?;
-                repo.commit(Some("HEAD"), &sig, &sig, &message, &tree, &[&parent])?;
+                std::process::Command::new("git")
+                    .args(&["commit", "-m", &message])
+                    .spawn()?
+                    .wait()?;
 
                 Ok(())
             })?


### PR DESCRIPTION
Replaces the installation logic with `std::command::Command` calls, libgit2 is too low of an API to not shoot yourself in the foot with