### PR TITLE
feat(cast): add tx command

### DIFF
--- a/cast/README.md
+++ b/cast/README.md
@@ -35,7 +35,7 @@
 - [x] `calldata`
 - [x] `chain`
 - [x] `chain-id`
-- [ ] `code`
+- [x] `code`
 - [ ] `debug`
 - [ ] `estimate`
 - [ ] `etherscan-source`
@@ -56,4 +56,4 @@
 - [x] `send` (partial)
 - [ ] `sign`
 - [x] `storage`
-- [ ] `tx`
+- [x] `tx`

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -124,6 +124,10 @@ async fn main() -> eyre::Result<()> {
         Subcommands::Namehash { name } => {
             println!("{}", SimpleCast::namehash(&name)?);
         }
+        Subcommands::Tx { rpc_url, hash, field, to_json } => {
+            let provider = Provider::try_from(rpc_url)?;
+            println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
+        }
         Subcommands::SendTx { eth, to, sig, cast_async, args } => {
             let provider = Provider::try_from(eth.rpc_url.as_str())?;
             let chain_id = Cast::new(&provider).chain_id().await?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -107,6 +107,16 @@ pub enum Subcommands {
     #[structopt(name = "namehash")]
     #[structopt(about = "returns ENS namehash of provided name")]
     Namehash { name: String },
+    #[structopt(name = "tx")]
+    #[structopt(about = "Show information about the transaction <tx-hash>")]
+    Tx {
+        hash: String,
+        field: Option<String>,
+        #[structopt(long = "--json", short = "-j")]
+        to_json: bool,
+        #[structopt(long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+    },
     #[structopt(name = "send")]
     #[structopt(about = "Publish a transaction signed by <from> to call <to> with <data>")]
     SendTx {


### PR DESCRIPTION
This commit ports the `seth tx` command to `cast`.
It follows the implementation of `cast block` and includes
the feature to print a specific field in the transaction
as well as printing the result in JSON.

```
$ cast tx --rpc-url <url> <tx-hash> [field]
```

The flag `-j`/`--json` is used to print the result
as JSON.

A whitespace is in a docstring is removed (autoformatted on save) and
the `cast` `README` is updated to indicate that the `tx` command was
implemented. Also check off the `code` command as it was previously
implemented.

Open to any stylistic feedback as I'm gaining experience writing Rust :)
The added doctest passes when I run it locally.