### PR TITLE
chore: cargo update ethers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdab415d6744056100f40250a66bc430c1a46f7a02e20bc11c94c79a0f0464df"
 
 [[package]]
+name = "const-oid"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +665,18 @@ name = "crypto-bigint"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d12477e115c0d570c12a2dfd859f80b55b60ddb5075df210d3af06d133a69f45"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array 0.14.4",
  "rand_core 0.6.3",
@@ -720,7 +738,16 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2adca118c71ecd9ae094d4b68257b3fdfcb711a612b9eec7b5a0d27a5a70a5b4"
 dependencies = [
- "const-oid",
+ "const-oid 0.6.1",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid 0.7.0",
 ]
 
 [[package]]
@@ -772,8 +799,8 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
- "der",
- "elliptic-curve",
+ "der 0.4.3",
+ "elliptic-curve 0.10.6",
  "hmac 0.11.0",
  "signature",
 ]
@@ -802,11 +829,25 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.2.10",
  "ff",
  "generic-array 0.14.4",
  "group",
  "pkcs8",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73d21281779c2c22cade2a4ab34eee34271869942546a364f7d552d30c62434"
+dependencies = [
+ "crypto-bigint 0.3.2",
+ "der 0.5.1",
+ "generic-array 0.14.4",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
@@ -948,11 +989,12 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "ethers-contract",
  "ethers-core",
+ "ethers-etherscan",
  "ethers-middleware",
  "ethers-providers",
  "ethers-signers",
@@ -961,8 +1003,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -979,8 +1021,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1000,8 +1042,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1014,15 +1056,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.5.5"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "arrayvec",
  "bytes",
  "cargo_metadata",
  "convert_case",
  "ecdsa",
- "elliptic-curve",
+ "elliptic-curve 0.11.1",
  "ethabi",
  "generic-array 0.14.4",
  "hex",
@@ -1042,8 +1084,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "0.1.1"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.2.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1054,8 +1096,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1077,8 +1119,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "0.5.4"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1106,13 +1148,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "0.5.3"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve",
+ "elliptic-curve 0.11.1",
  "eth-keystore",
  "ethers-core",
  "futures-executor",
@@ -1127,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#8a3ee415b73805e0d66c7ba39efca75d5debd91b"
+source = "git+https://github.com/gakonst/ethers-rs#0b68227c38a681cc23554779a64b47c2f1ffad5c"
 dependencies = [
  "colored",
  "ethers-core",
@@ -1141,6 +1183,7 @@ dependencies = [
  "semver 1.0.4",
  "serde",
  "serde_json",
+ "sha2 0.9.8",
  "svm-rs",
  "thiserror",
  "tokio",
@@ -1409,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1419,15 +1462,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1436,18 +1479,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg 1.0.1",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -1455,15 +1496,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-timer"
@@ -1473,11 +1514,10 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1487,8 +1527,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1942,7 +1980,7 @@ checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
- "elliptic-curve",
+ "elliptic-curve 0.10.6",
  "sha2 0.9.8",
  "sha3 0.9.1",
 ]
@@ -2461,7 +2499,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
- "der",
+ "der 0.4.3",
  "spki",
 ]
 
@@ -2559,18 +2597,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -3409,7 +3435,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
 dependencies = [
- "der",
+ "der 0.4.3",
 ]
 
 [[package]]
@@ -3481,13 +3507,15 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.1.2"
-source = "git+https://github.com/roynalnaruto/svm-rs#5d353ec236a596dbfd2b37878ee5aee53ab6eadf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a5e16a3a87cca053bcab26e5de589ccb5779f84dda466f96eead79a98d7de7c"
 dependencies = [
  "anyhow",
  "cfg-if",
  "console",
  "dialoguer",
+ "hex",
  "home",
  "indicatif",
  "itertools",
@@ -3497,6 +3525,7 @@ dependencies = [
  "semver 1.0.4",
  "serde",
  "serde_json",
+ "sha2 0.9.8",
  "structopt",
  "tempfile",
  "thiserror",
@@ -3506,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -167,6 +167,8 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> SputnikExecutor<CheatcodeStackState<'
             .map(|event| {
                 use HevmConsoleEvents::*;
                 match event {
+                    LogsFilter(inner) => format!("{}", inner.0),
+                    LogBytesFilter(inner) => format!("{}", inner.0),
                     LogNamedAddressFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
                     LogNamedBytes32Filter(inner) => {
                         format!("{}: 0x{}", inner.key, hex::encode(inner.val))

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -364,7 +364,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 let ret = self.call(
                     address,
                     Some(Transfer { source: caller, target: address, value }),
-                    input,
+                    input.to_vec(),
                     target_gas,
                     false,
                     context,
@@ -388,7 +388,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             HEVMCalls::Etch(inner) => {
                 let who = inner.0;
                 let code = inner.1;
-                state.set_code(who, code);
+                state.set_code(who, code.to_vec());
             }
         };
 


### PR DESCRIPTION
bump ethers and fix latest ethers breaking changes regard Bytes/Vec<u8>
close #171 