### PR TITLE
feat: add code to cast

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -44,7 +44,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    ///
+    /// 
     /// use cast::Cast;
     /// use ethers_core::types::Address;
     /// use ethers_providers::{Provider, Http};

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -286,6 +286,21 @@ where
         Ok(self.provider.get_gas_price().await?)
     }
 
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    /// use ethers_core::types::Address;
+    /// use std::{str::FromStr, convert::TryFrom};
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let addr = Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa")?;
+    /// let code = cast.code(addr, None).await?;
+    /// println!("{}", code);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn code<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         who: T,

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -44,7 +44,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    /// 
+    ///
     /// use cast::Cast;
     /// use ethers_core::types::Address;
     /// use ethers_providers::{Provider, Http};
@@ -284,6 +284,14 @@ where
 
     pub async fn gas_price(&self) -> Result<U256> {
         Ok(self.provider.get_gas_price().await?)
+    }
+
+    pub async fn code<T: Into<NameOrAddress> + Send + Sync>(
+        &self,
+        who: T,
+        block: Option<BlockId>,
+    ) -> Result<String> {
+        Ok(format!("{}", self.provider.get_code(who, block).await?))
     }
 }
 

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -110,6 +110,10 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).chain_id().await?);
         }
+        Subcommands::Code { block, who, rpc_url } => {
+            let provider = Provider::try_from(rpc_url)?;
+            println!("{}", Cast::new(provider).code(who, block).await?);
+        }
         Subcommands::Namehash { name } => {
             println!("{}", SimpleCast::namehash(&name)?);
         }

--- a/cli/src/cast_opts.rs
+++ b/cli/src/cast_opts.rs
@@ -152,6 +152,16 @@ pub enum Subcommands {
         #[structopt(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
+    #[structopt(name = "code")]
+    #[structopt(about = "Prints the bytecode at <address>")]
+    Code {
+        #[structopt(long, short, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        block: Option<BlockId>,
+        #[structopt(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
+        who: NameOrAddress,
+        #[structopt(short, long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+    },
     #[structopt(name = "gas-price")]
     #[structopt(about = "Prints current gas price of target chain")]
     GasPrice {


### PR DESCRIPTION
Tested by running both `seth code 0x00000000219ab540356cbb839cbe05303d7705fa` and `cargo run --bin cast code --rpc-url $RPC_URL 0x00000000219ab540356cbb839cbe05303d7705fa` and validated that the outputs were equal via diffchecker.

Feedback regarding implementation is welcome as I'm a Rust n00b and if there is more to be desired around test coverage, happy to update accordingly.