### PR TITLE
fix: cross-platform build

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      
+
       - name: Install libusb (for Ledger)
         run: sudo apt update && sudo apt install pkg-config libudev-dev
-      
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -57,3 +57,80 @@ jobs:
 
       - name: cargo clippy
         run: cargo +nightly clippy --all --all-features -- -D warnings
+
+
+  build:
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                  }
+          - { target: x86_64-apple-darwin         , os: macos-10.15                   }
+          - { target: i686-pc-windows-msvc        , os: windows-2019                  }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install prerequisites
+        shell: bash
+        run: |
+          case ${{ matrix.job.target }} in
+            arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+          esac
+
+      - name: Install packages (Ubuntu)
+        if: matrix.job.os == 'ubuntu-20.04'
+        run: |
+          sudo apt update
+          sudo apt install libudev-dev libssl-dev openssl pkg-config
+
+      - name: Extract crate information
+        shell: bash
+        run: |
+          echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+          echo "PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.job.target }}
+          override: true
+          profile: minimal
+
+      - name: Show installed version information (Rust, cargo, GCC,...)
+        shell: bash
+        run: |
+          gcc --version || true
+          rustup -V
+          rustup toolchain list
+          rustup default
+          cargo -V
+          rustc -V
+
+      - name: Build foundry and call crates
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.job.use-cross }}
+          command: build
+          args: --verbose --workspace
+
+      - name: Run forge
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.job.use-cross }}
+          command: run
+          args: -p foundry-cli --no-default-features --bin forge -- --help
+
+      - name: Run tests without --default-features to avoid solc-asm being used
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.job.use-cross }}
+          command: test
+          args: --verbose --no-default-features --workspace

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -114,23 +114,23 @@ jobs:
           cargo -V
           rustc -V
 
-      - name: Build foundry crates
+      - name: Build foundry and call crates
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --verbose --workspace
+          args: --no-default-features --verbose --workspace
 
       - name: Run forge
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: run
-          args: -p foundry-cli --bin forge -- --help
+          args: -p foundry-cli --no-default-features --bin forge -- --help
 
-      - name: Run tests
+      - name: Run tests without --default-features to avoid solc-asm being used
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --verbose --workspace
+          args: --verbose --no-default-features --workspace

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
         if: matrix.job.os == 'ubuntu-20.04'
         run: |
           sudo apt update
-          sudo apt install libudev-dev libssl-dev openssl pkg-config
+          sudo apt install libudev-dev pkg-config
 
       - name: Extract crate information
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --verbose --workspace
+          args: --no-default-features --verbose --workspace
 
       - name: Run forge
         uses: actions-rs/cargo@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -114,23 +114,23 @@ jobs:
           cargo -V
           rustc -V
 
-      - name: Build foundry and call crates
+      - name: Build foundry crates
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --no-default-features --verbose --workspace
+          args: --verbose --workspace
 
       - name: Run forge
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: run
-          args: -p foundry-cli --no-default-features --bin forge -- --help
+          args: -p foundry-cli --bin forge -- --help
 
-      - name: Run tests without --default-features to avoid solc-asm being used
+      - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --verbose --no-default-features --workspace
+          args: --verbose --workspace

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -114,6 +114,10 @@ jobs:
           cargo -V
           rustc -V
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
       - name: Build foundry and call crates
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -119,18 +119,18 @@ jobs:
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --no-default-features --verbose --workspace
+          args: --verbose --workspace
 
       - name: Run forge
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: run
-          args: -p foundry-cli --no-default-features --bin forge -- --help
+          args: -p foundry-cli --bin forge -- --help
 
       - name: Run tests without --default-features to avoid solc-asm being used
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --verbose --no-default-features --workspace
+          args: --verbose --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1249,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
+source = "git+https://github.com/gakonst/ethers-rs#0d2fc53541b3f448ec5918b4a6ddf1b5d49ee0c9"
 dependencies = [
  "colored",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1265,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
+source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
 dependencies = [
  "colored",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1229,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1265,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#9c11f6cb7b739e2453c5e9d47c20641581474b88"
 dependencies = [
  "colored",
  "ethers-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1281,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio-tungstenite",
  "tracing",
  "tracing-futures",
  "url",
@@ -1473,6 +1490,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forge"
@@ -1962,6 +1994,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "i256"
 version = "0.1.0"
 source = "git+https://github.com/vorot93/rust-i256#7e14ceab6bc45cf1ba6b4f1fb083e38f7187ddd0"
@@ -2270,6 +2315,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2483,20 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3082,11 +3159,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -3095,12 +3174,13 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.21.1",
  "winreg",
 ]
 
@@ -3309,6 +3389,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3371,6 +3461,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3460,6 +3573,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,6 +3608,16 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3834,6 +3970,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,6 +3988,24 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "rustls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.1",
 ]
 
 [[package]]
@@ -4000,6 +4164,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tungstenite"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.4",
+ "rustls",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4073,6 +4259,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -4268,6 +4460,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -1148,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1166,11 +1172,12 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "Inflector",
  "anyhow",
  "cfg-if 1.0.0",
+ "dunce",
  "ethers-core",
  "getrandom 0.2.3",
  "hex",
@@ -1187,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1201,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1229,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1242,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1265,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1295,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1317,9 +1324,10 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#d7c29cc615e260bd13f9efd93fa2223d48d9d31b"
+source = "git+https://github.com/gakonst/ethers-rs#ef13818e82e2a7a8f34012391367a5b3dbfa0c08"
 dependencies = [
  "colored",
+ "dunce",
  "ethers-core",
  "futures-util",
  "getrandom 0.2.3",

--- a/README.md
+++ b/README.md
@@ -20,13 +20,21 @@ Foundry consists of:
 ![demo](./assets/demo.svg)
 
 ## Dependencies
-Currently both Forge and Cast rely on the [libudev-dev](https://packages.debian.org/sid/libudev-dev) package. This package may be preinstalled for your system, but is also available in most packages managers.
+
+Currently both Forge and Cast rely on the
+[libudev-dev](https://packages.debian.org/sid/libudev-dev) package. This package
+may be preinstalled for your system, but is also available in most packages
+managers.
 
 ## Forge
 
 ```
 cargo install --git https://github.com/gakonst/foundry --bin forge --locked
 ```
+
+If you are on a x86/x86_64 Unix machine, you can also use `--features=solc-asm`
+to enable Sha2 Assembly instructions, which further speedup the compilation
+pipeline cache.
 
 We also recommend using [forgeup](https://github.com/transmissions11/forgeup)
 for managing various versions of Forge, so that you can easily test out bleeding

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,8 +40,7 @@ once_cell = "1.8.0"
 tempdir = "0.3.7"
 
 [features]
-default = ["sputnik-evm", "solc-asm", "rustls"]
-solc-asm = ["ethers/solc-sha2-asm"]
+default = ["sputnik-evm", "rustls"]
 rustls = ["ethers/rustls"]
 openssl = ["ethers/openssl"]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,8 @@ once_cell = "1.8.0"
 tempdir = "0.3.7"
 
 [features]
-default = ["sputnik-evm", "rustls"]
+default = ["sputnik-evm", "solc-asm", "rustls"]
+solc-asm = ["ethers/solc-sha2-asm"]
 rustls = ["ethers/rustls"]
 openssl = ["ethers/openssl"]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ once_cell = "1.8.0"
 tempdir = "0.3.7"
 
 [features]
-default = ["sputnik-evm", "solc-asm", "rustls"]
+default = ["sputnik-evm", "rustls"]
 solc-asm = ["ethers/solc-sha2-asm"]
 rustls = ["ethers/rustls"]
 openssl = ["ethers/openssl"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,10 @@ once_cell = "1.8.0"
 tempdir = "0.3.7"
 
 [features]
-default = ["sputnik-evm", "evmodin-evm"]
+default = ["sputnik-evm", "solc-asm", "rustls"]
+solc-asm = ["ethers/solc-sha2-asm"]
+rustls = ["ethers/rustls"]
+openssl = ["ethers/openssl"]
 
 sputnik-evm = [
     "sputnik",

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -13,13 +13,9 @@ use ethers::{
     solc::{ArtifactOutput, Project},
     types::{Address, U256},
 };
-use evm_adapters::{
-    sputnik::{vicinity, ForkMemoryBackend, PRECOMPILES_MAP},
-    FAUCET_ACCOUNT,
-};
+use evm_adapters::FAUCET_ACCOUNT;
 use forge::MultiContractRunnerBuilder;
 use regex::Regex;
-use sputnik::backend::Backend;
 use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
 use structopt::StructOpt;
 
@@ -127,8 +123,8 @@ impl Cmd for TestArgs {
         match evm_type {
             #[cfg(feature = "sputnik-evm")]
             EvmType::Sputnik => {
-                use evm_adapters::sputnik::Executor;
-                use sputnik::backend::MemoryBackend;
+                use evm_adapters::sputnik::{Executor, {vicinity, ForkMemoryBackend, PRECOMPILES_MAP}};
+                use sputnik::backend::{Backend, MemoryBackend};
                 let mut cfg = utils::sputnik_cfg(opts.evm_version);
 
                 // We disable the contract size limit by default, because Solidity

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -123,7 +123,9 @@ impl Cmd for TestArgs {
         match evm_type {
             #[cfg(feature = "sputnik-evm")]
             EvmType::Sputnik => {
-                use evm_adapters::sputnik::{Executor, {vicinity, ForkMemoryBackend, PRECOMPILES_MAP}};
+                use evm_adapters::sputnik::{
+                    vicinity, Executor, ForkMemoryBackend, PRECOMPILES_MAP,
+                };
                 use sputnik::backend::{Backend, MemoryBackend};
                 let mut cfg = utils::sputnik_cfg(opts.evm_version);
 

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1108,6 +1108,11 @@ mod tests {
 
         let abi = compiled.abi.as_ref().unwrap();
         for func in abi.functions().filter(|func| func.name.starts_with("test")) {
+            // Skip the FFI unit test if not in a unix system
+            if func.name == "testFFI" && !cfg!(unix) {
+                continue
+            }
+
             let should_fail = func.name.starts_with("testFail");
             if func.inputs.is_empty() {
                 let (_, reason, _, _) =


### PR DESCRIPTION
Fixes #229:
1. by removing the OpenSSL requirement and using Rustls as the TLS backend.
2. by only conditionally enabling Sha2 assembly instructions (which were not available in other platforms)
3. skips unit test for FFI on windows since that command (`echo`) does not exist on windows

ref:
https://github.com/gakonst/ethers-rs/pull/703
https://github.com/roynalnaruto/svm-rs/pull/11

supersedes https://github.com/gakonst/foundry/pull/218