### PR TITLE
chore(deps): bump ethers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
+source = "git+https://github.com/gakonst/ethers-rs#38e18463dcc13e89b224f073574ff6009dd7b935"
 dependencies = [
  "colored",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "block-modes"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567569e659735adb39ff2d4c20600f7cd78be5471f8c58ab162bce3c03fdbc5f"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +812,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8549e6bfdecd113b7e221fe60b433087f6957387a20f8118ebca9b12af19143d"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.1"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73d21281779c2c22cade2a4ab34eee34271869942546a364f7d552d30c62434"
+checksum = "1f01ff20862362c34074072c8be2de97399633d6b1d2114afa56bf77a8b7f0a4"
 dependencies = [
  "crypto-bigint 0.3.2",
  "der 0.5.1",
@@ -990,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1004,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1022,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1043,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1057,14 +1086,14 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "arrayvec",
  "bytes",
  "cargo_metadata",
  "convert_case",
  "ecdsa",
- "elliptic-curve 0.11.1",
+ "elliptic-curve 0.11.5",
  "ethabi",
  "generic-array 0.14.4",
  "hex",
@@ -1085,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1098,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1121,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1150,12 +1179,12 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
- "elliptic-curve 0.11.1",
+ "elliptic-curve 0.11.5",
  "eth-keystore",
  "ethers-core",
  "futures-executor",
@@ -1170,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#23c356ce3823272dd96e70f5453dea732c182d7b"
+source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
 dependencies = [
  "colored",
  "ethers-core",
@@ -1180,6 +1209,7 @@ dependencies = [
  "hex",
  "home",
  "md-5",
+ "num_cpus",
  "once_cell",
  "regex",
  "semver 1.0.4",
@@ -1188,6 +1218,7 @@ dependencies = [
  "sha2 0.9.8",
  "svm-rs",
  "thiserror",
+ "tiny-keccak",
  "tokio",
  "tracing",
  "walkdir",
@@ -2083,13 +2114,11 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "e6a38fc55c8bbc10058782919516f88826e70320db6d206aebc49611d24216ae"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest 0.10.0",
 ]
 
 [[package]]
@@ -2602,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#59cf9918289012d9235e70da40f8d93c1f9ff692"
+source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
 dependencies = [
  "colored",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#79f2e1d5ef66ede3e9a6abdd1c22172e831a467c"
+source = "git+https://github.com/gakonst/ethers-rs#991cda3f33da74785377fcf4eef199fe8c0168dc"
 dependencies = [
  "colored",
  "ethers-core",

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -204,7 +204,7 @@ mod test_helpers {
 
     pub fn can_call_vm_directly<S, E: Evm<S>>(mut evm: E, compiled: CompactContractRef) {
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let (_, status1, _, _) = evm
             .call::<(), _, _>(Address::zero(), addr, "greet(string)", "hi".to_owned(), 0.into())
@@ -223,7 +223,7 @@ mod test_helpers {
 
     pub fn solidity_unit_test<S, E: Evm<S>>(mut evm: E, compiled: CompactContractRef) {
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // call the setup function to deploy the contracts inside the test
         let status1 = evm.setup(addr).unwrap().0;

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -902,7 +902,7 @@ mod tests {
 
         let compiled = COMPILED.find("DebugLogs").expect("could not find contract");
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // after the evm call is done, we call `logs` and print it all to the user
         let (_, _, _, logs) =
@@ -943,7 +943,7 @@ mod tests {
 
         let compiled = COMPILED.find("ConsoleLogs").expect("could not find contract");
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // after the evm call is done, we call `logs` and print it all to the user
         let (_, _, _, logs) =
@@ -967,7 +967,7 @@ mod tests {
 
         let compiled = COMPILED.find("DebugLogs").expect("could not find contract");
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // after the evm call is done, we call `logs` and print it all to the user
         let (_, _, _, logs) = evm
@@ -992,7 +992,7 @@ mod tests {
 
         let compiled = COMPILED.find("CheatCodes").expect("could not find contract");
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let state = evm.state().clone();
         let mut cfg = proptest::test_runner::Config::default();
@@ -1038,7 +1038,7 @@ mod tests {
 
         let compiled = COMPILED.find("CheatCodes").expect("could not find contract");
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let err =
             evm.call::<(), _, _>(Address::zero(), addr, "testFFI()", (), 0.into()).unwrap_err();

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -236,7 +236,7 @@ mod tests {
         let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
 
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let (status, res) = evm.executor.transact_call(
             Address::zero(),
@@ -261,8 +261,9 @@ mod tests {
         let precompiles = PRECOMPILES_MAP.clone();
         let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
 
-        let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.clone().unwrap().clone(), 0.into()).unwrap();
+        let (addr, _, _, _) = evm
+            .deploy(Address::zero(), compiled.bytecode().clone().unwrap().clone(), 0.into())
+            .unwrap();
 
         // call the setup function to deploy the contracts inside the test
         let status = evm.setup(addr).unwrap().0;
@@ -291,7 +292,8 @@ mod tests {
         let mut evm = Executor::new(13_000_000, &cfg, &backend, &precompiles);
 
         let from = Address::random();
-        let (addr, _, _, _) = evm.deploy(from, compiled.bin.unwrap().clone(), 0.into()).unwrap();
+        let (addr, _, _, _) =
+            evm.deploy(from, compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // makes a call to the contract
         let sig = ethers::utils::id("foo()").to_vec();

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -233,7 +233,7 @@ mod tests {
         let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
 
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let (res, _, _, _) =
             evm.call::<U256, _, _>(Address::zero(), addr, "time()(uint256)", (), 0.into()).unwrap();

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -59,9 +59,10 @@ impl MultiContractRunnerBuilder {
         // artifacts
         let contracts = output.into_artifacts();
         let contracts: BTreeMap<String, (Abi, Address, Vec<String>)> = contracts
-            .map(|(fname, contract)| {
+            // only take contracts with valid abi and bytecode
+            .filter_map(|(fname, contract)| {
                 let (abi, bytecode) = contract.into_inner();
-                (fname, abi.unwrap(), bytecode.unwrap())
+                abi.and_then(|abi| bytecode.and_then(|bytecode| Some((fname, abi, bytecode))))
             })
             // Only take contracts with empty constructors.
             .filter(|(_, abi, _)| {

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -279,8 +279,9 @@ mod tests {
 
             let precompiles = PRECOMPILES_MAP.clone();
             let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
-            let (addr, _, _, _) =
-                evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            let (addr, _, _, _) = evm
+                .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
+                .unwrap();
 
             let mut runner =
                 ContractRunner::new(&mut evm, compiled.abi.as_ref().unwrap(), addr, None, &[]);
@@ -305,8 +306,9 @@ mod tests {
 
             let precompiles = PRECOMPILES_MAP.clone();
             let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
-            let (addr, _, _, _) =
-                evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            let (addr, _, _, _) = evm
+                .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
+                .unwrap();
 
             let mut runner =
                 ContractRunner::new(&mut evm, compiled.abi.as_ref().unwrap(), addr, None, &[]);
@@ -332,8 +334,9 @@ mod tests {
 
             let precompiles = PRECOMPILES_MAP.clone();
             let mut evm = Executor::new(u64::MAX, &cfg, &backend, &precompiles);
-            let (addr, _, _, _) =
-                evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            let (addr, _, _, _) = evm
+                .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
+                .unwrap();
 
             let mut runner =
                 ContractRunner::new(&mut evm, compiled.abi.as_ref().unwrap(), addr, None, &[]);
@@ -356,8 +359,9 @@ mod tests {
 
             let precompiles = PRECOMPILES_MAP.clone();
             let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
-            let (addr, _, _, _) =
-                evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            let (addr, _, _, _) = evm
+                .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
+                .unwrap();
 
             let mut runner =
                 ContractRunner::new(&mut evm, compiled.abi.as_ref().unwrap(), addr, None, &[]);
@@ -415,7 +419,7 @@ mod tests {
 
     pub fn test_runner<S: Clone, E: Evm<S>>(mut evm: E, compiled: CompactContractRef) {
         let (addr, _, _, _) =
-            evm.deploy(Address::zero(), compiled.bin.unwrap().clone(), 0.into()).unwrap();
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let mut runner =
             ContractRunner::new(&mut evm, compiled.abi.as_ref().unwrap(), addr, None, &[]);


### PR DESCRIPTION
updates ethers and adds a new check in the multi runner that skips artifacts (libs) that don't have a valid bytecode like lib artifacts (bin = "0x") or unlinked

~~This should probably wait until https://github.com/gakonst/ethers-rs/pull/665 got merged~~