### PR TITLE
chore: add dependencies section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Foundry consists of:
 
 ![demo](./assets/demo.svg)
 
+## Dependencies
+Currently both Forge and Cast rely on the [libudev-dev](https://packages.debian.org/sid/libudev-dev) package. This package may be preinstalled for your system, but is also available in most packages managers.
+
 ## Forge
 
 ```


### PR DESCRIPTION
Dependencies section includes a quick note about the `libudev-dev` requirement. I decided to put it in its own section rather than below the installation example since I think this is a dependency of both Forge and Cargo, and didn't want to have to repeat it in both places.