### PR TITLE
evmodin: update and fix breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "evmodin"
 version = "0.1.0"
-source = "git+https://github.com/vorot93/evmodin#ef1bee33aeee962421e32bf23cfb0bb4903a3125"
+source = "git+https://github.com/vorot93/evmodin#ecfa46e8feebe93b9313d9fe5eb758081ccfcc3f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1801,7 +1801,7 @@ dependencies = [
 [[package]]
 name = "i256"
 version = "0.1.0"
-source = "git+https://github.com/vorot93/rust-i256#ffd876a79fd6a0c8fb00bb72bd11410cb3b83ec2"
+source = "git+https://github.com/vorot93/rust-i256#7e14ceab6bc45cf1ba6b4f1fb083e38f7187ddd0"
 dependencies = [
  "primitive-types",
 ]
@@ -3450,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/evm-adapters/src/evmodin.rs
+++ b/evm-adapters/src/evmodin.rs
@@ -92,7 +92,10 @@ impl<S: HostExt, Tr: Tracer> Evm<S> for EvmOdin<S, Tr> {
         #[allow(deprecated)]
         let message = Message {
             sender: from,
-            destination: to,
+            recipient: to,
+            // This is only going to be different from `recipient` if
+            // used in a `CALLCODE` or `DELEGATECALL`, but here we're only doing calls
+            code_address: to,
             // What should this be?
             depth: 0,
             kind: self.call_kind.unwrap_or(CallKind::Call),


### PR DESCRIPTION
This fixes the breaking change in evmodin from https://github.com/vorot93/evmodin/commit/767c310aba2e9f8e303af852915ae7a3afc010a2. The tests fail still because we don't have a contract-deployment-enabled host.

If we want proper Evmodin support, we'll need to do something like this repo: https://github.com/guanqun/ethers-forked-evm-provider. This however [copy-pastes a lot of code](https://github.com/guanqun/ethers-forked-evm-provider/tree/master/src/akula) from [Akula](https://github.com/akula-bft/akula) which uses nightly. 

So if we don't want to become a nightly-only project, we'd want to:
1. Refactor Akula's code in non-nightly crates
2. Import Akula's types and most importantly the [opcode eloop](https://github.com/guanqun/ethers-forked-evm-provider/blob/master/src/akula/evm.rs#L293-L558)

Alternatively, we can maybe just clean up the code from the repo above, package it in a crate and import that as a dependency, instead of evmodin. cc @guanqun for visibility and to gauge if there's any interest in figuring out how to support evmodin/akula vm