### PR TITLE
chore(forge): remove tracing instrument of main

### DIFF
--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -9,7 +9,6 @@ use opts::forge::{Dependency, FullContractInfo, Opts, Subcommands};
 use std::{process::Command, str::FromStr};
 use structopt::StructOpt;
 
-#[tracing::instrument(err)]
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     utils::subscriber();


### PR DESCRIPTION
Closes #303 

removes `tracing::instrument` annotation from the main function as the error will be printed anyways.
This gets rid of the duplicated error log, with `#[tracing::instrument(err)]` the error would by printed by forge and also by the tracing subscriber since the error message is logged in the `ERROR` target as well.