### PR TITLE
feat: add nonce to cast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_STORE
 /target
 out/
 out.json

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: format lint test ready
+
 # Repositories for integration tests that will be cloned inside `integration-tests/testdata/REPO` folders
 INTEGRATION_TESTS_REPOS = \
 	mds1/drai \
@@ -17,3 +19,16 @@ $(INTEGRATION_TESTS_REPOS):
 	else cd $$FOLDER; git pull --recurse-submodules; fi
 
 testdata: integration-tests-testdata
+
+format: 
+	cargo +nightly fmt
+
+lint: 
+	cargo +nightly clippy --all-features -- -D warnings
+
+test:
+	cargo check
+	cargo test
+	cargo doc --open
+
+ready: format lint test

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -44,7 +44,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    ///
+    /// 
     /// use cast::Cast;
     /// use ethers_core::types::Address;
     /// use ethers_providers::{Provider, Http};

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -290,6 +290,21 @@ where
         Ok(self.provider.get_gas_price().await?)
     }
 
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    /// use ethers_core::types::Address;
+    /// use std::{str::FromStr, convert::TryFrom};
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let addr = Address::from_str("0x7eD52863829AB99354F3a0503A622e82AcD5F7d3")?;
+    /// let nonce = cast.nonce(addr, None).await?;
+    /// println!("{}", nonce);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn nonce<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         who: T,

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -44,7 +44,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    /// 
+    ///
     /// use cast::Cast;
     /// use ethers_core::types::Address;
     /// use ethers_providers::{Provider, Http};
@@ -288,6 +288,14 @@ where
 
     pub async fn gas_price(&self) -> Result<U256> {
         Ok(self.provider.get_gas_price().await?)
+    }
+
+    pub async fn nonce<T: Into<NameOrAddress> + Send + Sync>(
+        &self,
+        who: T,
+        block: Option<BlockId>,
+    ) -> Result<U256> {
+        Ok(self.provider.get_transaction_count(who, block).await?)
     }
 
     /// ```no_run

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -217,6 +217,10 @@ async fn main() -> eyre::Result<()> {
             let value = provider.get_storage_at(address, slot, block).await?;
             println!("{:?}", value);
         }
+        Subcommands::Nonce { block, who, rpc_url } => {
+            let provider = Provider::try_from(rpc_url)?;
+            println!("{}", Cast::new(provider).nonce(who, block).await?);
+        }
     };
 
     Ok(())

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -223,6 +223,16 @@ pub enum Subcommands {
         )]
         block: Option<BlockId>,
     },
+    #[structopt(name = "nonce")]
+    #[structopt(about = "Prints the number of transactions sent from <address>")]
+    Nonce {
+        #[structopt(long, short = "-B", help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        block: Option<BlockId>,
+        #[structopt(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
+        who: NameOrAddress,
+        #[structopt(short, long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+    },
 }
 
 fn parse_name_or_address(s: &str) -> eyre::Result<NameOrAddress> {


### PR DESCRIPTION
Tested by validating that both of the following commands output the same number on Ethereum mainnet (521):
- `seth nonce 0x7eD52863829AB99354F3a0503A622e82AcD5F7d3`
- `cargo run --bin cast nonce --rpc-url $RPC_URL 0x7eD52863829AB99354F3a0503A622e82AcD5F7d3`

Also added a few commands to the Makefile which I find helpful for local development. Happy to axe if unnecessary or move into a separate PR if that would be preferred.
