### PR TITLE
chore: use published versions of ethers/evm/evmodin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,8 +989,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d16b7455aa6e3de419d9e7d270605f402f87ffdbcfcd1c2d036d4cfceafdba"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1003,8 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb2b42ed54282b47225563f8f8ecb5356337ecb6342cf7a6129421413574947"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1021,8 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02185a49bdd3bc4cdbb59164ab5a2c6c99eb50d1162d051d40e3ec7fd9b77b9"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1042,8 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfe93d0ab5f7eb3656f78a56d73e8da4cdef11b22ded7a2015afc5fddc54d8f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1056,8 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e101557a375366496ecdc53b69a1bfdebf393b6c0691f5d667659e4580164b68"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1084,8 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75615bf40e98ad5100b5854608238d7f6cda6ba2779141b6d7c7d9f27246dfc4"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1097,8 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5d80cc912cf090997b1bc1d01138cc1efed44445e64621cb7f8b29d2bb1bc6"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1120,8 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254efa7740027e29145f4674324ad3745a569244d2f8932c3bb9847992324b78"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1149,8 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1b5ef38b0159c99324abb1db1b131e80944968ae1227032d3a84d2368bd79c"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1169,8 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#d06bfdc15ca387f5e1327be8e48ef1a695a31ae8"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca81cc5875d2194ba552e7b0c9262f7b6dd8268c69d0db42ddc15deb04dc2348"
 dependencies = [
  "colored",
  "ethers-core",
@@ -1200,9 +1210,28 @@ dependencies = [
  "auto_impl",
  "environmental",
  "ethereum",
- "evm-core",
- "evm-gasometer",
- "evm-runtime",
+ "evm-core 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
+ "evm-gasometer 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
+ "evm-runtime 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
+ "log",
+ "parity-scale-codec",
+ "primitive-types",
+ "rlp",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "evm"
+version = "0.33.0"
+source = "git+https://github.com/rust-blockchain/evm#953f6cb16a07458d139e8dec5bafdc6cff4f6c4b"
+dependencies = [
+ "environmental",
+ "ethereum",
+ "evm-core 0.33.0 (git+https://github.com/rust-blockchain/evm)",
+ "evm-gasometer 0.33.0 (git+https://github.com/rust-blockchain/evm)",
+ "evm-runtime 0.33.0 (git+https://github.com/rust-blockchain/evm)",
  "log",
  "parity-scale-codec",
  "primitive-types",
@@ -1218,7 +1247,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "ethers",
- "evm",
+ "evm 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
  "evmodin",
  "eyre",
  "foundry-utils",
@@ -1246,13 +1275,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "evm-core"
+version = "0.33.0"
+source = "git+https://github.com/rust-blockchain/evm#953f6cb16a07458d139e8dec5bafdc6cff4f6c4b"
+dependencies = [
+ "funty",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
 name = "evm-gasometer"
 version = "0.33.0"
 source = "git+https://github.com/gakonst/evm?branch=feat/auto-impl#1b5e1c67e0b518a265e44f079f3537f5534a68d2"
 dependencies = [
  "environmental",
- "evm-core",
- "evm-runtime",
+ "evm-core 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
+ "evm-runtime 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
+ "primitive-types",
+]
+
+[[package]]
+name = "evm-gasometer"
+version = "0.33.0"
+source = "git+https://github.com/rust-blockchain/evm#953f6cb16a07458d139e8dec5bafdc6cff4f6c4b"
+dependencies = [
+ "environmental",
+ "evm-core 0.33.0 (git+https://github.com/rust-blockchain/evm)",
+ "evm-runtime 0.33.0 (git+https://github.com/rust-blockchain/evm)",
  "primitive-types",
 ]
 
@@ -1263,7 +1315,18 @@ source = "git+https://github.com/gakonst/evm?branch=feat/auto-impl#1b5e1c67e0b51
 dependencies = [
  "auto_impl",
  "environmental",
- "evm-core",
+ "evm-core 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
+ "primitive-types",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "evm-runtime"
+version = "0.33.0"
+source = "git+https://github.com/rust-blockchain/evm#953f6cb16a07458d139e8dec5bafdc6cff4f6c4b"
+dependencies = [
+ "environmental",
+ "evm-core 0.33.0 (git+https://github.com/rust-blockchain/evm)",
  "primitive-types",
  "sha3 0.8.2",
 ]
@@ -1359,7 +1422,7 @@ name = "forge"
 version = "0.1.0"
 dependencies = [
  "ethers",
- "evm",
+ "evm 0.33.0 (git+https://github.com/rust-blockchain/evm)",
  "evm-adapters",
  "evmodin",
  "eyre",
@@ -1393,8 +1456,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "cast",
  "ethers",
- "ethers-etherscan",
- "evm",
+ "evm 0.33.0 (git+https://github.com/gakonst/evm?branch=feat/auto-impl)",
  "evm-adapters",
  "evmodin",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ lto = true
 codegen-units = 1
 panic = "abort"
 
-[patch."https://github.com/rust-blockchain/evm"]
+[patch.crates-io]
 evm = { git = "https://github.com/gakonst/evm", branch = "feat/auto-impl" }

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -8,9 +8,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 foundry-utils = { path = "../utils" }
-# ethers = "0.5"
-ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-core = { version = "^0.6.0", default-features = false }
+ethers-providers = { version = "^0.6.0", default-features = false }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
 serde_json = "1.0.67"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,8 +14,7 @@ cast = { path = "../cast" }
 evm-adapters = { path = "../evm-adapters" }
 
 # ethers = "0.5"
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
-ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs" }
+ethers = { version = "^0.6.0" }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
 serde_json = "1.0.67"
@@ -27,8 +26,7 @@ tracing-subscriber = "0.2.20"
 tracing = "0.1.26"
 
 ## EVM Implementations
-# evm = { version = "0.30.1" }
-sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true }
+sputnik = { package = "evm", version = "^0.33.0",  optional = true }
 evmodin = { git = "https://github.com/vorot93/evmodin", optional = true }
 proptest = "1.0.0"
 git2 = "0.13.22"

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -8,8 +8,8 @@ use ethers::{
     core::types::Chain,
     prelude::Provider,
     providers::Middleware,
+    etherscan::{contract::VerifyContract, Client},
 };
-use ethers_etherscan::{contract::VerifyContract, Client};
 use eyre::ContextCompat;
 use std::convert::TryFrom;
 

--- a/evm-adapters/Cargo.toml
+++ b/evm-adapters/Cargo.toml
@@ -9,11 +9,10 @@ edition = "2021"
 [dependencies]
 foundry-utils = { path = "./../utils" }
 
-sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true, features = ["tracing"] }
-
+sputnik = { package = "evm", version = "^0.33.0",  optional = true, features = ["tracing"] }
 evmodin = { git = "https://github.com/vorot93/evmodin",  optional = true }
 
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["solc-full"] }
+ethers = { version = "^0.6.0", features = ["solc-full"] }
 eyre = "0.6.5"
 once_cell = "1.8.0"
 tracing = "0.1.28"
@@ -28,7 +27,7 @@ revm_precompiles = "0.1.0"
 
 [dev-dependencies]
 evmodin = { git = "https://github.com/vorot93/evmodin", features = ["util"] }
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["solc-full", "solc-tests"] }
+ethers = { version = "^0.6.0", features = ["solc-full", "solc-tests"] }
 
 [features]
 sputnik-helpers = ["sputnik"]

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -7,11 +7,10 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-foundry-utils = { path = "./../utils" }
-evm-adapters = { path = "./../evm-adapters", default-features = false }
+foundry-utils = { version = "^0.1.0", path = "./../utils" }
+evm-adapters = { version = "^0.1.0", path = "./../evm-adapters", default-features = false }
 
-# ethers = { version = "0.5.2" }
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["solc-full"] }
+ethers = { version = "^0.6.0", features = ["solc-full"] }
 
 eyre = "0.6.5"
 semver = "1.0.4"
@@ -30,4 +29,4 @@ proptest = "1.0.0"
 evm-adapters = { path = "./../evm-adapters", features = ["sputnik", "sputnik-helpers", "evmodin", "evmodin-helpers"] }
 evmodin = { git = "https://github.com/vorot93/evmodin", features = ["util"] }
 evm = { git = "https://github.com/rust-blockchain/evm" }
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["solc-full", "solc-tests"] }
+ethers = { version = "^0.6.0", features = ["solc-full", "solc-tests"] }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,8 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# ethers = "0.5"
-ethers-core = { git = "https://github.com/gakonst/ethers-rs" }
+ethers-core = { version = "^0.6.0", default-features = false }
 
 eyre = { version = "0.6.5", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }


### PR DESCRIPTION
blocked on:
* [ ] evmodin new release
* [ ] sputnik new release

Once released, we can move forward with testing out #183 with brew