### PR TITLE
feat: `forge run`

### DIFF
--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod build;
 pub mod create;
+pub mod run;
 pub mod snapshot;
 pub mod test;
 pub mod verify;

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -17,6 +17,8 @@ use ethers::{
 
 use evm_adapters::Evm;
 
+use ansi_term::Colour;
+
 #[derive(Debug, Clone, StructOpt)]
 pub struct RunArgs {
     #[structopt(help = "the path to the contract to run")]
@@ -78,7 +80,14 @@ impl Cmd for RunArgs {
         let result = runner.run_test(&func, false, None)?;
 
         // 6. print the result nicely
-        dbg!(&result);
+        if result.success {
+            println!("{}", Colour::Green.paint("Script ran successfully."));
+        } else {
+            println!("{}", Colour::Red.paint("Script failed."));
+        }
+        println!("Gas Used: {}", result.gas_used);
+        println!("== Logs == ");
+        result.logs.iter().for_each(|log| println!("{}", log));
 
         Ok(())
     }

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -55,3 +55,71 @@ impl Cmd for RunArgs {
         Ok(())
     }
 }
+
+impl RunArgs {
+    /// Compiles the file with auto-detection and compiler params.
+    // TODO: This is too verbose. We definitely want an easier way to do "take this file, detect
+    // its solc version and give me all its ABIs & Bytecodes in memory w/o touching disk".
+    pub fn build(&self) -> eyre::Result<CompactContract> {
+        let paths = ProjectPathsConfig::builder().root(&self.path).sources(&self.path).build()?;
+
+        let optimizer = Optimizer {
+            enabled: Some(self.compiler.optimize),
+            runs: Some(self.compiler.optimize_runs as usize),
+        };
+
+        let solc_settings = Settings {
+            optimizer,
+            evm_version: Some(self.compiler.evm_version),
+            ..Default::default()
+        };
+        let solc_cfg = SolcConfig::builder().settings(solc_settings).build()?;
+
+        // setup the compiler
+        let mut builder = Project::builder()
+            .paths(paths)
+            .allowed_path(&self.path)
+            .solc_config(solc_cfg)
+            // we do not want to generate any compilation artifacts in the script run mode
+            .no_artifacts()
+            // no cache
+            .ephemeral();
+        if self.no_auto_detect {
+            builder = builder.no_auto_detect();
+        }
+        let project = builder.build()?;
+
+        println!("compiling...");
+        let output = project.compile()?;
+        if output.has_compiler_errors() {
+            // return the diagnostics error back to the user.
+            eyre::bail!(output.to_string())
+        } else if output.is_unchanged() {
+            println!("no files changed, compilation skippped.");
+        } else {
+            println!("success.");
+        };
+
+        // get the contracts
+        let contracts = output.output();
+
+        // get the specific contract
+        let contract = if let Some(ref contract) = self.contract {
+            let contract = contracts.find(contract).ok_or_else(|| {
+                eyre::Error::msg("contract not found, did you type the name wrong?")
+            })?;
+            CompactContract::from(contract)
+        } else {
+            let mut contracts =
+                contracts.contracts_into_iter().filter(|(_, contract)| contract.evm.is_some());
+            let contract = contracts.next().ok_or_else(|| eyre::Error::msg("no contract found"))?.1;
+            if contracts.peekable().peek().is_some() {
+                eyre::bail!(
+                    ">1 contracts found, please provide a contract name to choose one of them"
+                )
+            }
+            CompactContract::from(contract)
+        };
+        Ok(contract)
+    }
+}

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -1,0 +1,57 @@
+use crate::{
+    cmd::Cmd,
+    opts::forge::{CompilerArgs, EvmOpts},
+};
+use forge::ContractRunner;
+use foundry_utils::IntoFunction;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+use ethers::{
+    prelude::artifacts::CompactContract,
+    solc::{
+        artifacts::{Optimizer, Settings},
+        Project, ProjectPathsConfig, SolcConfig,
+    },
+};
+
+use evm_adapters::Evm;
+
+#[derive(Debug, Clone, StructOpt)]
+pub struct RunArgs {
+    #[structopt(help = "the path to the contract to run")]
+    pub path: PathBuf,
+
+    #[structopt(flatten)]
+    pub compiler: CompilerArgs,
+
+    #[structopt(flatten)]
+    pub evm_opts: EvmOpts,
+
+    #[structopt(
+        long,
+        short,
+        help = "the function you want to call on the script contract, defaults to run()"
+    )]
+    pub sig: Option<String>,
+
+    #[structopt(
+        long,
+        short,
+        help = "the contract you want to call and deploy, only necessary if there are more than 1 contract (Interfaces do not count) definitions on the script"
+    )]
+    pub contract: Option<String>,
+
+    #[structopt(
+        help = "if set to true, skips auto-detecting solc and uses what is in the user's $PATH ",
+        long
+    )]
+    pub no_auto_detect: bool,
+}
+
+impl Cmd for RunArgs {
+    type Output = ();
+    fn run(self) -> eyre::Result<Self::Output> {
+        Ok(())
+    }
+}

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -22,6 +22,9 @@ fn main() -> eyre::Result<()> {
         Subcommands::Build(cmd) => {
             cmd.run()?;
         }
+        Subcommands::Run(cmd) => {
+            cmd.run()?;
+        }
         Subcommands::VerifyContract { contract, address, constructor_args } => {
             let FullContractInfo { path, name } = contract;
             let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -3,7 +3,7 @@ use structopt::StructOpt;
 use ethers::{solc::EvmVersion, types::Address};
 use std::{path::PathBuf, str::FromStr};
 
-use crate::cmd::{build::BuildArgs, create::CreateArgs, snapshot, test};
+use crate::cmd::{build::BuildArgs, create::CreateArgs, run::RunArgs, snapshot, test};
 
 #[derive(Debug, StructOpt)]
 pub struct Opts {
@@ -23,6 +23,10 @@ pub enum Subcommands {
     #[structopt(about = "build your smart contracts")]
     #[structopt(alias = "b")]
     Build(BuildArgs),
+
+    #[structopt(about = "run a single smart contract as a script")]
+    #[structopt(alias = "r")]
+    Run(RunArgs),
 
     #[structopt(alias = "u", about = "fetches all upstream lib changes")]
     Update {


### PR DESCRIPTION
supersedes #314, adds `forge run` which will run a contract as a script. defaults to the `run()` function by default, but one can specify a custom function signature in their script if they want. all cheatcodes are enabled, and forking is supported with the standard `--fork-url`  cli arg

Example:

```solidity

pragma solidity ^0.7.6;

interface ERC20 {
    function balanceOf(address) external view returns (uint256);
    function deposit() payable external;
}

interface VM {
    function startPrank(address) external;
}

contract C {
    ERC20 weth = ERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
    VM constant vm  = VM(address(bytes20(uint160(uint256(keccak256('hevm cheat code'))))));
    address who = 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045;

    event log_uint(uint256);

    function run() external {
        // impersonate the account
        vm.startPrank(who);

        uint256 balanceBefore = weth.balanceOf(who);
        emit log_uint(balanceBefore);

        weth.deposit{value: 15 ether}();

        uint256 balanceAfter = weth.balanceOf(who);
        emit log_uint(balanceAfter);

    }
}
```


And you'd run: `forge run ./C.sol  --verbosity=2 --fork-url=https://eth-mainnet.alchemyapi.io/v2/<API KEY>`

If there is more than 1 contract with non-empty bytecode, then you must also pass `--contract <ContractName>` to let the program know which one to choose.

As a follow-up PR, we should improve the automatic detection of ABIs with etherscan, maybe we can automatically fetch source code & bytecodes for tracing, cc @brockelmore @mds1 