### PR TITLE
fix(forge): no longer git commit on init when in an existing git repo

### DIFF
--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -105,14 +105,13 @@ fn main() -> eyre::Result<()> {
                     .wait()?;
                 if !is_git.success() {
                     Command::new("git").arg("init").current_dir(&root).spawn()?.wait()?;
+                    Command::new("git").args(&["add", "."]).current_dir(&root).spawn()?.wait()?;
+                    Command::new("git")
+                        .args(&["commit", "-m", "chore: forge init"])
+                        .current_dir(&root)
+                        .spawn()?
+                        .wait()?;
                 }
-                Command::new("git").args(&["add", "."]).current_dir(&root).spawn()?.wait()?;
-                Command::new("git")
-                    .args(&["commit", "-m", "chore: forge init"])
-                    .current_dir(&root)
-                    .spawn()?
-                    .wait()?;
-
                 Dependency::from_str("https://github.com/dapphub/ds-test")
                     .and_then(|dependency| install(root, vec![dependency]))?;
             }


### PR DESCRIPTION
Fix for #231. Now `init` will only `git add/commit` when it creates a new repo.