### PR TITLE
fix: pass through evm version

### DIFF
--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -1,8 +1,11 @@
 //! Test command
 
-use crate::cmd::{
-    build::{BuildArgs, Env, EvmType},
-    Cmd,
+use crate::{
+    cmd::{
+        build::{BuildArgs, Env, EvmType},
+        Cmd,
+    },
+    utils,
 };
 use ansi_term::Colour;
 use ethers::{
@@ -127,7 +130,7 @@ impl Cmd for TestArgs {
             EvmType::Sputnik => {
                 use evm_adapters::sputnik::Executor;
                 use sputnik::backend::MemoryBackend;
-                let mut cfg = opts.evm_version.sputnik_cfg();
+                let mut cfg = utils::sputnik_cfg(opts.evm_version);
 
                 // We disable the contract size limit by default, because Solidity
                 // test smart contracts are likely to be >24kb
@@ -168,7 +171,7 @@ impl Cmd for TestArgs {
                 use evm_adapters::evmodin::EvmOdin;
                 use evmodin::tracing::NoopTracer;
 
-                let revision = opts.evm_version.evmodin_cfg();
+                let revision = utils::evmodin_cfg(opts.evm_version);
 
                 // TODO: Replace this with a proper host. We'll want this to also be
                 // provided generically when we add the Forking host(s).

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,10 +1,15 @@
-use ethers::solc::artifacts::Contract;
+use ethers::solc::{artifacts::Contract, EvmVersion};
 
 use eyre::{ContextCompat, WrapErr};
 use std::{
     env::VarError,
     path::{Path, PathBuf},
 };
+
+#[cfg(feature = "evmodin-evm")]
+use evmodin::Revision;
+#[cfg(feature = "sputnik-evm")]
+use sputnik::Config;
 
 /// Default local RPC endpoint
 const LOCAL_RPC_URL: &str = "http://127.0.0.1:8545";
@@ -113,4 +118,24 @@ fn find_fave_or_alt_path(root: impl AsRef<Path>, fave: &str, alt: &str) -> PathB
         }
     }
     p
+}
+
+#[cfg(feature = "sputnik-evm")]
+pub fn sputnik_cfg(evm: EvmVersion) -> Config {
+    match evm {
+        EvmVersion::Istanbul => Config::istanbul(),
+        EvmVersion::Berlin => Config::berlin(),
+        EvmVersion::London => Config::london(),
+        _ => panic!("Unsupported EVM version"),
+    }
+}
+
+#[cfg(feature = "evmodin-evm")]
+pub fn evmodin_cfg(evm: EvmVersion) -> Revision {
+    match evm {
+        EvmVersion::Istanbul => Revision::Istanbul,
+        EvmVersion::Berlin => Revision::Berlin,
+        EvmVersion::London => Revision::London,
+        _ => panic!("Unsupported EVM version"),
+    }
 }


### PR DESCRIPTION
supersedes https://github.com/gakonst/foundry/pull/203
fixes https://github.com/gakonst/foundry/issues/202

also removes duplicate type `EvmVersion`