### PR TITLE
feat(forge): Expect Revert cheatcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,11 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76ef192b63e8a44b3d08832acebbb984c3fba154b5c26f70037c860202a0d4b"
+version = "16.0.0"
+source = "git+https://github.com/rust-ethereum/ethabi?branch=master#7f4bb3d6164775928485b2bad2f6e130a96f438e"
 dependencies = [
- "anyhow",
  "ethereum-types",
  "hex",
  "serde",
@@ -1136,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1150,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1168,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1189,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1203,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1231,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1244,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1267,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1296,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1318,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#f4c89c6cb1038f40b806224ff62b11410dd1b0ee"
+source = "git+https://github.com/gakonst/ethers-rs#4d647453e3df09d0934964ef913951cd38366286"
 dependencies = [
  "colored",
  "ethers-core",

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -756,8 +756,8 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
         // NB: This is very similar to how Optimism's custom intercept logic to "predeploys" work
         // (e.g. with the StateManager)
 
-        let expected_revert = &self.state().expected_revert.clone();
-        self.state_mut().expected_revert = None;
+        let expected_revert = self.state_mut().expected_revert.take();
+
         if code_address == *CHEATCODE_ADDRESS {
             self.apply_cheatcode(input, transfer, target_gas)
         } else if code_address == *CONSOLE_ADDRESS {
@@ -792,7 +792,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                                     String::from_utf8_lossy(
                                         &decoded_data[..]
                                     ),
-                                    String::from_utf8_lossy(expected_revert)
+                                    String::from_utf8_lossy(&expected_revert)
                                 ))
                             }
                         }

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -779,8 +779,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                     Capture::Exit((ExitReason::Revert(_e), data)) => {
                         if data.len() >= 4 && data[0..4] == [8, 195, 121, 160] {
                             // its a revert string
-                            let decoded_data = ethers::abi::decode(&[ethers::abi::ParamType::Bytes], &data[4..]).expect("String error code, but not actual string");
-                            let decoded_data = decoded_data[0].clone().into_bytes().expect("Can never fail because it is bytes");
+                            let decoded_data =
+                                ethers::abi::decode(&[ethers::abi::ParamType::Bytes], &data[4..])
+                                    .expect("String error code, but not actual string");
+                            let decoded_data = decoded_data[0]
+                                .clone()
+                                .into_bytes()
+                                .expect("Can never fail because it is bytes");
                             if decoded_data == *expected_revert {
                                 return Capture::Exit((
                                     ExitReason::Succeed(ExitSucceed::Returned),
@@ -789,9 +794,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                             } else {
                                 return evm_error(&*format!(
                                     "Error != expected error: '{}' != '{}'",
-                                    String::from_utf8_lossy(
-                                        &decoded_data[..]
-                                    ),
+                                    String::from_utf8_lossy(&decoded_data[..]),
                                     String::from_utf8_lossy(&expected_revert)
                                 ))
                             }

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -15,6 +15,7 @@ use ethers::types::{H160, H256, U256};
 pub struct MemoryStackStateOwned<'config, B> {
     pub backend: B,
     pub substate: MemoryStackSubstate<'config>,
+    pub expected_revert: Option<Vec<u8>>,
 }
 
 impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
@@ -25,7 +26,7 @@ impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
 
 impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
     pub fn new(metadata: StackSubstateMetadata<'config>, backend: B) -> Self {
-        Self { backend, substate: MemoryStackSubstate::new(metadata) }
+        Self { backend, substate: MemoryStackSubstate::new(metadata), expected_revert: None }
     }
 }
 

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -53,6 +53,7 @@ ethers::contract::abigen!(
             prank(address,address,bytes)(bool,bytes)
             deal(address,uint256)
             etch(address,bytes)
+            expectRevert(bytes)
     ]"#,
 );
 pub use hevm_mod::HEVMCalls;

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -218,6 +218,14 @@ contract CheatCodes is DSTest {
         target.stringErr(99); 
     }
 
+    function testExpectCustomRevert() public {
+        ExpectRevert target = new ExpectRevert();
+        bytes memory data = abi.encodePacked(bytes4(keccak256("InputTooLarge()")));
+        hevm.expectRevert(data);
+        target.customErr(101);
+        target.customErr(99); 
+    }
+
     function testCalleeExpectRevert() public {
         ExpectRevert target = new ExpectRevert();
         hevm.expectRevert("Value too largeCallee");
@@ -255,7 +263,7 @@ contract CheatCodes is DSTest {
 }
 
 
-// error InputTooLarge();
+error InputTooLarge();
 contract ExpectRevert {
     function stringErrCall(uint256 a) public returns (uint256) {
         ExpectRevertCallee callee = new ExpectRevertCallee();
@@ -273,14 +281,12 @@ contract ExpectRevert {
         return a;
     }
 
-    // TODO: ethabi doesn't support custom errors, so whenever they do we can reimpl this test
-
-    // function customErr(uint256 a) public returns (uint256) {
-    //     if (a < 100) {
-    //         revert InputTooLarge();
-    //     }
-    //     return a;
-    // }
+    function customErr(uint256 a) public returns (uint256) {
+        if (a > 99) {
+            revert InputTooLarge();
+        }
+        return a;
+    }
 }
 
 contract ExpectRevertCallee {

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -1,6 +1,6 @@
 // Taken from:
 // https://github.com/dapphub/dapptools/blob/e41b6cd9119bbd494aba1236838b859f2136696b/src/dapp-tests/pass/cheatCodes.sol
-pragma solidity ^0.6.6;
+pragma solidity ^0.8.4;
 pragma experimental ABIEncoderV2;
 
 import "./DsTest.sol";
@@ -26,6 +26,8 @@ interface Hevm {
     function deal(address, uint256) external;
     // Sets an address' code, (who, newCode)
     function etch(address, bytes calldata) external;
+    // Expects an error on next call
+    function expectRevert(bytes calldata) external;
 }
 
 contract HasStorage {
@@ -209,6 +211,32 @@ contract CheatCodes is DSTest {
         assertEq(string(newCode), string(n_code));
     }
 
+    function testExpectRevert() public {
+        ExpectRevert target = new ExpectRevert();
+        hevm.expectRevert("Value too large");
+        target.stringErr(101);
+        target.stringErr(99); 
+    }
+
+    function testCalleeExpectRevert() public {
+        ExpectRevert target = new ExpectRevert();
+        hevm.expectRevert("Value too largeCallee");
+        target.stringErrCall(101);
+        target.stringErrCall(99);
+    }
+
+    function testFailExpectRevert() public {
+        ExpectRevert target = new ExpectRevert();
+        hevm.expectRevert("Value too large");
+        target.stringErr2(101);
+    }
+
+    function testFailExpectRevert2() public {
+        ExpectRevert target = new ExpectRevert();
+        hevm.expectRevert("Value too large");
+        target.stringErr(99);
+    }
+
     function getCode(address who) internal returns (bytes memory o_code) {
         assembly {
             // retrieve the size of the code, this needs assembly
@@ -223,6 +251,47 @@ contract CheatCodes is DSTest {
             // actually retrieve the code, this needs assembly
             extcodecopy(who, add(o_code, 0x20), 0, size)
         }
+    }
+}
+
+
+// error InputTooLarge();
+contract ExpectRevert {
+    function stringErrCall(uint256 a) public returns (uint256) {
+        ExpectRevertCallee callee = new ExpectRevertCallee();
+        uint256 amount = callee.stringErr(a);
+        return amount;
+    }
+
+    function stringErr(uint256 a) public returns (uint256) {
+        require(a < 100, "Value too large");
+        return a;
+    }
+
+    function stringErr2(uint256 a) public returns (uint256) {
+        require(a < 100, "Value too large2");
+        return a;
+    }
+
+    // TODO: ethabi doesn't support custom errors, so whenever they do we can reimpl this test
+
+    // function customErr(uint256 a) public returns (uint256) {
+    //     if (a < 100) {
+    //         revert InputTooLarge();
+    //     }
+    //     return a;
+    // }
+}
+
+contract ExpectRevertCallee {
+    function stringErr(uint256 a) public returns (uint256) {
+        require(a < 100, "Value too largeCallee");
+        return a;
+    }
+
+    function stringErr2(uint256 a) public returns (uint256) {
+        require(a < 100, "Value too large2Callee");
+        return a;
     }
 }
 

--- a/forge/README.md
+++ b/forge/README.md
@@ -136,12 +136,22 @@ which implements the following methods:
 
 - `function prank(address from, address to, bytes calldata) (bool success,bytes retdata)`:
   Performs a smart contract call as another address
+- `function expectRevert(bytes calldata expectedError)`:
+  Tells the evm to expect that the next call to revert with a specified error bytes.
 
-The below example uses the `warp` cheatcode to override the timestamp:
+The below example uses the `warp` cheatcode to override the timestamp & `expectRevert` to expect a specific revert string:
 
 ```solidity
 interface Vm {
     function warp(uint256 x) external;
+    function expectRevert(bytes calldata) external;
+}
+
+contract Foo {
+    function bar(uint256 a) public returns (uint256) {
+        require(a < 100, "My expected revert string");
+        return a;
+    }
 }
 
 contract MyTest {
@@ -151,6 +161,47 @@ contract MyTest {
         vm.warp(100);
         require(block.timestamp == 100);
     }
+
+    function testBarExpectedRevert() public {
+        vm.expectRevert("My expected revert string");
+        // This would fail *if* we didnt expect revert. Since we expect the revert,
+        // it doesn't, unless the revert string is wrong.
+        foo.bar(101);
+    }
+
+    function testFailBar() public {
+        // this call would revert, causing this test to pass
+        foo.bar(101);
+    }
+}
+```
+
+A full interface for all cheatcodes is here:
+```solidity
+interface Vm {
+    // Set block.timestamp (newTimestamp)
+    function warp(uint256) external;
+    // Set block.height (newHeight)
+    function roll(uint256) external;
+    // Loads a storage slot from an address (who, slot)
+    function load(address,bytes32) external returns (bytes32);
+    // Stores a value to an address' storage slot, (who, slot, value)
+    function store(address,bytes32,bytes32) external;
+    // Signs data, (privateKey, digest) => (r, v, s)
+    function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
+    // Gets address for a given private key, (privateKey) => (address)
+    function addr(uint256) external returns (address);
+    // Performs a foreign function call via terminal, (stringInputs) => (result)
+    function ffi(string[] calldata) external returns (bytes memory);
+    // Calls another contract with a specified `msg.sender`, (newSender, contract, input) => (success, returnData)
+    function prank(address, address, bytes calldata) external payable returns (bool, bytes memory);
+    // Sets an address' balance, (who, newBalance)
+    function deal(address, uint256) external;
+    // Sets an address' code, (who, newCode)
+    function etch(address, bytes calldata) external;
+    // Expects an error on next call
+    function expectRevert(bytes calldata) external;
+}
 ```
 
 ## Future Features

--- a/forge/README.md
+++ b/forge/README.md
@@ -137,7 +137,7 @@ which implements the following methods:
 - `function prank(address from, address to, bytes calldata) (bool success,bytes retdata)`:
   Performs a smart contract call as another address
 - `function expectRevert(bytes calldata expectedError)`:
-  Tells the evm to expect that the next call to revert with a specified error bytes.
+  Tells the evm to expect that the next call reverts with specified error bytes.
 
 The below example uses the `warp` cheatcode to override the timestamp & `expectRevert` to expect a specific revert string:
 


### PR DESCRIPTION
Adds `expectRevert` cheatcode, allowing you do to something like:

```solidity
interface Vm {
    function expectRevert(bytes calldata) external;
}

contract Foo {
    function bar(uint256 a) public returns (uint256) {
        require(a < 100, "My expected revert string");
        return a;
    }
}

contract MyTest {
    Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

    function testBarExpectedRevert() public {
        vm.expectRevert("My expected revert string");
        // This would fail *if* we didnt expect revert. Since we expect the revert,
        // it doesn't, unless the revert string is wrong.
        foo.bar(101);
    }

    function testFailBar() public {
        // this call would revert, causing this test to pass
        foo.bar(101);
    }

    function testBar() public {
        // this test would *fail*
        foo.bar(101);
    }
}
```