### PR TITLE
feat: add median and mean gas to fuzz test result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "revm_precompiles",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -194,7 +194,7 @@ pub struct Test {
 }
 
 impl Test {
-    pub fn gas_used(&self) -> Option<u64> {
+    pub fn gas_used(&self) -> u64 {
         self.result.gas_used
     }
 }
@@ -304,15 +304,8 @@ fn test<A: ArtifactOutput + 'static, S: Clone, E: evm_adapters::Evm<S>>(
 
                     Colour::Red.paint(txt)
                 };
-                println!(
-                    "{} {} (gas: {})",
-                    status,
-                    name,
-                    result
-                        .gas_used
-                        .map(|x| x.to_string())
-                        .unwrap_or_else(|| "[fuzztest]".to_string())
-                );
+
+                println!("{} {} {}", status, name, result.kind.gas_used());
             }
 
             if verbosity > 1 {

--- a/evm-adapters/Cargo.toml
+++ b/evm-adapters/Cargo.toml
@@ -26,6 +26,7 @@ parking_lot = "0.11.2"
 futures = "0.3.17"
 revm_precompiles = "0.1.0"
 serde_json = "1.0.72"
+serde = "1.0.130"
 
 [dev-dependencies]
 evmodin = { git = "https://github.com/vorot93/evmodin", features = ["util"] }

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -168,23 +168,23 @@ impl FuzzedCases {
     }
 
     /// Returns the average gas use of all test cases
-    fn mean_gas(&self) -> u64 {
-        self.cases.iter().map(|c| c.gas).sum::<u64>() / numbers.len() as u64
+    pub fn mean_gas(&self) -> u64 {
+        self.cases.iter().map(|c| c.gas).sum::<u64>() / self.cases.len() as u64
     }
 
-    fn highest(&self) -> Option<&FuzzCase> {
+    pub fn highest(&self) -> Option<&FuzzCase> {
         self.cases.last()
     }
 
-    fn lowest(&self) -> Option<&FuzzCase> {
+    pub fn lowest(&self) -> Option<&FuzzCase> {
         self.cases.first()
     }
 
-    fn highest_gas(&self) -> u64 {
+    pub fn highest_gas(&self) -> u64 {
         self.highest().map(|c| c.gas).unwrap_or_default()
     }
 
-    fn lowest_gas(&self) -> u64 {
+    pub fn lowest_gas(&self) -> u64 {
         self.lowest().map(|c| c.gas).unwrap_or_default()
     }
 }

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -9,12 +9,12 @@ use std::{
     marker::PhantomData,
 };
 
+pub use proptest::test_runner::Config as FuzzConfig;
 use proptest::{
     prelude::*,
     test_runner::{TestError, TestRunner},
 };
-
-pub use proptest::test_runner::Config as FuzzConfig;
+use serde::{Deserialize, Serialize};
 
 /// Wrapper around any [`Evm`](crate::Evm) implementor which provides fuzzing support using [`proptest`](https://docs.rs/proptest/1.0.0/proptest/).
 ///
@@ -43,12 +43,14 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
     /// Fuzzes the provided function, assuming it is available at the contract at `address`
     /// If `should_fail` is set to `true`, then it will stop only when there's a success
     /// test case.
+    ///
+    /// Returns a list of all the consumed gas and calldata of every fuzz case
     pub fn fuzz(
         &self,
         func: &Function,
         address: Address,
         should_fail: bool,
-    ) -> Result<(), TestError<Bytes>>
+    ) -> FuzzTestResult<E::ReturnReason>
     where
         // We need to be able to clone the state so as to snapshot it and reset
         // it back after every test run, to have isolation of state across each
@@ -60,34 +62,121 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
         // Snapshot the state before the test starts running
         let pre_test_state = self.evm.borrow().state().clone();
 
+        // stores the consumed gas and calldata of every successful fuzz call
+        let fuzz_cases: RefCell<Vec<FuzzedCase>> = RefCell::new(Default::default());
+
+        // stores the latest reason of a test call, this will hold the return reason of failed test
+        // case if the runner failed
+        let return_reason: RefCell<Option<E::ReturnReason>> = RefCell::new(None);
+
         let mut runner = self.runner.clone();
         tracing::debug!(func = ?func.name, should_fail, "fuzzing");
-        runner.run(&strat, |calldata| {
-            let mut evm = self.evm.borrow_mut();
+        let test_error = runner
+            .run(&strat, |calldata| {
+                let mut evm = self.evm.borrow_mut();
+                // Before each test, we must reset to the initial state
+                evm.reset(pre_test_state.clone());
 
-            // Before each test, we must reset to the initial state
-            evm.reset(pre_test_state.clone());
+                let (returndata, reason, gas, _) = evm
+                    .call_raw(self.sender, address, calldata.clone(), 0.into(), false)
+                    .expect("could not make raw evm call");
 
-            let (returndata, reason, _, _) = evm
-                .call_raw(self.sender, address, calldata, 0.into(), false)
-                .expect("could not make raw evm call");
+                // We must check success before resetting the state, otherwise resetting the state
+                // will also reset the `failed` state variable back to false.
+                let success = evm.check_success(address, &reason, should_fail);
 
-            // We must check success before resetting the state, otherwise resetting the state
-            // will also reset the `failed` state variable back to false.
-            let success = evm.check_success(address, &reason, should_fail);
+                // store the result of this test case
+                let _ = return_reason.borrow_mut().insert(reason);
 
-            // This will panic and get caught by the executor
-            proptest::prop_assert!(
-                success,
-                "{}, expected failure: {}, reason: '{}'",
-                func.name,
-                should_fail,
-                foundry_utils::decode_revert(returndata.as_ref())?
-            );
+                // This will panic and get caught by the executor
+                proptest::prop_assert!(
+                    success,
+                    "{}, expected failure: {}, reason: '{}'",
+                    func.name,
+                    should_fail,
+                    foundry_utils::decode_revert(returndata.as_ref())?
+                );
 
-            Ok(())
-        })
+                // push test case to the case set
+                fuzz_cases.borrow_mut().push(FuzzedCase { calldata, gas });
+
+                Ok(())
+            })
+            .err()
+            .map(|test_error| FuzzError {
+                test_error,
+                return_reason: return_reason.into_inner().expect("Reason must be set"),
+            });
+
+        FuzzTestResult { cases: FuzzedCases::new(fuzz_cases.into_inner()), test_error }
     }
+}
+
+/// The outcome of a fuzz test
+pub struct FuzzTestResult<Reason> {
+    /// Every successful fuzz test case
+    pub cases: FuzzedCases,
+    /// if there was a case that resulted in an error, this contains the error and the return
+    /// reason of the failed call
+    pub test_error: Option<FuzzError<Reason>>,
+}
+
+impl<Reason> FuzzTestResult<Reason> {
+    /// Returns `true` if all test cases succeeded
+    pub fn is_ok(&self) -> bool {
+        self.test_error.is_none()
+    }
+
+    /// Returns `true` if a test case failed
+    pub fn is_err(&self) -> bool {
+        self.test_error.is_some()
+    }
+}
+
+pub struct FuzzError<Reason> {
+    /// The proptest error occurred as a result of a test case
+    pub test_error: TestError<Bytes>,
+    /// The return reason of the offending call
+    pub return_reason: Reason,
+}
+
+/// Container type for all successful test cases
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FuzzedCases {
+    cases: Vec<FuzzedCase>,
+}
+
+impl FuzzedCases {
+    fn new(mut cases: Vec<FuzzedCase>) -> Self {
+        cases.sort_by_key(|c| c.gas);
+        Self { cases }
+    }
+
+    pub fn cases(&self) -> &[FuzzedCase] {
+        &self.cases
+    }
+
+    pub fn into_cases(self) -> Vec<FuzzedCase> {
+        self.cases
+    }
+}
+
+impl FuzzedCases {
+    /// Returns the median gas of all test cases
+    pub fn median_gas(&self) -> u64 {
+        let mid = self.cases.len() / 2;
+        self.cases.get(mid).map(|c| c.gas).unwrap_or_default()
+    }
+}
+
+/// Data of a single fuzz test case
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FuzzedCase {
+    /// The calldata used for this fuzz test
+    pub calldata: Bytes,
+    // Consumed gas
+    pub gas: u64,
 }
 
 /// Given a function, it returns a proptest strategy which generates valid abi-encoded calldata

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1018,8 +1018,7 @@ mod tests {
                     evm.as_mut().call_unchecked(Address::zero(), addr, func, (), 0.into()).unwrap();
                 assert!(evm.as_mut().check_success(addr, &reason, should_fail));
             } else {
-                // if the unwrap passes then it works
-                evm.fuzz(func, addr, should_fail).unwrap();
+                assert!(evm.fuzz(func, addr, should_fail).is_ok());
             }
 
             evm.as_mut().reset(state.clone());

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -261,9 +261,8 @@ mod tests {
         let precompiles = PRECOMPILES_MAP.clone();
         let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
 
-        let (addr, _, _, _) = evm
-            .deploy(Address::zero(), compiled.bytecode().clone().unwrap().clone(), 0.into())
-            .unwrap();
+        let (addr, _, _, _) =
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // call the setup function to deploy the contracts inside the test
         let status = evm.setup(addr).unwrap().0;

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -1,5 +1,5 @@
 mod runner;
-pub use runner::{ContractRunner, TestKind, TestResult};
+pub use runner::{ContractRunner, TestKind, TestKindGas, TestResult};
 
 mod multi_runner;
 pub use multi_runner::{MultiContractRunner, MultiContractRunnerBuilder};

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -1,5 +1,5 @@
 mod runner;
-pub use runner::{ContractRunner, TestResult};
+pub use runner::{ContractRunner, TestKind, TestResult};
 
 mod multi_runner;
 pub use multi_runner::{MultiContractRunner, MultiContractRunnerBuilder};

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -246,7 +246,6 @@ mod tests {
                 .iter()
                 .map(|(name, res)| (name, res.logs.clone()))
                 .collect::<HashMap<_, _>>();
-            dbg!(&reasons);
             assert_eq!(
                 reasons[&"test1()".to_owned()],
                 vec!["constructor".to_owned(), "setUp".to_owned(), "one".to_owned()]

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -183,7 +183,7 @@ mod tests {
 
         let paths = ProjectPathsConfig::builder().root(&root).sources(&root).build().unwrap();
 
-        let project = Project::builder()
+        Project::builder()
             // need to add the ilb path here. would it be better placed in the ProjectPathsConfig
             // instead? what is the `libs` modifier useful for then? linked libraries?
             .allowed_path(root.join("../../evm-adapters/testdata"))
@@ -191,9 +191,7 @@ mod tests {
             .ephemeral()
             .no_artifacts()
             .build()
-            .unwrap();
-
-        project
+            .unwrap()
     }
 
     fn runner<S: Clone, E: Evm<S>>(evm: E) -> MultiContractRunner<E, S> {

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -40,7 +40,10 @@ pub struct TestResult {
     /// still be successful (i.e self.success == true) when it's expected to fail.
     pub reason: Option<String>,
 
-    /// The gas used during execution
+    /// The gas used during execution.
+    ///
+    /// If this is the result of a fuzz test (`TestKind::Fuzz`), then this is the median of all
+    /// successful cases
     pub gas_used: Option<u64>,
 
     /// Minimal reproduction test case for failing fuzz tests


### PR DESCRIPTION
# changes

* introduce `TestKind{Standard, Fuzz}`, `Fuzz` stores all test cases (input, gas used)
* `gas_used` doesn't need to be an Option anymore
* updated snapshot output, Should diff compare fuzz cases as well? because there is a high chance, median or mean differ by +-1 or so

Fuzz gas formatting as `(μ: <mean_gas>, ~: <median gas>)`
![image](https://user-images.githubusercontent.com/19890894/146267117-0cae18ee-5d52-4dbf-9262-3a77f3e25b09.png)
