### PR TITLE
feat(forge): Add `expectEmit` cheatcode

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1020,15 +1020,14 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 new_context,
             );
 
-            if !self.state_mut().expected_emits.is_empty() {
-                for expected in self.state().expected_emits.clone().into_iter() {
-                    if curr_depth == expected.depth {
-                        // we have returned back to the expected depth
-                        if !expected.found {
-                            return evm_error("Log != expected log")
-                        }
-                    }
-                }
+            if !self.state_mut().expected_emits.is_empty() && !self
+                .state()
+                .expected_emits
+                .iter()
+                .filter(|expected| expected.depth == curr_depth)
+                .all(|expected| expected.found) {
+            {
+                return evm_error("Log != expected log")
             }
 
             if let Some(expected_revert) = expected_revert {

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1020,12 +1020,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 new_context,
             );
 
-            if !self.state_mut().expected_emits.is_empty() && !self
-                .state()
-                .expected_emits
-                .iter()
-                .filter(|expected| expected.depth == curr_depth)
-                .all(|expected| expected.found) {
+            if !self.state_mut().expected_emits.is_empty() &&
+                !self
+                    .state()
+                    .expected_emits
+                    .iter()
+                    .filter(|expected| expected.depth == curr_depth)
+                    .all(|expected| expected.found)
             {
                 return evm_error("Log != expected log")
             }

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     call_tracing::{CallTrace, CallTraceArena, LogCallOrder},
-    sputnik::{Executor, SputnikExecutor},
+    sputnik::{cheatcodes::memory_stackstate_owned::ExpectedEmit, Executor, SputnikExecutor},
     Evm,
 };
 
@@ -538,6 +538,19 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     res = ethers::abi::encode(&[Token::Array(vec![]), Token::Array(vec![])]);
                 }
             }
+            HEVMCalls::ExpectEmit(inner) => {
+                let expected_emit = ExpectedEmit {
+                    depth: if let Some(depth) = self.state().metadata().depth() {
+                        depth + 1
+                    } else {
+                        0
+                    },
+                    log: None,
+                    checks: [inner.0, inner.1, inner.2, inner.3],
+                    found: false,
+                };
+                self.state_mut().expected_emits.push(expected_emit);
+            }
         };
 
         self.fill_trace(&trace, true, Some(res.clone()), pre_index);
@@ -967,11 +980,11 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
             let expected_revert = self.state_mut().expected_revert.take();
             let mut new_context = context;
             let mut new_transfer = transfer;
+            let curr_depth =
+                if let Some(depth) = self.state().metadata().depth() { depth + 1 } else { 0 };
 
             // handle `startPrank` - see apply_cheatcodes for more info
             if let Some((original_msg_sender, permanent_caller, depth)) = self.state().msg_sender {
-                let curr_depth =
-                    if let Some(depth) = self.state().metadata().depth() { depth + 1 } else { 0 };
                 if curr_depth == depth && new_context.caller == original_msg_sender {
                     new_context.caller = permanent_caller;
 
@@ -1006,6 +1019,17 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 true,
                 new_context,
             );
+
+            if !self.state_mut().expected_emits.is_empty() {
+                for expected in self.state().expected_emits.clone().into_iter() {
+                    if curr_depth == expected.depth {
+                        // we have returned back to the expected depth
+                        if !expected.found {
+                            return evm_error("Log != expected log")
+                        }
+                    }
+                }
+            }
 
             if let Some(expected_revert) = expected_revert {
                 let final_res = match res {
@@ -1154,6 +1178,48 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
             convert_log(Log { address, topics: topics.clone(), data: data.clone() })
         {
             self.state_mut().all_logs.push(decoded);
+        }
+
+        if !self.state().expected_emits.is_empty() {
+            // get expected emits
+            let expected_emits = &mut self.state_mut().expected_emits;
+
+            // do we have empty expected emits to fill?
+            if let Some(next_expect_to_fill) =
+                expected_emits.iter_mut().find(|expect| expect.log.is_none())
+            {
+                next_expect_to_fill.log =
+                    Some(RawLog { topics: topics.clone(), data: data.clone() });
+            } else {
+                // no unfilled, grab next unfound
+                // try to fill the first unfound
+                if let Some(next_expect) = expected_emits.iter_mut().find(|expect| !expect.found) {
+                    // unpack the log
+                    if let Some(RawLog { topics: expected_topics, data: expected_data }) =
+                        &next_expect.log
+                    {
+                        if expected_topics[0] == topics[0] {
+                            // same event topic 0, topic length should be the same
+                            let topics_match = topics
+                                .iter()
+                                .skip(1)
+                                .enumerate()
+                                .filter(|(i, _topic)| {
+                                    // do we want to check?
+                                    next_expect.checks[*i]
+                                })
+                                .all(|(i, topic)| topic == &expected_topics[i + 1]);
+
+                            // check data
+                            next_expect.found = if next_expect.checks[3] {
+                                expected_data == &data && topics_match
+                            } else {
+                                topics_match
+                            };
+                        }
+                    }
+                }
+            }
         }
 
         self.handler.log(address, topics, data)

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -6,7 +6,10 @@ use sputnik::{
 
 use crate::call_tracing::CallTraceArena;
 
-use ethers::types::{H160, H256, U256};
+use ethers::{
+    abi::RawLog,
+    types::{H160, H256, U256},
+};
 
 use std::{cell::RefCell, collections::BTreeMap};
 
@@ -16,6 +19,13 @@ pub struct RecordAccess {
     pub writes: RefCell<BTreeMap<H160, Vec<H256>>>,
 }
 
+#[derive(Clone, Default, Debug)]
+pub struct ExpectedEmit {
+    pub depth: usize,
+    pub log: Option<RawLog>,
+    pub checks: [bool; 4],
+    pub found: bool,
+}
 /// This struct implementation is copied from [upstream](https://github.com/rust-blockchain/evm/blob/5ecf36ce393380a89c6f1b09ef79f686fe043624/src/executor/stack/state.rs#L412) and modified to own the Backend type.
 ///
 /// We had to copy it so that we can modify the Stack's internal backend, because
@@ -34,6 +44,7 @@ pub struct MemoryStackStateOwned<'config, B> {
     pub msg_sender: Option<(H160, H160, usize)>,
     pub accesses: Option<RecordAccess>,
     pub all_logs: Vec<String>,
+    pub expected_emits: Vec<ExpectedEmit>,
 }
 
 impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
@@ -73,6 +84,7 @@ impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
             msg_sender: None,
             accesses: None,
             all_logs: Default::default(),
+            expected_emits: Default::default(),
         }
     }
 }

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -24,6 +24,7 @@ pub struct ExpectedEmit {
     pub depth: usize,
     pub log: Option<RawLog>,
     pub checks: [bool; 4],
+    /// Whether this expected emit was actually found in the subcall
     pub found: bool,
 }
 

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -26,6 +26,7 @@ pub struct ExpectedEmit {
     pub checks: [bool; 4],
     pub found: bool,
 }
+
 /// This struct implementation is copied from [upstream](https://github.com/rust-blockchain/evm/blob/5ecf36ce393380a89c6f1b09ef79f686fe043624/src/executor/stack/state.rs#L412) and modified to own the Backend type.
 ///
 /// We had to copy it so that we can modify the Stack's internal backend, because

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -60,6 +60,7 @@ ethers::contract::abigen!(
             expectRevert(bytes)
             record()
             accesses(address)(bytes32[],bytes32[])
+            expectEmit(bool,bool,bool,bool)
     ]"#,
 );
 pub use hevm_mod::{HEVMCalls, HEVM_ABI};

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -38,6 +38,10 @@ interface Hevm {
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
     function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
+    // Call this function, then emit an event, then call a function. Internally after the call, we check if
+    // logs were emited in the expected order with the expected topics and data (as specified by the booleans)
+    function expectEmit(bool,bool,bool,bool) external;
 }
 
 contract HasStorage {
@@ -284,6 +288,55 @@ contract CheatCodes is DSTest {
         assertEq(writes2[0], bytes32(uint256(2)));
     }
 
+    event Transfer(address indexed from,address indexed to, uint256 amount);
+    function testExpectEmit() public {
+        ExpectEmit emitter = new ExpectEmit();
+        // check topic 1, topic 2, and data are the same as the following emitted event
+        hevm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1337), 1337);
+        emitter.t();
+    }
+
+    function testExpectEmit2() public {
+        ExpectEmit emitter = new ExpectEmit();
+        // check topic 1, topic 2, and data are the same as the following emitted event
+        hevm.expectEmit(true,false,false,true);
+        emit Transfer(address(this), address(1338), 1337);
+        emitter.t();
+    }
+
+    function testExpectEmit3() public {
+        ExpectEmit emitter = new ExpectEmit();
+        // check topic 1, topic 2, and data are the same as the following emitted event
+        hevm.expectEmit(false,false,false,true);
+        emit Transfer(address(1338), address(1338), 1337);
+        emitter.t();
+    }
+
+    function testExpectEmit4() public {
+        ExpectEmit emitter = new ExpectEmit();
+        // check topic 1, topic 2, and data are the same as the following emitted event
+        hevm.expectEmit(true,true,true,false);
+        emit Transfer(address(this), address(1337), 1338);
+        emitter.t();
+    }
+
+    function testExpectEmit5() public {
+        ExpectEmit emitter = new ExpectEmit();
+        // check topic 1, topic 2, and data are the same as the following emitted event
+        hevm.expectEmit(true,true,true,false);
+        emit Transfer(address(this), address(1337), 1338);
+        emitter.t2();
+    }
+
+    function testFailExpectEmit() public {
+        ExpectEmit emitter = new ExpectEmit();
+        // check topic 1, topic 2, and data are the same as the following emitted event
+        hevm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1338), 1337);
+        emitter.t();
+    }
+
     // Test should fail if nothing is called
     // after expectRevert
     function testFailExpectRevert3() public {
@@ -401,4 +454,16 @@ contract ComplexPrank {
     }
 }
 
+contract ExpectEmit {
+    event Transfer(address indexed from,address indexed to, uint256 amount);
+    event Transfer2(address indexed from,address indexed to, uint256 amount);
+    function t() public {
+        emit Transfer(msg.sender, address(1337), 1337);
+    }
+
+    function t2() public {
+        emit Transfer2(msg.sender, address(1337), 1337);
+        emit Transfer(msg.sender, address(1337), 1337);
+    }
+}
 

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -297,9 +297,17 @@ contract CheatCodes is DSTest {
         emitter.t();
     }
 
+    function testExpectEmitMultiple() public {
+        ExpectEmit emitter = new ExpectEmit();
+        hevm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1337), 1337);
+        hevm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1337), 1337);
+        emitter.t3();
+    }
+
     function testExpectEmit2() public {
         ExpectEmit emitter = new ExpectEmit();
-        // check topic 1, topic 2, and data are the same as the following emitted event
         hevm.expectEmit(true,false,false,true);
         emit Transfer(address(this), address(1338), 1337);
         emitter.t();
@@ -307,7 +315,6 @@ contract CheatCodes is DSTest {
 
     function testExpectEmit3() public {
         ExpectEmit emitter = new ExpectEmit();
-        // check topic 1, topic 2, and data are the same as the following emitted event
         hevm.expectEmit(false,false,false,true);
         emit Transfer(address(1338), address(1338), 1337);
         emitter.t();
@@ -315,7 +322,6 @@ contract CheatCodes is DSTest {
 
     function testExpectEmit4() public {
         ExpectEmit emitter = new ExpectEmit();
-        // check topic 1, topic 2, and data are the same as the following emitted event
         hevm.expectEmit(true,true,true,false);
         emit Transfer(address(this), address(1337), 1338);
         emitter.t();
@@ -323,7 +329,6 @@ contract CheatCodes is DSTest {
 
     function testExpectEmit5() public {
         ExpectEmit emitter = new ExpectEmit();
-        // check topic 1, topic 2, and data are the same as the following emitted event
         hevm.expectEmit(true,true,true,false);
         emit Transfer(address(this), address(1337), 1338);
         emitter.t2();
@@ -331,7 +336,6 @@ contract CheatCodes is DSTest {
 
     function testFailExpectEmit() public {
         ExpectEmit emitter = new ExpectEmit();
-        // check topic 1, topic 2, and data are the same as the following emitted event
         hevm.expectEmit(true,true,false,true);
         emit Transfer(address(this), address(1338), 1337);
         emitter.t();
@@ -463,6 +467,11 @@ contract ExpectEmit {
 
     function t2() public {
         emit Transfer2(msg.sender, address(1337), 1337);
+        emit Transfer(msg.sender, address(1337), 1337);
+    }
+
+    function t3() public {
+        emit Transfer(msg.sender, address(1337), 1337);
         emit Transfer(msg.sender, address(1337), 1337);
     }
 }


### PR DESCRIPTION
Closes #310 

This works by grabbing the next emitted event. You specify if you want to match against topics 1-3 and the data in the call. You can expect multiple events by repeatedly doing `vm.expectEvent` then emitting an event prior to a call. After the call, if the expected events are found, it continues execution. Otherwise, if the expected logs aren't found, it reverts.

```solidity
interface Vm {
    function expectEmit(bool,bool,bool,bool) external;
}

contract T is DSTest {
    Vm vm = Vm(HEVM_ADDRESS);
    event Transfer(address indexed from,address indexed to, uint256 amount);
    function testExpectEmit() public {
        ExpectEmit emitter = new ExpectEmit();
        // check topic 1, topic 2, and data are the same as the following emitted event
        hevm.expectEmit(true,true,false,true);
        emit Transfer(address(this), address(1337), 1337);
        emitter.t();
    }
}

contract ExpectEmit {
    event Transfer(address indexed from,address indexed to, uint256 amount);
    function t() public {
        emit Transfer(msg.sender, address(1337), 1337);
    }
}
```