### PR TITLE
updated forge readme with remapping explainer

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -228,6 +228,23 @@ console.log(someValue);
 
 ```
 
+## Remappings
+If you are working in a repo with NPM-style imports, like
+```
+import "@openzeppelin/contracts/access/Ownable.sol";
+```
+
+then you will need to create a `remappings.txt` file at the top level of your project directory, so that Forge knows where to find these dependencies. 
+
+For example, if you have `@openzeppelin` imports, you would 
+
+1. `forge install openzeppelin/openzeppelin-contracts` (this will add the repo to `lib/openzepplin-contracts`)
+2. Create a remappings file: `touch remappings.txt`
+3. Add this line to `remappings.txt`  
+```
+@openzeppelin/=lib/openzeppelin-contracts/
+```
+
 ## Future Features
 
 ### Dapptools feature parity


### PR DESCRIPTION
I and several others have been confused about failing imports and the need for remappings. In this PR I added a remappings explainer to the forge readme.
<img width="909" alt="Screen Shot 2021-12-31 at 11 39 22 AM" src="https://user-images.githubusercontent.com/49502823/147832710-e8defbfb-102c-4863-977f-40ed855d7747.png">
 