### PR TITLE
feat: source configuration files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1411,7 @@ dependencies = [
  "proptest",
  "regex",
  "rpassword",
+ "run_script",
  "rustc-hex",
  "semver 1.0.4",
  "serde_json",
@@ -1423,6 +1430,17 @@ dependencies = [
  "eyre",
  "rustc-hex",
  "serde_json",
+]
+
+[[package]]
+name = "fsio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e87827efaf94c7a44b562ff57de06930712fe21b530c3797cdede26e6377eb"
+dependencies = [
+ "dunce",
+ "rand 0.8.4",
+ "users",
 ]
 
 [[package]]
@@ -3035,6 +3053,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "run_script"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd85213e37f76b40186ee781cf3a689b05c518c3102c987acf679c573d8e4ef"
+dependencies = [
+ "fsio",
+]
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3934,6 +3961,16 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ ansi_term = "0.12.1"
 rpassword = "5.0.1"
 tracing-subscriber = "0.2.20"
 tracing = "0.1.26"
+run_script = "^0.9.0"
 
 ## EVM Implementations
 # evm = { version = "0.30.1" }


### PR DESCRIPTION
- fixes #155 
- Doesn't work, because `source` doesn't propagate but works for the subshell. On top, while `UNIX` commands like `cat`, run properly and find the config files, `source` outputs an error. 