### PR TITLE
fix: emit console.log events on nested calls

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -968,8 +968,9 @@ mod tests {
             evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
 
         // after the evm call is done, we call `logs` and print it all to the user
-        let (_, _, _, logs) =
-            evm.call::<(), _, _>(Address::zero(), addr, "test_log_elsewhere()", (), 0.into()).unwrap();
+        let (_, _, _, logs) = evm
+            .call::<(), _, _>(Address::zero(), addr, "test_log_elsewhere()", (), 0.into())
+            .unwrap();
         let expected = ["0x1111111111111111111111111111111111111111", "Hi", "Hi, Hi"]
             .iter()
             .map(ToString::to_string)

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -560,7 +560,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         }
     }
 
-    // NB: This function is copy-pasted from uptream's call_inner
+    // NB: This function is copy-pasted from uptream's create_inner
     fn create_inner(
         &mut self,
         caller: H160,
@@ -743,7 +743,16 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
         } else if code_address == *CONSOLE_ADDRESS {
             self.console_log(input)
         } else {
-            self.handler.call(code_address, transfer, input, target_gas, is_static, context)
+            self.call_inner(
+                code_address,
+                transfer,
+                input,
+                target_gas,
+                is_static,
+                true,
+                true,
+                context,
+            )
         }
     }
 

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -954,6 +954,30 @@ mod tests {
     }
 
     #[test]
+    fn console_logs_external_contract() {
+        let config = Config::istanbul();
+        let vicinity = new_vicinity();
+        let backend = new_backend(&vicinity, Default::default());
+        let gas_limit = 10_000_000;
+        let precompiles = PRECOMPILES_MAP.clone();
+        let mut evm =
+            Executor::new_with_cheatcodes(backend, gas_limit, &config, &precompiles, true);
+
+        let compiled = COMPILED.find("ConsoleLogs").expect("could not find contract");
+        let (addr, _, _, _) =
+            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+
+        // after the evm call is done, we call `logs` and print it all to the user
+        let (_, _, _, logs) =
+            evm.call::<(), _, _>(Address::zero(), addr, "test_log_elsewhere()", (), 0.into()).unwrap();
+        let expected = ["0x1111111111111111111111111111111111111111", "Hi", "Hi, Hi"]
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        assert_eq!(logs, expected);
+    }
+
+    #[test]
     fn cheatcodes() {
         let config = Config::istanbul();
         let vicinity = new_vicinity();

--- a/evm-adapters/testdata/ConsoleLogs.sol
+++ b/evm-adapters/testdata/ConsoleLogs.sol
@@ -9,12 +9,12 @@ contract ConsoleLogs {
 		console.log("Hi", "Hi");
     }
 	function test_log_elsewhere() public {
-		_OtherContract _otherContract = new _OtherContract();
-		_otherContract.test_log();
+		OtherContract otherContract = new OtherContract();
+		otherContract.test_log();
     }
 }
 
-contract _OtherContract {
+contract OtherContract {
     function test_log() public {
 		console.log(0x1111111111111111111111111111111111111111);
 		console.log("Hi");

--- a/evm-adapters/testdata/ConsoleLogs.sol
+++ b/evm-adapters/testdata/ConsoleLogs.sol
@@ -8,4 +8,16 @@ contract ConsoleLogs {
 		console.log("Hi");
 		console.log("Hi", "Hi");
     }
+	function test_log_elsewhere() public {
+		_OtherContract _otherContract = new _OtherContract();
+		_otherContract.test_log();
+    }
+}
+
+contract _OtherContract {
+    function test_log() public {
+		console.log(0x1111111111111111111111111111111111111111);
+		console.log("Hi");
+		console.log("Hi", "Hi");
+    }
 }


### PR DESCRIPTION
Ensures that our own `call_inner` function gets hooked in on nested calls as well