### PR TITLE
feat: hw support for `cast wallet`

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256};
 use structopt::StructOpt;
 
-use super::EthereumOpts;
+use super::{EthereumOpts, Wallet};
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Perform Ethereum RPC calls from the comfort of your command line.")]
@@ -308,24 +308,15 @@ pub enum WalletSubcommands {
     },
     #[structopt(name = "address", about = "Convert a private key to an address")]
     Address {
-        #[structopt(
-            long = "--unsafe-key",
-            help = "private key to generate address from in cleartext. This is UNSAFE to use and we recommend using the secure password prompt which appears when not providing this argument",
-            env = "CAST_PRIVATE_KEY"
-        )]
-        unsafe_private_key: Option<String>,
+        #[structopt(flatten)]
+        wallet: Wallet,
     },
     #[structopt(name = "sign", about = "Sign the message with provided private key")]
     Sign {
         #[structopt(help = "message to sign")]
         message: String,
-        #[structopt(
-            long = "--unsafe-key",
-            help = "private key to sign with in cleartext. This is UNSAFE to use and we recommend using secure password prompt which appears when not providing this argument",
-            env = "CAST_PRIVATE_KEY",
-            conflicts_with("private_key")
-        )]
-        unsafe_private_key: Option<String>,
+        #[structopt(flatten)]
+        wallet: Wallet,
     },
     #[structopt(name = "verify", about = "Verify the signature on the message")]
     Verify {

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -130,7 +130,9 @@ pub struct Wallet {
 impl Wallet {
     fn interactive(&self) -> Result<Option<LocalWallet>> {
         Ok(if self.interactive {
+            println!("Insert private key:");
             let private_key = rpassword::read_password()?;
+            let private_key = private_key.strip_prefix("0x").unwrap_or(&private_key);
             Some(LocalWallet::from_str(&private_key)?)
         } else {
             None

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -133,7 +133,7 @@ impl Wallet {
             println!("Insert private key:");
             let private_key = rpassword::read_password()?;
             let private_key = private_key.strip_prefix("0x").unwrap_or(&private_key);
-            Some(LocalWallet::from_str(&private_key)?)
+            Some(LocalWallet::from_str(private_key)?)
         } else {
             None
         })


### PR DESCRIPTION
re-uses the `EthereumOpts` which are already supporting all hw wallets / mnemonics etc, and adds `--interactive` for inserting secrets w/o leaking them in the terminal.

This is a bit ugly, but does the job, until we can make the `Signer` object safe. Alternatively, we should create a simple `Signer` enum and impl `Signer` for it.