### PR TITLE
ci: run forge in release mode

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
       # if couldn't get, install forge
       - name: Install forge
         if: steps.cache-forge.outputs.cache-hit != 'true'
-        run: cargo build --bin forge
+        run: cargo build --release --bin forge
 
       - name: Test ${{ matrix.repo }}
         run: ./test.sh ${{ matrix.repo }}

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -21,9 +21,9 @@ function runTests() {
     make install || true
 
     # update the deps
-    $DIR/../target/debug/forge update
+    $DIR/../target/release/forge update
     # always have the ffi flag turned on
-    $DIR/../target/debug/forge test --ffi
+    $DIR/../target/release/forge test --ffi
 
     cd -
 }


### PR DESCRIPTION
should make running Solmate tests much faster