### PR TITLE
feat(forge): better prank

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -16,6 +16,7 @@ pub struct MemoryStackStateOwned<'config, B> {
     pub backend: B,
     pub substate: MemoryStackSubstate<'config>,
     pub expected_revert: Option<Vec<u8>>,
+    pub next_msg_sender: Option<H160>,
 }
 
 impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
@@ -26,7 +27,12 @@ impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
 
 impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
     pub fn new(metadata: StackSubstateMetadata<'config>, backend: B) -> Self {
-        Self { backend, substate: MemoryStackSubstate::new(metadata), expected_revert: None }
+        Self {
+            backend,
+            substate: MemoryStackSubstate::new(metadata),
+            expected_revert: None,
+            next_msg_sender: None,
+        }
     }
 }
 

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -50,7 +50,7 @@ ethers::contract::abigen!(
             ffi(string[])(bytes)
             addr(uint256)(address)
             sign(uint256,bytes32)(uint8,bytes32,bytes32)
-            prank(address,address,bytes)(bool,bytes)
+            prank(address)
             deal(address,uint256)
             etch(address,bytes)
             expectRevert(bytes)


### PR DESCRIPTION
*BREAKING CHANGE*

Improves the `prank` cheatcode by following the `expectRevert` model of prepare -> call
```solidity
interface Vm {
    function prank(address) external;
}

contract Foo {
    function bar(address expectedMsgSender) public {
        require(msg.sender == expectedMsgSender, "bad prank");
    }
}

contract MyTest {
    Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

    function testBar() public {
        vm.prank(address(1337));
        foo.bar(address(1337));
        foo.bar(address(this));
    }
}
```