### PR TITLE
fix: counterexample display

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -189,12 +189,12 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::CalldataDecode { sig, calldata } => {
             let tokens = SimpleCast::abi_decode(&sig, &calldata, true)?;
-            let tokens = utils::format_tokens(&tokens);
+            let tokens = foundry_utils::format_tokens(&tokens);
             tokens.for_each(|t| println!("{}", t));
         }
         Subcommands::AbiDecode { sig, calldata, input } => {
             let tokens = SimpleCast::abi_decode(&sig, &calldata, input)?;
-            let tokens = utils::format_tokens(&tokens);
+            let tokens = foundry_utils::format_tokens(&tokens);
             tokens.for_each(|t| println!("{}", t));
         }
         Subcommands::FourByte { selector } => {
@@ -219,7 +219,7 @@ async fn main() -> eyre::Result<()> {
             }?;
 
             let tokens = SimpleCast::abi_decode(sig, &calldata, true)?;
-            let tokens = utils::format_tokens(&tokens);
+            let tokens = foundry_utils::format_tokens(&tokens);
 
             tokens.for_each(|t| println!("{}", t));
         }

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,5 +1,4 @@
 use ethers::{
-    abi::Token,
     providers::Provider,
     solc::{artifacts::Contract, EvmVersion},
 };
@@ -127,16 +126,6 @@ fn find_fave_or_alt_path(root: impl AsRef<Path>, fave: &str, alt: &str) -> PathB
         }
     }
     p
-}
-
-// need some special handling to print the types nicely
-#[allow(dead_code)]
-pub fn format_tokens(tokens: &[Token]) -> impl Iterator<Item = String> + '_ {
-    tokens.iter().map(|token| match token {
-        Token::Address(inner) => format!("{:?}", inner),
-        Token::Uint(inner) => format!("{}", inner),
-        other => other.to_string(),
-    })
 }
 
 #[cfg(feature = "sputnik-evm")]

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -26,7 +26,7 @@ pub struct CounterExample {
 impl fmt::Display for CounterExample {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let args = foundry_utils::format_tokens(&self.args).collect::<Vec<_>>().join(", ");
-        write!(f, "calldata=0x{}, args={}", hex::encode(&self.calldata), args)
+        write!(f, "calldata=0x{}, args=[{}]", hex::encode(&self.calldata), args)
     }
 }
 

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -369,7 +369,9 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
                 }
                 result => panic!("Unexpected test result: {:?}", result),
             }
-            reason = Some(err.revert_reason);
+            if !err.revert_reason.is_empty() {
+                reason = Some(err.revert_reason);
+            }
         }
 
         let duration = Instant::now().duration_since(start);

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -25,7 +25,8 @@ pub struct CounterExample {
 
 impl fmt::Display for CounterExample {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "calldata=0x{}, args={:?}", hex::encode(&self.calldata), self.args)
+        let args = foundry_utils::format_tokens(&self.args).collect::<Vec<_>>().join(", ");
+        write!(f, "calldata=0x{}, args={}", hex::encode(&self.calldata), args)
     }
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -303,6 +303,43 @@ pub fn abi_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> 
     Ok(res)
 }
 
+/// Pretty print a slice of tokens.
+pub fn format_tokens(tokens: &[Token]) -> impl Iterator<Item = String> + '_ {
+    tokens.iter().map(|param| format_token(param))
+}
+
+// Gets pretty print strings for tokens
+pub fn format_token(param: &Token) -> String {
+    match param {
+        Token::Address(addr) => format!("{:?}", addr),
+        Token::FixedBytes(bytes) => format!("0x{}", hex::encode(&bytes)),
+        Token::Bytes(bytes) => format!("0x{}", hex::encode(&bytes)),
+        Token::Int(mut num) => {
+            if num.bit(255) {
+                num = num - 1;
+                format!("-{}", num.overflowing_neg().0)
+            } else {
+                num.to_string()
+            }
+        }
+        Token::Uint(num) => num.to_string(),
+        Token::Bool(b) => format!("{}", b),
+        Token::String(s) => s.clone(),
+        Token::FixedArray(tokens) => {
+            let string = tokens.into_iter().map(format_token).collect::<Vec<String>>().join(", ");
+            format!("[{}]", string)
+        }
+        Token::Array(tokens) => {
+            let string = tokens.into_iter().map(format_token).collect::<Vec<String>>().join(", ");
+            format!("[{}]", string)
+        }
+        Token::Tuple(tokens) => {
+            let string = tokens.into_iter().map(format_token).collect::<Vec<String>>().join(", ");
+            format!("({})", string)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -324,7 +324,7 @@ pub fn format_token(param: &Token) -> String {
         }
         Token::Uint(num) => num.to_string(),
         Token::Bool(b) => format!("{}", b),
-        Token::String(s) => s.clone(),
+        Token::String(s) => format!("{:?}", s),
         Token::FixedArray(tokens) => {
             let string = tokens.into_iter().map(format_token).collect::<Vec<String>>().join(", ");
             format!("[{}]", string)

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -305,7 +305,7 @@ pub fn abi_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> 
 
 /// Pretty print a slice of tokens.
 pub fn format_tokens(tokens: &[Token]) -> impl Iterator<Item = String> + '_ {
-    tokens.iter().map(|param| format_token(param))
+    tokens.iter().map(format_token)
 }
 
 // Gets pretty print strings for tokens
@@ -326,15 +326,15 @@ pub fn format_token(param: &Token) -> String {
         Token::Bool(b) => format!("{}", b),
         Token::String(s) => format!("{:?}", s),
         Token::FixedArray(tokens) => {
-            let string = tokens.into_iter().map(format_token).collect::<Vec<String>>().join(", ");
+            let string = tokens.iter().map(format_token).collect::<Vec<String>>().join(", ");
             format!("[{}]", string)
         }
         Token::Array(tokens) => {
-            let string = tokens.into_iter().map(format_token).collect::<Vec<String>>().join(", ");
+            let string = tokens.iter().map(format_token).collect::<Vec<String>>().join(", ");
             format!("[{}]", string)
         }
         Token::Tuple(tokens) => {
-            let string = tokens.into_iter().map(format_token).collect::<Vec<String>>().join(", ");
+            let string = tokens.iter().map(format_token).collect::<Vec<String>>().join(", ");
             format!("({})", string)
         }
     }


### PR DESCRIPTION
* we deduplicate our pretty printing functions and now re-use the one from call tracing. 
* using that, we now properly print counterexamples (instead of using the `Token`'s `Debug` impl)

cc @mds1 regarding the formatting issue from #353, now it looks like below (and ints are printed properly, manually tested)

```
[FAIL. Counterexample: calldata=0xe49066450000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, args=[0, "", 0]] testBarFuzzed(uint256,string,uint256) (runs: 0, μ: 0, ~: 0)
```