### PR TITLE
fix(fuzz): ensure the state is reset to the original before fuzz tests

### DIFF
--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -203,6 +203,7 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
                 .iter()
                 .filter(|func| !func.inputs.is_empty())
                 .map(|func| {
+                    self.evm.reset(init_state.clone());
                     let result = self.run_fuzz_test(func, needs_setup, fuzzer.clone())?;
                     Ok((func.signature(), result))
                 })


### PR DESCRIPTION
Otherwise we may start over from dirty state from a previous unit or fuzz test
and that can break test isolation

this is a follow up PR from https://github.com/gakonst/foundry/pull/226 / https://github.com/gakonst/foundry/issues/225, since the original PRs did not fix the issue with fuzz tests

This was detected in this repo https://github.com/zangGallery/testing/tree/2804d19db0fec7657ae4a0e64fbb2ce808b4354d