### PR TITLE
fix(cast): call deserialization

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -75,16 +75,20 @@ where
         let res = self.provider.call(&tx, None).await?;
 
         // decode args into tokens
-        let res = func.decode_output(res.as_ref())?;
+        let decoded = func.decode_output(res.as_ref())?;
+        // handle case when return type is not specified
+        if decoded.len() == 0 {
+            Ok(format!("{}\n", res))
+        } else {
+            // concatenate them
+            let mut s = String::new();
+            for output in decoded {
+                s.push_str(&format!("0x{}\n", output));
+            }
 
-        // concatenate them
-        let mut s = String::new();
-        for output in res {
-            s.push_str(&format!("{}\n", output));
+            // return string
+            Ok(s)
         }
-
-        // return string
-        Ok(s)
     }
 
     pub async fn balance<T: Into<NameOrAddress> + Send + Sync>(

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -77,7 +77,7 @@ where
         // decode args into tokens
         let decoded = func.decode_output(res.as_ref())?;
         // handle case when return type is not specified
-        if decoded.len() == 0 {
+        if decoded.is_empty() {
             Ok(format!("{}\n", res))
         } else {
             // concatenate them


### PR DESCRIPTION
After this commit, the return value of `cast call`
will be still be printed even if the ABI type of the
return value is not specified. This matches the
behavior of `seth`.

Example:

```
$ cast call 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D 'WETH()(address)'
0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2

$ cast call 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D 'WETH()'
0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
```

Previously, the second command above would print nothing as there
would be no decoded values to iterate over when building the
string output.

This commit also prepends a `0x` to each decoded return type,
which matches the behavior of `seth`.