### PR TITLE
fix git args

### DIFF
--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -90,7 +90,7 @@ fn main() -> eyre::Result<()> {
 
                 // sets up git
                 let is_git = Command::new("git")
-                    .args(&["rev-parse,--is-inside-work-tree"])
+                    .args(&["rev-parse", "--is-inside-work-tree"])
                     .current_dir(&root)
                     .spawn()?
                     .wait()?;


### PR DESCRIPTION
I was seeing the error `git: 'rev-parse,--is-inside-work-tree' is not a git command. See 'git --help'.` when running `forge init`. This should fix it.