### PR TITLE
add `remove` command to remove a library from git submodules

### DIFF
--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -34,9 +34,13 @@ pub enum Subcommands {
 
     #[structopt(alias = "i", about = "installs one or more dependencies as git submodules")]
     Install {
-        #[structopt(
-            help = "the submodule name of the library you want to update (will update all if none is provided)"
-        )]
+        #[structopt(help = "the submodule name of the library you want to install")]
+        dependencies: Vec<Dependency>,
+    },
+
+    #[structopt(alias = "r", about = "removes one or more dependencies from git submodules")]
+    Remove {
+        #[structopt(help = "the submodule name of the library you want to remove")]
         dependencies: Vec<Dependency>,
     },
 


### PR DESCRIPTION
followed instructions from [this SO post](https://stackoverflow.com/questions/55937975/can-i-uninitialize-a-git-submodule) for removing a git submodule from a project. similar structure as the `install()` function. considered naming it `uninstall` but `-u` is already taken so went with `remove`

tested locally with `ds-math`, was able to install, remove, then install again no issues