### PR TITLE
tests: use helper fns to instantiate the EVMs

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -996,30 +996,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
 
 #[cfg(test)]
 mod tests {
-    use sputnik::Config;
-
-    use crate::{
-        fuzz::FuzzedExecutor,
-        sputnik::{
-            helpers::{new_backend, new_vicinity},
-            Executor, PRECOMPILES_MAP,
-        },
-        test_helpers::COMPILED,
-        Evm,
-    };
+    use crate::{fuzz::FuzzedExecutor, sputnik::helpers::vm, test_helpers::COMPILED, Evm};
 
     use super::*;
 
     #[test]
     fn ds_test_logs() {
-        let config = Config::istanbul();
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let gas_limit = 10_000_000;
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm =
-            Executor::new_with_cheatcodes(backend, gas_limit, &config, &precompiles, true);
-
+        let mut evm = vm();
         let compiled = COMPILED.find("DebugLogs").expect("could not find contract");
         let (addr, _, _, _) =
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
@@ -1053,13 +1036,7 @@ mod tests {
 
     #[test]
     fn console_logs() {
-        let config = Config::istanbul();
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let gas_limit = 10_000_000;
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm =
-            Executor::new_with_cheatcodes(backend, gas_limit, &config, &precompiles, true);
+        let mut evm = vm();
 
         let compiled = COMPILED.find("ConsoleLogs").expect("could not find contract");
         let (addr, _, _, _) =
@@ -1084,13 +1061,7 @@ mod tests {
 
     #[test]
     fn logs_external_contract() {
-        let config = Config::istanbul();
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let gas_limit = 10_000_000;
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm =
-            Executor::new_with_cheatcodes(backend, gas_limit, &config, &precompiles, true);
+        let mut evm = vm();
 
         let compiled = COMPILED.find("DebugLogs").expect("could not find contract");
         let (addr, _, _, _) =
@@ -1109,14 +1080,7 @@ mod tests {
 
     #[test]
     fn cheatcodes() {
-        let config = Config::london();
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let gas_limit = 10_000_000;
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm =
-            Executor::new_with_cheatcodes(backend, gas_limit, &config, &precompiles, true);
-
+        let mut evm = vm();
         let compiled = COMPILED.find("CheatCodes").expect("could not find contract");
         let (addr, _, _, _) =
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
@@ -1159,13 +1123,8 @@ mod tests {
 
     #[test]
     fn ffi_fails_if_disabled() {
-        let config = Config::istanbul();
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let gas_limit = 10_000_000;
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm =
-            Executor::new_with_cheatcodes(backend, gas_limit, &config, &precompiles, false);
+        let mut evm = vm();
+        evm.executor.enable_ffi = false;
 
         let compiled = COMPILED.find("CheatCodes").expect("could not find contract");
         let (addr, _, _, _) =

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -187,8 +187,8 @@ pub mod helpers {
         CheatcodeStackExecutor<'a, 'a, B, BTreeMap<Address, PrecompileFn>>,
     >;
 
-    static CFG: Lazy<Config> = Lazy::new(|| Config::london());
-    static VICINITY: Lazy<MemoryVicinity> = Lazy::new(|| new_vicinity());
+    static CFG: Lazy<Config> = Lazy::new(Config::london);
+    static VICINITY: Lazy<MemoryVicinity> = Lazy::new(new_vicinity);
     const GAS_LIMIT: u64 = 30_000_000;
 
     /// Instantiates a Sputnik EVM with enabled cheatcodes + FFI and a simple non-forking in memory
@@ -202,8 +202,7 @@ pub mod helpers {
     pub fn fuzzvm<'a, B: Backend>(
         evm: &'a mut TestSputnikVM<'a, B>,
     ) -> FuzzedExecutor<'a, TestSputnikVM<'a, B>, CheatcodeStackState<'a, B>> {
-        let mut cfg = proptest::test_runner::Config::default();
-        cfg.failure_persistence = None;
+        let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
 
         let runner = proptest::test_runner::TestRunner::new(cfg);
         FuzzedExecutor::new(evm, runner, Address::zero())

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -171,6 +171,28 @@ pub mod helpers {
     use ethers::types::H160;
     use sputnik::backend::{MemoryBackend, MemoryVicinity};
 
+    use crate::sputnik::{
+        cheatcodes::cheatcode_handler::{CheatcodeStackExecutor, CheatcodeStackState},
+        PrecompileFn, PRECOMPILES_MAP,
+    };
+    use once_cell::sync::Lazy;
+
+    type TestSputnikVM<'a, B> = Executor<
+        // state
+        CheatcodeStackState<'a, B>,
+        // actual stack executor
+        CheatcodeStackExecutor<'a, 'a, B, BTreeMap<Address, PrecompileFn>>,
+    >;
+
+    static CFG: Lazy<Config> = Lazy::new(|| Config::london());
+    static VICINITY: Lazy<MemoryVicinity> = Lazy::new(|| new_vicinity());
+    const GAS_LIMIT: u64 = 30_000_000;
+
+    pub fn vm<'a>() -> TestSputnikVM<'a, MemoryBackend<'a>> {
+        let backend = new_backend(&*VICINITY, Default::default());
+        Executor::new_with_cheatcodes(backend, GAS_LIMIT, &*CFG, &*PRECOMPILES_MAP, true)
+    }
+
     pub fn new_backend(vicinity: &MemoryVicinity, state: MemoryState) -> MemoryBackend<'_> {
         MemoryBackend::new(vicinity, state)
     }
@@ -193,51 +215,32 @@ pub mod helpers {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        helpers::{new_backend, new_vicinity},
-        *,
+    use super::*;
+    use crate::{
+        sputnik::helpers::vm,
+        test_helpers::{can_call_vm_directly, solidity_unit_test, COMPILED},
     };
-    use crate::test_helpers::{can_call_vm_directly, solidity_unit_test, COMPILED};
-
-    use crate::sputnik::PRECOMPILES_MAP;
     use ethers::utils::id;
     use sputnik::{ExitReason, ExitRevert, ExitSucceed};
 
     #[test]
     fn sputnik_can_call_vm_directly() {
-        let cfg = Config::istanbul();
+        let evm = vm();
         let compiled = COMPILED.find("Greeter").expect("could not find contract");
-
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let precompiles = PRECOMPILES_MAP.clone();
-        let evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
         can_call_vm_directly(evm, compiled);
     }
 
     #[test]
     fn sputnik_solidity_unit_test() {
-        let cfg = Config::istanbul();
-
+        let evm = vm();
         let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let precompiles = PRECOMPILES_MAP.clone();
-        let evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
         solidity_unit_test(evm, compiled);
     }
 
     #[test]
     fn failing_with_no_reason_if_no_setup() {
-        let cfg = Config::istanbul();
-
+        let mut evm = vm();
         let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
 
         let (addr, _, _, _) =
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
@@ -256,14 +259,8 @@ mod tests {
 
     #[test]
     fn failing_solidity_unit_test() {
-        let cfg = Config::istanbul();
-
+        let mut evm = vm();
         let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
 
         let (addr, _, _, _) =
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
@@ -280,19 +277,13 @@ mod tests {
             _ => panic!("unexpected error variant"),
         };
         assert_eq!(reason, "not equal to `hi`".to_string());
-        assert_eq!(gas_used, 31233);
+        assert_eq!(gas_used, 26633);
     }
 
     #[test]
     fn test_can_call_large_contract() {
-        let cfg = Config::istanbul();
-
+        let mut evm = vm();
         let compiled = COMPILED.find("LargeContract").expect("could not find contract");
-
-        let vicinity = new_vicinity();
-        let backend = new_backend(&vicinity, Default::default());
-        let precompiles = PRECOMPILES_MAP.clone();
-        let mut evm = Executor::new(13_000_000, &cfg, &backend, &precompiles);
 
         let from = Address::random();
         let (addr, _, _, _) =

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -152,7 +152,7 @@ impl<'a, 'b, S: StackState<'a>, P: PrecompileSet> SputnikExecutor<S>
 
 use std::borrow::Cow;
 
-type PrecompileFn =
+pub type PrecompileFn =
     fn(&[u8], Option<u64>, &sputnik::Context, bool) -> Result<PrecompileOutput, PrecompileFailure>;
 
 /// Precompiled contracts which should be provided when instantiating the EVM.

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -223,23 +223,12 @@ mod tests {
 
     mod sputnik {
         use super::*;
-        use evm::Config;
-        use evm_adapters::sputnik::{
-            helpers::{new_backend, new_vicinity},
-            Executor, PRECOMPILES_MAP,
-        };
+        use evm_adapters::sputnik::helpers::vm;
         use std::collections::HashMap;
 
         #[test]
         fn test_sputnik_debug_logs() {
-            let config = Config::istanbul();
-            let gas_limit = 12_500_000;
-            let env = new_vicinity();
-            let backend = new_backend(&env, Default::default());
-            // important to instantiate the VM with cheatcodes
-            let precompiles = PRECOMPILES_MAP.clone();
-            let evm =
-                Executor::new_with_cheatcodes(backend, gas_limit, &config, &precompiles, false);
+            let evm = vm();
 
             let mut runner = runner(evm);
             let results = runner.test(Regex::new(".*").unwrap()).unwrap();
@@ -260,13 +249,7 @@ mod tests {
 
         #[test]
         fn test_sputnik_multi_runner() {
-            let config = Config::istanbul();
-            let gas_limit = 12_500_000;
-            let env = new_vicinity();
-            let backend = new_backend(&env, Default::default());
-            let precompiles = PRECOMPILES_MAP.clone();
-            let evm = Executor::new(gas_limit, &config, &backend, &precompiles);
-            test_multi_runner(evm);
+            test_multi_runner(vm());
         }
     }
 

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -329,16 +329,11 @@ mod tests {
     use super::*;
     use crate::test_helpers::COMPILED;
     use ethers::solc::artifacts::CompactContractRef;
-    use evm::Config;
-    use evm_adapters::sputnik::PRECOMPILES_MAP;
+    use evm_adapters::sputnik::helpers::vm;
 
     mod sputnik {
         use std::str::FromStr;
 
-        use evm_adapters::sputnik::{
-            helpers::{new_backend, new_vicinity},
-            Executor,
-        };
         use foundry_utils::get_func;
         use proptest::test_runner::Config as FuzzConfig;
 
@@ -346,24 +341,15 @@ mod tests {
 
         #[test]
         fn test_runner() {
-            let cfg = Config::istanbul();
             let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-            let vicinity = new_vicinity();
-            let backend = new_backend(&vicinity, Default::default());
-            let precompiles = PRECOMPILES_MAP.clone();
-            let evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
+            let evm = vm();
             super::test_runner(evm, compiled);
         }
 
         #[test]
         fn test_function_overriding() {
-            let cfg = Config::istanbul();
             let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-            let vicinity = new_vicinity();
-            let backend = new_backend(&vicinity, Default::default());
-
-            let precompiles = PRECOMPILES_MAP.clone();
-            let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
+            let mut evm = vm();
             let (addr, _, _, _) = evm
                 .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
                 .unwrap();
@@ -390,13 +376,8 @@ mod tests {
 
         #[test]
         fn test_fuzzing_counterexamples() {
-            let cfg = Config::istanbul();
             let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-            let vicinity = new_vicinity();
-            let backend = new_backend(&vicinity, Default::default());
-
-            let precompiles = PRECOMPILES_MAP.clone();
-            let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
+            let mut evm = vm();
             let (addr, _, _, _) = evm
                 .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
                 .unwrap();
@@ -420,13 +401,8 @@ mod tests {
 
         #[test]
         fn test_fuzzing_ok() {
-            let cfg = Config::istanbul();
             let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-            let vicinity = new_vicinity();
-            let backend = new_backend(&vicinity, Default::default());
-
-            let precompiles = PRECOMPILES_MAP.clone();
-            let mut evm = Executor::new(u64::MAX, &cfg, &backend, &precompiles);
+            let mut evm = vm();
             let (addr, _, _, _) = evm
                 .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
                 .unwrap();
@@ -445,13 +421,8 @@ mod tests {
 
         #[test]
         fn test_fuzz_shrinking() {
-            let cfg = Config::istanbul();
             let compiled = COMPILED.find("GreeterTest").expect("could not find contract");
-            let vicinity = new_vicinity();
-            let backend = new_backend(&vicinity, Default::default());
-
-            let precompiles = PRECOMPILES_MAP.clone();
-            let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);
+            let mut evm = vm();
             let (addr, _, _, _) = evm
                 .deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into())
                 .unwrap();


### PR DESCRIPTION
Was quite annoying and repetitive and error prone before. This helper function saves us from a lot of pain.