### PR TITLE
chore: remove libgit2 / last openssl deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,6 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -1525,7 +1522,6 @@ dependencies = [
  "eyre",
  "forge",
  "foundry-utils",
- "git2",
  "glob",
  "once_cell",
  "proptest",
@@ -1743,21 +1739,6 @@ name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
-name = "git2"
-version = "0.13.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
 
 [[package]]
 name = "glob"
@@ -2105,15 +2086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,50 +2130,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.12.26+1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "libusb1-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8772b7e8d4d988e19684aec5a3f5e470ecaf5c705cf0303da3973508e873027"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,7 +31,6 @@ tracing = "0.1.26"
 sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true }
 evmodin = { git = "https://github.com/vorot93/evmodin", optional = true }
 proptest = "1.0.0"
-git2 = "0.13.22"
 glob = "0.3.0"
 semver = "1.0.4"
 once_cell = "1.8.0"

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -32,24 +32,16 @@ fn main() -> eyre::Result<()> {
             cmd.run()?;
         }
         Subcommands::Update { lib } => {
-            // TODO: Should we add some sort of progress bar here? Would be nice
-            // but not a requirement.
-            // open the repo
-            let repo = git2::Repository::open(".")?;
+            let mut cmd = Command::new("git");
+
+            cmd.args(&["submodule", "update", "--init", "--recursive"]);
 
             // if a lib is specified, open it
             if let Some(lib) = lib {
-                println!("Updating submodule {:?}", lib);
-                repo.find_submodule(
-                    &lib.into_os_string().into_string().expect("invalid submodule path"),
-                )?
-                .update(true, None)?;
-            } else {
-                Command::new("git")
-                    .args(&["submodule", "update", "--init", "--recursive"])
-                    .spawn()?
-                    .wait()?;
+                cmd.args(&["--", lib.display().to_string().as_str()]);
             }
+
+            cmd.spawn()?.wait()?;
         }
         // TODO: Make it work with updates?
         Subcommands::Install { dependencies } => {

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -4,6 +4,7 @@ use eyre::{ContextCompat, WrapErr};
 use std::{
     env::VarError,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 #[cfg(feature = "evmodin-evm")]
@@ -80,9 +81,9 @@ pub fn find_dapp_json_contract(path: &str, name: &str) -> eyre::Result<Contract>
 }
 
 pub fn find_git_root_path() -> eyre::Result<PathBuf> {
-    let repo = git2::Repository::discover(".").wrap_err("Failed to find git root path")?;
-
-    Ok(repo.path().parent().unwrap().to_path_buf())
+    let path = Command::new("git").args(&["rev-parse", "--show-toplevel"]).output()?.stdout;
+    let path = std::str::from_utf8(&path)?.trim_end_matches('\n');
+    Ok(PathBuf::from(path))
 }
 
 /// Determines the source directory to use given the root path to a project's workspace.


### PR DESCRIPTION
as title - replaces them with native calls to `git`, removes the need to `apt install pkg-config libssl-dev`