### PR TITLE
wip: try to not count fuzztest cases which return early

### DIFF
--- a/evm-adapters/src/evmodin.rs
+++ b/evm-adapters/src/evmodin.rs
@@ -36,6 +36,12 @@ pub trait HostExt: Host {
     fn set_balance(&mut self, address: Address, balance: U256);
 }
 
+impl crate::Reason for StatusCode {
+    fn stopped(&self) -> bool {
+        *self == StatusCode::Success
+    }
+}
+
 impl<S: HostExt, Tr: Tracer> Evm<S> for EvmOdin<S, Tr> {
     type ReturnReason = StatusCode;
 

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -42,12 +42,16 @@ pub enum EvmError {
     Eyre(#[from] eyre::Error),
 }
 
+pub trait Reason {
+    fn stopped(&self) -> bool;
+}
+
 // TODO: Any reason this should be an async trait?
 /// Low-level abstraction layer for interfacing with various EVMs. Once instantiated, one
 /// only needs to specify the transaction parameters
 pub trait Evm<State> {
     /// The returned reason type from an EVM (Success / Revert/ Stopped etc.)
-    type ReturnReason: std::fmt::Debug + PartialEq;
+    type ReturnReason: Reason + std::fmt::Debug + PartialEq;
 
     /// Gets the revert reason type
     fn revert() -> Self::ReturnReason;

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -7,7 +7,7 @@ use sputnik::{
     executor::stack::{
         MemoryStackState, PrecompileSet, StackExecutor, StackState, StackSubstateMetadata,
     },
-    Config, CreateScheme, ExitReason, ExitRevert, Transfer,
+    Config, CreateScheme, ExitReason, ExitRevert, ExitSucceed, Transfer,
 };
 use std::{collections::BTreeMap, marker::PhantomData};
 
@@ -48,6 +48,12 @@ impl<'a, 'b, B: Backend, P: PrecompileSet>
         let executor = StackExecutor::new_with_precompiles(state, config, precompiles);
 
         Self { executor, gas_limit, marker: PhantomData }
+    }
+}
+
+impl crate::Reason for ExitReason {
+    fn stopped(&self) -> bool {
+        *self == ExitReason::Succeed(ExitSucceed::Stopped)
     }
 }
 


### PR DESCRIPTION
There’s a bug here, if a test returns early, it does not contribute (meaningfully) towards the test’s gas consumption, but it gets pushed to the array of tests, driving the median/means down. Ideally we should be able to differentiate on whether a function call RETURNs early or STOPs at the end of it.

This is still WIP / not working

For example, compare the `testDeposit` gas costs below. The fuzzed deposit surely can't be costing less than the non-fuzzed!

![telegram-cloud-photo-size-2-5318780731230632199-x](https://user-images.githubusercontent.com/17802178/146284606-4ce01fb0-8a15-43ec-a469-dc6b6bbfe433.jpg)

![telegram-cloud-photo-size-2-5318780731230632200-x](https://user-images.githubusercontent.com/17802178/146284615-1fab169f-dede-4778-bcb1-b6bf27fe311c.jpg)
![telegram-cloud-photo-size-2-5318780731230632201-x](https://user-images.githubusercontent.com/17802178/146284621-6b393aa6-06d3-427a-a9e0-ed7eeeeda631.jpg)

cc @mattsse 