### PR TITLE
feat(forge): Decode expectRevert in call traces

### DIFF
--- a/evm-adapters/src/call_tracing.rs
+++ b/evm-adapters/src/call_tracing.rs
@@ -450,6 +450,15 @@ impl CallTrace {
                                     .map(format_token)
                                     .collect::<Vec<String>>()
                                     .join(", ");
+
+                                #[cfg(feature = "sputnik")]
+                                if self.addr == *CHEATCODE_ADDRESS && func.name == "expectRevert" {
+                                    if let Ok(decoded) =
+                                        foundry_utils::decode_revert(&self.data[4..])
+                                    {
+                                        strings = decoded;
+                                    }
+                                }
                             }
 
                             println!(

--- a/evm-adapters/src/call_tracing.rs
+++ b/evm-adapters/src/call_tracing.rs
@@ -453,9 +453,8 @@ impl CallTrace {
 
                                 #[cfg(feature = "sputnik")]
                                 if self.addr == *CHEATCODE_ADDRESS && func.name == "expectRevert" {
-                                    if let Ok(decoded) =
-                                        foundry_utils::decode_revert(&self.data[4..])
-                                    {
+                                    // try to decode better than just `bytes` for `expectRevert`
+                                    if let Ok(decoded) = foundry_utils::decode_revert(&self.data) {
                                         strings = decoded;
                                     }
                                 }

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -231,6 +231,12 @@ contract CheatCodes is DSTest {
         target.stringErr(99);
     }
 
+    function testExpectRevertBuiltin() public {
+        ExpectRevert target = new ExpectRevert();
+        hevm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        target.arithmeticErr(101);
+    }
+
     function testExpectCustomRevert() public {
         ExpectRevert target = new ExpectRevert();
         bytes memory data = abi.encodePacked(bytes4(keccak256("InputTooLarge()")));
@@ -293,6 +299,11 @@ contract ExpectRevert {
     function stringErr(uint256 a) public returns (uint256) {
         require(a < 100, "Value too large");
         return a;
+    }
+
+    function arithmeticErr(uint256 a) public returns (uint256) {
+        uint256 b = 100 - a;
+        return b;
     }
 
     function stringErr2(uint256 a) public returns (uint256) {


### PR DESCRIPTION
Tries to decode `expectRevert` input data to string or builtin revert codes to match revert output