### PR TITLE
fix: key tests hashmap by function signature (not name)

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -212,7 +212,7 @@ mod tests {
         assert_eq!(only_gm.len(), 1);
 
         assert_eq!(only_gm["GmTest"].len(), 1);
-        assert!(only_gm["GmTest"]["testGm"].success);
+        assert!(only_gm["GmTest"]["testGm()"].success);
     }
 
     mod sputnik {
@@ -241,12 +241,13 @@ mod tests {
                 .iter()
                 .map(|(name, res)| (name, res.logs.clone()))
                 .collect::<HashMap<_, _>>();
+            dbg!(&reasons);
             assert_eq!(
-                reasons[&"test1".to_owned()],
+                reasons[&"test1()".to_owned()],
                 vec!["constructor".to_owned(), "setUp".to_owned(), "one".to_owned()]
             );
             assert_eq!(
-                reasons[&"test2".to_owned()],
+                reasons[&"test2()".to_owned()],
                 vec!["constructor".to_owned(), "setUp".to_owned(), "two".to_owned()]
             );
         }

--- a/forge/testdata/GreetTest.sol
+++ b/forge/testdata/GreetTest.sol
@@ -85,6 +85,15 @@ contract GreeterTest is GreeterTestSetup {
         greeter.greet("yo");
         require(keccak256(abi.encodePacked(greeter.greeting())) == keccak256(abi.encodePacked("yo")), "not equal");
     }
+    function testGreeting(string memory message) public {
+        greeter.greet(message);
+        require(keccak256(abi.encodePacked(greeter.greeting())) == keccak256(abi.encodePacked(message)), "not equal");
+    }
+    function testGreeting(string memory message, string memory _message) public {
+        greeter.greet(message);
+        require(keccak256(abi.encodePacked(greeter.greeting())) == keccak256(abi.encodePacked(message)), "not equal");
+    }
+
 
     // check the unhappy case
     function testFailGreeting() public {


### PR DESCRIPTION
As title, previously we'd not print the result of functions with the same name (yikes)