### PR TITLE
fix(cli): replace underscore for hyphen on wallet cli args

### DIFF
--- a/cli/src/cast_opts.rs
+++ b/cli/src/cast_opts.rs
@@ -267,23 +267,23 @@ impl EthereumOpts {
 
 #[derive(StructOpt, Debug, Clone)]
 pub struct Wallet {
-    #[structopt(long = "private_key", help = "Your private key string")]
+    #[structopt(long = "private-key", help = "Your private key string")]
     pub private_key: Option<String>,
 
     #[structopt(long = "keystore", help = "Path to your keystore folder / file")]
     pub keystore_path: Option<String>,
 
-    #[structopt(long = "password", help = "Your keystore password", requires = "keystore_path")]
+    #[structopt(long = "password", help = "Your keystore password", requires = "keystore-path")]
     pub keystore_password: Option<String>,
 
-    #[structopt(long = "mnemonic_path", help = "Path to your mnemonic file")]
+    #[structopt(long = "mnemonic-path", help = "Path to your mnemonic file")]
     pub mnemonic_path: Option<String>,
 
     #[structopt(
         long = "mnemonic_index",
         help = "your index in the standard hd path",
         default_value = "0",
-        requires = "mnemonic_path"
+        requires = "mnemonic-path"
     )]
     pub mnemonic_index: u32,
 }


### PR DESCRIPTION
`_` vs `-` were causing clap-rs to panic if some requirements were not met, instead of giving a proper error:

```
ETH_FROM=$ADDR cargo run --bin cast -- send  $ADDR "get()"

thread 'main' panicked at 'Fatal internal error. Please consider filing a bug report at https://github.com/clap-rs/clap/issues', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/app/usage.rs:475:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```