### PR TITLE
feat(cast): add trezor signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1168,7 +1168,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1189,7 +1189,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1312,12 +1312,13 @@ dependencies = [
  "semver 1.0.4",
  "sha2 0.9.8",
  "thiserror",
+ "trezor-client",
 ]
 
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#5dec757493f15be016074e9355f7154d8e84aaae"
+source = "git+https://github.com/gakonst/ethers-rs#ebf52934e4091a8a861c5f8cc5665a0cfcbcf780"
 dependencies = [
  "colored",
  "ethers-core",
@@ -2205,6 +2206,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libusb1-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22e89d08bbe6816c6c5d446203b859eba35b8fa94bf1b7edb2f6d25d43f023f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,6 +2847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3256,16 @@ checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "rusb"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a5084628cc5be77b1c750b3e5ee0cc519d2f2491b3f06b78b3aac3328b00ad"
+dependencies = [
+ "libc",
+ "libusb1-sys",
 ]
 
 [[package]]
@@ -3738,9 +3767,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5e16a3a87cca053bcab26e5de589ccb5779f84dda466f96eead79a98d7de7c"
+checksum = "8733662d7e2c4bc2bdc5ca4102c7f8b13d1c3c12fb767089de07c2c3df3cd03d"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4072,6 +4101,21 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "trezor-client"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff94fab279e0d429d762c289f9727f37a0f1b8207ea4795f09c11caad009046f"
+dependencies = [
+ "byteorder",
+ "hex",
+ "hidapi",
+ "log",
+ "primitive-types",
+ "protobuf",
+ "rusb",
 ]
 
 [[package]]

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -11,7 +11,7 @@ foundry-utils = { path = "../utils" }
 # ethers = "0.5"
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
-ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["ledger"] }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["ledger", "trezor"] }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
 serde_json = "1.0.67"

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -125,6 +125,9 @@ async fn main() -> eyre::Result<()> {
                     cast_opts::WalletType::Local(signer) => {
                         cast_send(&signer, signer.address(), to, sig, args, eth.cast_async).await?;
                     }
+                    cast_opts::WalletType::Trezor(signer) => {
+                        cast_send(&signer, signer.address(), to, sig, args, eth.cast_async).await?;
+                    }
                 }
             } else {
                 let from = eth.from.expect("No ETH_FROM or signer specified");


### PR DESCRIPTION
+ bumps ethers
+ enables the trezor feature from ethers-signers
+ adds `--hd-path` for custom derivation paths on hardware wallets

https://github.com/gakonst/ethers-rs/issues/592 this will probably make things less... verbose

### Test/Usage:
`ETH_FROM=$ADDR ETH_RPC_URL=$RPC cargo run --bin cast -- send  $ADDR "totalSupply() returns uint256" -t`

`ETH_FROM=$ADDR ETH_RPC_URL=$RPC cargo run --bin cast -- send  $ADDR "totalSupply() returns uint256" -t --hd-path "m/44'/60'/0'/0" `