### PR TITLE
making tracing gas costs more accurate

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -602,19 +602,17 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             arena[new_trace.idx].trace.output = output.unwrap_or_default();
             arena[new_trace.idx].trace.cost = match new_trace.depth {
                 // testFunction. Children will update the gas costs as they are executed
-                0 => {
-                    arena[new_trace.idx].trace.cost
-                },
+                0 => arena[new_trace.idx].trace.cost,
                 // external contract calls
                 1 => {
                     // Update testFunction gas costs [includes refunds]
-                    let parent =  arena[new_trace.idx].parent.unwrap();
+                    let parent = arena[new_trace.idx].parent.unwrap();
                     arena[parent].trace.cost += used_gas;
 
                     used_gas
                 }
                 // inner contract calls
-                _ => total_used_gas
+                _ => total_used_gas,
             };
 
             arena[new_trace.idx].trace.success = success;
@@ -696,7 +694,12 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             if depth == 1 {
                 let transaction_cost = gasometer::call_transaction_cost(&input, &[]);
 
-                match self.state_mut().metadata_mut().gasometer_mut().record_transaction(transaction_cost) {
+                match self
+                    .state_mut()
+                    .metadata_mut()
+                    .gasometer_mut()
+                    .record_transaction(transaction_cost)
+                {
                     Ok(()) => (),
                     Err(e) => return Capture::Exit((e.into(), Vec::new())),
                 };


### PR DESCRIPTION
### Motivation

Here comes my attempt at convincing @brockelmore in a more structured way, i hope! I left some examples after the explanation.

Currently, the gas costs exposed by tracing are in my opinion misleading, or, are not as valuable as they could be.

In my opinion, the **_main issue is coming from the fact that we calculate gas costs including the `testYYY` functions (depth = 0),_** instead of treating each contract call as a standalone transaction (depth = 1). It does not reflect a real world scenario for multiple reasons:
* Transactions costs are not taken into account, on each individual transaction (depth = 1). If I try to reproduce a `testYYY` in a local node using some JS stack, the gas costs will be fairly different.
* Transaction refunds are inaccurate . Refunds depend on the total gas usage of a transaction, which is being calculated on a `testYYY` context. Imagine a standalone transaction which gets a capped refund in a real world scenario, but since it's part of an extensive `testYYY`, it won't. The actual refund amount will be smaller than `gas_used(testYYY) // MAX_REFUND_QUOTIENT`, and thus, allowed.
* If there are multiple transactions in a `testYYY` function which should issue a refund, a similar issue as above appears.

Additionally, in my workflow, I really don't care about the transaction or execution cost of `testYYY`, only its children.  I don't see a workflow which values that... maybe someone can offer up an example?
When I look at gas costs, I'd rather deal with values, which are as close as possible to real scenario values.

Maybe, it's just my personal preference, but what do you think?

### Solution
* Add `call transaction costs` to all contract calls which are at `depth = 1`
* `testYYY` (depth = 0) gas costs are a sum of all `depth = 1` calls

### Missing
How to distinguish between helper functions called on `testYYY` and contract calls? Both are at `depth 1`.

---
#### Contract
```
// SPDX-License-Identifier: Unlicense
pragma solidity 0.8.10;

contract Contract {
    uint256 public oi;
    mapping(uint256 => uint256) aai;

    constructor() {
        oi = 1;
        aai[1] = 1;
    }

    function cleanAnotherStorageVar() public {
        oi = 0;
    }
    function dirty() public  {
        oi = 1;
    }
    function cleanStorageVar() public {
        this.dirty();
        delete aai[1];
    }
}
```
#### Before
```
compiling...
success.
Running 1 test for ContractTest
[PASS] testSimple() (gas: 143192)

Success: testSimple()


[98] ContractTest::setUp()
  └─ ← ()
[114503] ContractTest::testSimple()
  ├─ → new Contract@0xf4d9…1c37
  │   └─ ← 323 bytes of code
  ├─ [692] Contract::cleanStorageVar()
  │   ├─ [216] Contract::dirty()
  │   │   └─ ← ()
  │   └─ ← ()
  ├─ [226] Contract::cleanAnotherStorageVar()
  │   └─ ← ()
  └─ ← ()
```
#### After
```
compiling...
success.
Running 1 test for ContractTest
[PASS] testSimple() (gas: 185320)

Success: testSimple()


[0] ContractTest::setUp()
  └─ ← ()
[143574] ContractTest::testSimple()
  ├─ → new Contract@0xf4d9…1c37
  │   └─ ← 323 bytes of code
  ├─ [17544] Contract::cleanStorageVar()
  │   ├─ [216] Contract::dirty()
  │   │   └─ ← ()
  │   └─ ← ()
  ├─ [17077] Contract::cleanAnotherStorageVar()
  │   └─ ← ()
  └─ ← ()
```