### PR TITLE
chore: fix repo url in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/reflexer-labs/geb
 [submodule "integration-tests/testdata/guni-lev"]
 	path = integration-tests/testdata/guni-lev
-	url = https://github.com/hexonaut/guni-lev/
+	url = https://github.com/hexonaut/guni-lev
 [submodule "integration-tests/testdata/solmate"]
 	path = integration-tests/testdata/solmate
 	url = https://github.com/Rari-Capital/solmate


### PR DESCRIPTION
```console
➜  ~ cargo install --git https://github.com/gakonst/foundry --bin forge --locked
    Updating git repository `https://github.com/gakonst/foundry`
    Updating git submodule `https://github.com/hexonaut/guni-lev/`
error: failed to update submodule `integration-tests/testdata/guni-lev`

Caused by:
  failed to fetch submodule `integration-tests/testdata/guni-lev` from https://github.com/hexonaut/guni-lev/

Caused by:
  process didn't exit successfully: `git fetch --tags --force --update-head-ok 'https://github.com/hexonaut/guni-lev/' 'refs/heads/*:refs/remotes/origin/*' 'HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
  --- stderr
  ERROR: Repository not found.
  fatal: Could not read from remote repository.

  Please make sure you have the correct access rights
  and the repository exists.
```