### PR TITLE
feat: add cast --from-wei

### DIFF
--- a/cast/README.md
+++ b/cast/README.md
@@ -7,7 +7,7 @@
 - [x] `--from-ascii` (with `--from-utf8` alias)
 - [ ] `--from-bin`
 - [ ] `--from-fix`
-- [ ] `--from-wei`
+- [x] `--from-wei`
 - [ ] `--max-int`
 - [x] `--max-uint`
 - [ ] `--min-int`

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -511,6 +511,41 @@ impl SimpleCast {
         })
     }
 
+    /// Converts wei into an eth amount
+    /// 
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    /// 
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::from_wei(1.into(), "gwei".to_string())?, "0.000000001");
+    ///     assert_eq!(Cast::from_wei(12340000005u64.into(), "gwei".to_string())?, "12.340000005");
+    ///     assert_eq!(Cast::from_wei(10.into(), "ether".to_string())?, "0.00000000000000001");
+    ///     assert_eq!(Cast::from_wei(100.into(), "eth".to_string())?, "0.0000000000000001");
+    ///     assert_eq!(Cast::from_wei(17.into(), "".to_string())?, "17");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn from_wei(value: U256, unit: String) -> Result<String> {
+        Ok(match &unit[..] {
+            "gwei" => {
+                let gwei = U256::pow(10.into(), 9.into());
+                let left = value / gwei;
+                let right = value - left * gwei;
+                let res = format!("{}.{:0>9}", left, right.to_string());
+                res.trim_end_matches("0").to_string()
+            },
+            "eth" | "ether" => {
+                let wei = U256::pow(10.into(), 18.into());
+                let left = value / wei;
+                let right = value - left * wei;
+                let res = format!("{}.{:0>18}", left, right.to_string());
+                res.trim_end_matches("0").to_string()
+            },
+            _ => value.to_string(),
+        })
+    }
+
     /// Converts an Ethereum address to its checksum format
     /// according to [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md)
     ///

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -512,10 +512,10 @@ impl SimpleCast {
     }
 
     /// Converts wei into an eth amount
-    /// 
+    ///
     /// ```
     /// use cast::SimpleCast as Cast;
-    /// 
+    ///
     /// fn main() -> eyre::Result<()> {
     ///     assert_eq!(Cast::from_wei(1.into(), "gwei".to_string())?, "0.000000001");
     ///     assert_eq!(Cast::from_wei(12340000005u64.into(), "gwei".to_string())?, "12.340000005");
@@ -533,15 +533,15 @@ impl SimpleCast {
                 let left = value / gwei;
                 let right = value - left * gwei;
                 let res = format!("{}.{:0>9}", left, right.to_string());
-                res.trim_end_matches("0").to_string()
-            },
+                res.trim_end_matches('0').to_string()
+            }
             "eth" | "ether" => {
                 let wei = U256::pow(10.into(), 18.into());
                 let left = value / wei;
                 let right = value - left * wei;
                 let res = format!("{}.{:0>18}", left, right.to_string());
-                res.trim_end_matches("0").to_string()
-            },
+                res.trim_end_matches('0').to_string()
+            }
             _ => value.to_string(),
         })
     }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -94,6 +94,16 @@ async fn main() -> eyre::Result<()> {
                 )?
             );
         }
+        Subcommands::FromWei { value, unit } => {
+            let val = unwrap_or_stdin(value)?;
+            println!(
+                "{}",
+                SimpleCast::from_wei(
+                    U256::from_dec_str(&val)?,
+                    unit.unwrap_or_else(|| String::from("wei"))
+                )?
+            );
+        }
         Subcommands::Block { rpc_url, block, full, field, to_json } => {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).block(block, full, field, to_json).await?);

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -50,6 +50,9 @@ pub enum Subcommands {
     #[structopt(name = "--to-wei")]
     #[structopt(about = "convert an ETH amount into wei")]
     ToWei { value: Option<String>, unit: Option<String> },
+    #[structopt(name = "--from-wei")]
+    #[structopt(about = "convert wei into an ETH amount")]
+    FromWei { value: Option<String>, unit: Option<String> },
     #[structopt(name = "block")]
     #[structopt(
         about = "Prints information about <block>. If <field> is given, print only the value of that field"


### PR DESCRIPTION
One thing I was not sure about here was how to handle the default behavior when a unit string is not supplied. In dapptools, it defaults to ether, however this is not consistent with the behavior of both dapptools and foundry for --to-wei, which defaults to wei when no unit string is supplied. I chose to make it default to wei, but can change it to ether if that is preferred.