### PR TITLE
fix(forge): empty fuzz cases panic

### DIFF
--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -170,11 +170,10 @@ impl FuzzedCases {
     /// Returns the average gas use of all test cases
     pub fn mean_gas(&self) -> u64 {
         if self.cases.is_empty() {
-            0
-        } else {
-            (self.cases.iter().map(|c| c.gas as u128).sum::<u128>() / self.cases.len() as u128)
-                as u64
+            return 0
         }
+
+        (self.cases.iter().map(|c| c.gas as u128).sum::<u128>() / self.cases.len() as u128) as u64
     }
 
     pub fn highest(&self) -> Option<&FuzzCase> {

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -169,7 +169,12 @@ impl FuzzedCases {
 
     /// Returns the average gas use of all test cases
     pub fn mean_gas(&self) -> u64 {
-        (self.cases.iter().map(|c| c.gas as u128).sum::<u128>() / self.cases.len() as u128) as u64
+        if !self.cases.is_empty() {
+            (self.cases.iter().map(|c| c.gas as u128).sum::<u128>() / self.cases.len() as u128)
+                as u64
+        } else {
+            0
+        }
     }
 
     pub fn highest(&self) -> Option<&FuzzCase> {

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -169,11 +169,11 @@ impl FuzzedCases {
 
     /// Returns the average gas use of all test cases
     pub fn mean_gas(&self) -> u64 {
-        if !self.cases.is_empty() {
+        if self.cases.is_empty() {
+            0
+        } else {
             (self.cases.iter().map(|c| c.gas as u128).sum::<u128>() / self.cases.len() as u128)
                 as u64
-        } else {
-            0
         }
     }
 


### PR DESCRIPTION
When the first fuzz test fails, no test cases get added and we panic in the mean gas calculation.