### PR TITLE
fix(forge): prepare -> create cheatcodes work

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -376,11 +376,11 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     if call {
                         return ExpectRevertReturn::Call(evm_error(
                             "Expected revert call did not revert",
-                        ));
+                        ))
                     } else {
                         return ExpectRevertReturn::Create(evm_create_error(
                             "Expected revert create did not revert",
-                        ));
+                        ))
                     }
                 }
             }
@@ -399,7 +399,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             return ExpectRevertReturn::Call(Capture::Exit((
                                 ExitReason::Succeed(ExitSucceed::Returned),
                                 DUMMY_OUTPUT.to_vec(),
-                            )));
+                            )))
                         } else {
                             return ExpectRevertReturn::Create(Capture::Exit((
                                 ExitReason::Succeed(ExitSucceed::Returned),
@@ -409,20 +409,20 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                                         [0..20],
                                 )),
                                 Vec::new(),
-                            )));
+                            )))
                         }
                     } else if call {
                         return ExpectRevertReturn::Call(evm_error(&*format!(
                             "Error != expected error: '{}' != '{}'",
                             String::from_utf8_lossy(&decoded_data[..]),
                             String::from_utf8_lossy(&expected_revert)
-                        )));
+                        )))
                     } else {
                         return ExpectRevertReturn::Create(evm_create_error(&*format!(
                             "Error != expected error: '{}' != '{}'",
                             String::from_utf8_lossy(&decoded_data[..]),
                             String::from_utf8_lossy(&expected_revert)
-                        )));
+                        )))
                     }
                 }
 
@@ -431,7 +431,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                         return ExpectRevertReturn::Call(Capture::Exit((
                             ExitReason::Succeed(ExitSucceed::Returned),
                             DUMMY_OUTPUT.to_vec(),
-                        )));
+                        )))
                     } else {
                         return ExpectRevertReturn::Create(Capture::Exit((
                             ExitReason::Succeed(ExitSucceed::Returned),
@@ -440,7 +440,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                                     .expect("valid address hex")[0..20],
                             )),
                             Vec::new(),
-                        )));
+                        )))
                     }
                 } else if call {
                     ExpectRevertReturn::Call(evm_error(&*format!(
@@ -543,7 +543,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             HEVMCalls::Addr(inner) => {
                 let sk = inner.0;
                 if sk.is_zero() {
-                    return evm_error("Bad Cheat Code. Private Key cannot be 0.");
+                    return evm_error("Bad Cheat Code. Private Key cannot be 0.")
                 }
                 // 256 bit priv key -> 32 byte slice
                 let mut bs: [u8; 32] = [0; 32];
@@ -559,7 +559,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 let sk = inner.0;
                 let digest = inner.1;
                 if sk.is_zero() {
-                    return evm_error("Bad Cheat Code. Private Key cannot be 0.");
+                    return evm_error("Bad Cheat Code. Private Key cannot be 0.")
                 }
                 // 256 bit priv key -> 32 byte slice
                 let mut bs: [u8; 32] = [0; 32];
@@ -635,7 +635,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 if self.state().expected_revert.is_some() {
                     return evm_error(
                         "You must call another function prior to expecting a second revert.",
-                    );
+                    )
                 } else {
                     self.state_mut().expected_revert = Some(inner.0.to_vec());
                 }
@@ -674,8 +674,8 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             .into_tokens()[0]
                             .clone(),
                     ]);
-                    if record_accesses.reads.borrow().len() == 0
-                        && record_accesses.writes.borrow().len() == 0
+                    if record_accesses.reads.borrow().len() == 0 &&
+                        record_accesses.writes.borrow().len() == 0
                     {
                         self.state_mut().accesses = None;
                     }
@@ -788,7 +788,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     Ok(v) => v,
                     Err(e) => {
                         self.fill_trace(&trace, false, None, pre_index);
-                        return Capture::Exit((e.into(), Vec::new()));
+                        return Capture::Exit((e.into(), Vec::new()))
                     }
                 }
             };
@@ -830,7 +830,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             if depth > self.config().call_stack_limit {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Reverted);
-                return Capture::Exit((ExitError::CallTooDeep.into(), Vec::new()));
+                return Capture::Exit((ExitError::CallTooDeep.into(), Vec::new()))
             }
         }
 
@@ -840,7 +840,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 Err(e) => {
                     self.fill_trace(&trace, false, None, pre_index);
                     let _ = self.handler.exit_substate(StackExitKind::Reverted);
-                    return Capture::Exit((ExitReason::Error(e), Vec::new()));
+                    return Capture::Exit((ExitReason::Error(e), Vec::new()))
                 }
             }
         }
@@ -859,7 +859,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             Ok(_) => continue,
                             Err(error) => {
                                 self.fill_trace(&trace, false, Some(output.clone()), pre_index);
-                                return Capture::Exit((ExitReason::Error(error), output));
+                                return Capture::Exit((ExitReason::Error(error), output))
                             }
                         }
                     }
@@ -881,7 +881,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     let _ = self.handler.exit_substate(StackExitKind::Failed);
                     Capture::Exit((e, Vec::new()))
                 }
-            };
+            }
         }
 
         // each cfg is about 200 bytes, is this a lot to clone? why does this error
@@ -940,7 +940,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     Ok(v) => v,
                     Err(e) => {
                         self.fill_trace(&trace, false, None, pre_index);
-                        return Capture::Exit((e.into(), None, Vec::new()));
+                        return Capture::Exit((e.into(), None, Vec::new()))
                     }
                 }
             };
@@ -949,7 +949,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         fn check_first_byte(config: &Config, code: &[u8]) -> Result<(), ExitError> {
             if config.disallow_executable_format {
                 if let Some(0xef) = code.get(0) {
-                    return Err(ExitError::InvalidCode);
+                    return Err(ExitError::InvalidCode)
                 }
             }
             Ok(())
@@ -965,13 +965,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         if let Some(depth) = self.state().metadata().depth() {
             if depth > self.config().call_stack_limit {
                 self.fill_trace(&trace, false, None, pre_index);
-                return Capture::Exit((ExitError::CallTooDeep.into(), None, Vec::new()));
+                return Capture::Exit((ExitError::CallTooDeep.into(), None, Vec::new()))
             }
         }
 
         if self.balance(caller) < value {
             self.fill_trace(&trace, false, None, pre_index);
-            return Capture::Exit((ExitError::OutOfFund.into(), None, Vec::new()));
+            return Capture::Exit((ExitError::OutOfFund.into(), None, Vec::new()))
         }
 
         let after_gas = if take_l64 && self.config().call_l64_after_gas {
@@ -1000,13 +1000,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             if self.code_size(address) != U256::zero() {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Failed);
-                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()));
+                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
             }
 
             if self.handler.nonce(address) > U256::zero() {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Failed);
-                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()));
+                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
             }
 
             self.state_mut().reset_storage(address);
@@ -1019,7 +1019,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             Err(e) => {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Reverted);
-                return Capture::Exit((ExitReason::Error(e), None, Vec::new()));
+                return Capture::Exit((ExitReason::Error(e), None, Vec::new()))
             }
         }
 
@@ -1042,7 +1042,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     self.state_mut().metadata_mut().gasometer_mut().fail();
                     self.fill_trace(&trace, false, None, pre_index);
                     let _ = self.handler.exit_substate(StackExitKind::Failed);
-                    return Capture::Exit((e.into(), None, Vec::new()));
+                    return Capture::Exit((e.into(), None, Vec::new()))
                 }
 
                 if let Some(limit) = self.config().create_contract_limit {
@@ -1054,7 +1054,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             ExitError::CreateContractLimit.into(),
                             None,
                             Vec::new(),
-                        ));
+                        ))
                     }
                 }
 
@@ -1165,15 +1165,15 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 new_context,
             );
 
-            if !self.state_mut().expected_emits.is_empty()
-                && !self
+            if !self.state_mut().expected_emits.is_empty() &&
+                !self
                     .state()
                     .expected_emits
                     .iter()
                     .filter(|expected| expected.depth == curr_depth)
                     .all(|expected| expected.found)
             {
-                return evm_error("Log != expected log");
+                return evm_error("Log != expected log")
             }
 
             self.expected_revert(ExpectRevertReturn::Call(res), expected_revert, true)
@@ -1357,15 +1357,15 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
             new_caller = caller;
         }
         let res = self.create_inner(new_caller, scheme, value, init_code, target_gas, true);
-        if !self.state_mut().expected_emits.is_empty()
-            && !self
+        if !self.state_mut().expected_emits.is_empty() &&
+            !self
                 .state()
                 .expected_emits
                 .iter()
                 .filter(|expected| expected.depth == curr_depth)
                 .all(|expected| expected.found)
         {
-            return evm_create_error("Log != expected log");
+            return evm_create_error("Log != expected log")
         }
 
         self.expected_revert(ExpectRevertReturn::Create(res), expected_revert, false)
@@ -1498,7 +1498,7 @@ mod tests {
         for func in abi.functions().filter(|func| func.name.starts_with("test")) {
             // Skip the FFI unit test if not in a unix system
             if func.name == "testFFI" && !cfg!(unix) {
-                continue;
+                continue
             }
 
             let should_fail = func.name.starts_with("testFail");

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -66,6 +66,10 @@ impl ExpectRevertReturn {
             _ => panic!("tried to get create response inner from a call"),
         }
     }
+
+    pub fn is_call(&self) -> bool {
+        matches!(self, ExpectRevertReturn::Call(..))
+    }
 }
 
 /// For certain cheatcodes, we may internally change the status of the call, i.e. in
@@ -357,8 +361,8 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         &mut self,
         res: ExpectRevertReturn,
         expected_revert: Option<Vec<u8>>,
-        call: bool,
     ) -> ExpectRevertReturn {
+        let call = res.is_call();
         if let Some(expected_revert) = expected_revert {
             let data;
             match res {
@@ -1175,8 +1179,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 return evm_error("Log != expected log")
             }
 
-            self.expected_revert(ExpectRevertReturn::Call(res), expected_revert, true)
-                .into_call_inner()
+            self.expected_revert(ExpectRevertReturn::Call(res), expected_revert).into_call_inner()
         }
     }
 
@@ -1379,8 +1382,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
             return evm_create_error("Log != expected log")
         }
 
-        self.expected_revert(ExpectRevertReturn::Create(res), expected_revert, false)
-            .into_create_inner()
+        self.expected_revert(ExpectRevertReturn::Create(res), expected_revert).into_create_inner()
     }
 
     fn pre_validate(

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1263,7 +1263,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
         if let Some(caller) = self.state_mut().next_msg_sender.take() {
             new_caller = caller;
         }
-        let res = self.create_inner(new_caller, scheme, value, init_code.clone(), target_gas, true);
+        let res = self.create_inner(new_caller, scheme, value, init_code, target_gas, true);
         if !self.state_mut().expected_emits.is_empty() &&
             !self
                 .state()

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -57,13 +57,13 @@ impl ExpectRevertReturn {
     pub fn into_call_inner(self) -> Capture<(ExitReason, Vec<u8>), Infallible> {
         match self {
             ExpectRevertReturn::Call(inner) => inner,
-            _ => panic!("tried to get create from call expect revert"),
+            _ => panic!("tried to get call response inner from a create"),
         }
     }
     pub fn into_create_inner(self) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Infallible> {
         match self {
             ExpectRevertReturn::Create(inner) => inner,
-            _ => panic!("tried to get call from create expect revert"),
+            _ => panic!("tried to get create response inner from a call"),
         }
     }
 }
@@ -376,11 +376,11 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     if call {
                         return ExpectRevertReturn::Call(evm_error(
                             "Expected revert call did not revert",
-                        ))
+                        ));
                     } else {
                         return ExpectRevertReturn::Create(evm_create_error(
                             "Expected revert create did not revert",
-                        ))
+                        ));
                     }
                 }
             }
@@ -399,7 +399,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             return ExpectRevertReturn::Call(Capture::Exit((
                                 ExitReason::Succeed(ExitSucceed::Returned),
                                 DUMMY_OUTPUT.to_vec(),
-                            )))
+                            )));
                         } else {
                             return ExpectRevertReturn::Create(Capture::Exit((
                                 ExitReason::Succeed(ExitSucceed::Returned),
@@ -409,20 +409,20 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                                         [0..20],
                                 )),
                                 Vec::new(),
-                            )))
+                            )));
                         }
                     } else if call {
                         return ExpectRevertReturn::Call(evm_error(&*format!(
                             "Error != expected error: '{}' != '{}'",
                             String::from_utf8_lossy(&decoded_data[..]),
                             String::from_utf8_lossy(&expected_revert)
-                        )))
+                        )));
                     } else {
                         return ExpectRevertReturn::Create(evm_create_error(&*format!(
                             "Error != expected error: '{}' != '{}'",
                             String::from_utf8_lossy(&decoded_data[..]),
                             String::from_utf8_lossy(&expected_revert)
-                        )))
+                        )));
                     }
                 }
 
@@ -431,7 +431,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                         return ExpectRevertReturn::Call(Capture::Exit((
                             ExitReason::Succeed(ExitSucceed::Returned),
                             DUMMY_OUTPUT.to_vec(),
-                        )))
+                        )));
                     } else {
                         return ExpectRevertReturn::Create(Capture::Exit((
                             ExitReason::Succeed(ExitSucceed::Returned),
@@ -440,7 +440,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                                     .expect("valid address hex")[0..20],
                             )),
                             Vec::new(),
-                        )))
+                        )));
                     }
                 } else if call {
                     ExpectRevertReturn::Call(evm_error(&*format!(
@@ -543,7 +543,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             HEVMCalls::Addr(inner) => {
                 let sk = inner.0;
                 if sk.is_zero() {
-                    return evm_error("Bad Cheat Code. Private Key cannot be 0.")
+                    return evm_error("Bad Cheat Code. Private Key cannot be 0.");
                 }
                 // 256 bit priv key -> 32 byte slice
                 let mut bs: [u8; 32] = [0; 32];
@@ -559,7 +559,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 let sk = inner.0;
                 let digest = inner.1;
                 if sk.is_zero() {
-                    return evm_error("Bad Cheat Code. Private Key cannot be 0.")
+                    return evm_error("Bad Cheat Code. Private Key cannot be 0.");
                 }
                 // 256 bit priv key -> 32 byte slice
                 let mut bs: [u8; 32] = [0; 32];
@@ -635,7 +635,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 if self.state().expected_revert.is_some() {
                     return evm_error(
                         "You must call another function prior to expecting a second revert.",
-                    )
+                    );
                 } else {
                     self.state_mut().expected_revert = Some(inner.0.to_vec());
                 }
@@ -674,8 +674,8 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             .into_tokens()[0]
                             .clone(),
                     ]);
-                    if record_accesses.reads.borrow().len() == 0 &&
-                        record_accesses.writes.borrow().len() == 0
+                    if record_accesses.reads.borrow().len() == 0
+                        && record_accesses.writes.borrow().len() == 0
                     {
                         self.state_mut().accesses = None;
                     }
@@ -788,7 +788,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     Ok(v) => v,
                     Err(e) => {
                         self.fill_trace(&trace, false, None, pre_index);
-                        return Capture::Exit((e.into(), Vec::new()))
+                        return Capture::Exit((e.into(), Vec::new()));
                     }
                 }
             };
@@ -830,7 +830,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             if depth > self.config().call_stack_limit {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Reverted);
-                return Capture::Exit((ExitError::CallTooDeep.into(), Vec::new()))
+                return Capture::Exit((ExitError::CallTooDeep.into(), Vec::new()));
             }
         }
 
@@ -840,7 +840,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 Err(e) => {
                     self.fill_trace(&trace, false, None, pre_index);
                     let _ = self.handler.exit_substate(StackExitKind::Reverted);
-                    return Capture::Exit((ExitReason::Error(e), Vec::new()))
+                    return Capture::Exit((ExitReason::Error(e), Vec::new()));
                 }
             }
         }
@@ -859,7 +859,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             Ok(_) => continue,
                             Err(error) => {
                                 self.fill_trace(&trace, false, Some(output.clone()), pre_index);
-                                return Capture::Exit((ExitReason::Error(error), output))
+                                return Capture::Exit((ExitReason::Error(error), output));
                             }
                         }
                     }
@@ -881,7 +881,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     let _ = self.handler.exit_substate(StackExitKind::Failed);
                     Capture::Exit((e, Vec::new()))
                 }
-            }
+            };
         }
 
         // each cfg is about 200 bytes, is this a lot to clone? why does this error
@@ -940,7 +940,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     Ok(v) => v,
                     Err(e) => {
                         self.fill_trace(&trace, false, None, pre_index);
-                        return Capture::Exit((e.into(), None, Vec::new()))
+                        return Capture::Exit((e.into(), None, Vec::new()));
                     }
                 }
             };
@@ -949,7 +949,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         fn check_first_byte(config: &Config, code: &[u8]) -> Result<(), ExitError> {
             if config.disallow_executable_format {
                 if let Some(0xef) = code.get(0) {
-                    return Err(ExitError::InvalidCode)
+                    return Err(ExitError::InvalidCode);
                 }
             }
             Ok(())
@@ -965,13 +965,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         if let Some(depth) = self.state().metadata().depth() {
             if depth > self.config().call_stack_limit {
                 self.fill_trace(&trace, false, None, pre_index);
-                return Capture::Exit((ExitError::CallTooDeep.into(), None, Vec::new()))
+                return Capture::Exit((ExitError::CallTooDeep.into(), None, Vec::new()));
             }
         }
 
         if self.balance(caller) < value {
             self.fill_trace(&trace, false, None, pre_index);
-            return Capture::Exit((ExitError::OutOfFund.into(), None, Vec::new()))
+            return Capture::Exit((ExitError::OutOfFund.into(), None, Vec::new()));
         }
 
         let after_gas = if take_l64 && self.config().call_l64_after_gas {
@@ -1000,13 +1000,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             if self.code_size(address) != U256::zero() {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Failed);
-                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
+                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()));
             }
 
             if self.handler.nonce(address) > U256::zero() {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Failed);
-                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
+                return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()));
             }
 
             self.state_mut().reset_storage(address);
@@ -1019,7 +1019,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             Err(e) => {
                 self.fill_trace(&trace, false, None, pre_index);
                 let _ = self.handler.exit_substate(StackExitKind::Reverted);
-                return Capture::Exit((ExitReason::Error(e), None, Vec::new()))
+                return Capture::Exit((ExitReason::Error(e), None, Vec::new()));
             }
         }
 
@@ -1042,7 +1042,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     self.state_mut().metadata_mut().gasometer_mut().fail();
                     self.fill_trace(&trace, false, None, pre_index);
                     let _ = self.handler.exit_substate(StackExitKind::Failed);
-                    return Capture::Exit((e.into(), None, Vec::new()))
+                    return Capture::Exit((e.into(), None, Vec::new()));
                 }
 
                 if let Some(limit) = self.config().create_contract_limit {
@@ -1054,7 +1054,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                             ExitError::CreateContractLimit.into(),
                             None,
                             Vec::new(),
-                        ))
+                        ));
                     }
                 }
 
@@ -1165,15 +1165,15 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 new_context,
             );
 
-            if !self.state_mut().expected_emits.is_empty() &&
-                !self
+            if !self.state_mut().expected_emits.is_empty()
+                && !self
                     .state()
                     .expected_emits
                     .iter()
                     .filter(|expected| expected.depth == curr_depth)
                     .all(|expected| expected.found)
             {
-                return evm_error("Log != expected log")
+                return evm_error("Log != expected log");
             }
 
             self.expected_revert(ExpectRevertReturn::Call(res), expected_revert, true)
@@ -1357,15 +1357,15 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
             new_caller = caller;
         }
         let res = self.create_inner(new_caller, scheme, value, init_code, target_gas, true);
-        if !self.state_mut().expected_emits.is_empty() &&
-            !self
+        if !self.state_mut().expected_emits.is_empty()
+            && !self
                 .state()
                 .expected_emits
                 .iter()
                 .filter(|expected| expected.depth == curr_depth)
                 .all(|expected| expected.found)
         {
-            return evm_create_error("Log != expected log")
+            return evm_create_error("Log != expected log");
         }
 
         self.expected_revert(ExpectRevertReturn::Create(res), expected_revert, false)
@@ -1498,7 +1498,7 @@ mod tests {
         for func in abi.functions().filter(|func| func.name.starts_with("test")) {
             // Skip the FFI unit test if not in a unix system
             if func.name == "testFFI" && !cfg!(unix) {
-                continue
+                continue;
             }
 
             let should_fail = func.name.starts_with("testFail");

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -371,20 +371,17 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
     ) -> ExpectRevertReturn {
         let call = res.is_call();
         if let Some(expected_revert) = expected_revert {
-            let data;
-            match res {
+            let data = match res {
                 ExpectRevertReturn::Create(Capture::Exit((
                     ExitReason::Revert(_e),
                     None,
                     revdata,
-                ))) => {
-                    data = Some(revdata);
-                }
+                ))) => Some(revdata),
                 ExpectRevertReturn::Call(Capture::Exit((ExitReason::Revert(_e), revdata))) => {
-                    data = Some(revdata);
+                    Some(revdata)
                 }
                 _ => return revert_return_evm_error("Expected revert did not revert", call),
-            }
+            };
             let final_res = if let Some(data) = data {
                 if data.len() >= 4 && data[0..4] == [8, 195, 121, 160] {
                     // its a revert string

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1276,7 +1276,6 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
         }
 
         if let Some(expected_revert) = expected_revert {
-            println!("expected revert {:?}\n {:?}", expected_revert, res);
             let final_res = match res {
                 Capture::Exit((ExitReason::Revert(_e), None, data)) => {
                     if data.len() >= 4 && data[0..4] == [8, 195, 121, 160] {
@@ -1289,7 +1288,6 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                             .into_bytes()
                             .expect("Can never fail because it is bytes");
                         if decoded_data == *expected_revert {
-                            println!("was decoded data");
                             return Capture::Exit((
                                 ExitReason::Succeed(ExitSucceed::Returned),
                                 Some(Address::from_slice(

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -183,6 +183,13 @@ contract CheatCodes is DSTest {
         prank.bar(address(this));
     }
 
+    function testPrankConstructor() public {
+        PrankConstructor prank = new PrankConstructor(address(this));
+        address new_sender = address(1337);
+        hevm.prank(new_sender);
+        PrankConstructor prank2 = new PrankConstructor(address(1337));
+    }
+
     function testPrankStart() public {
         Prank prank = new Prank();
         address new_sender = address(1337);
@@ -237,6 +244,11 @@ contract CheatCodes is DSTest {
         hevm.expectRevert("Value too large");
         target.stringErr(101);
         target.stringErr(99);
+    }
+
+    function testExpectRevertConstructor() public {
+        hevm.expectRevert("Value too large Constructor");
+        ExpectRevertConstructor target = new ExpectRevertConstructor(101);
     }
 
     function testExpectRevertBuiltin() public {
@@ -414,6 +426,16 @@ contract ExpectRevert {
     }
 }
 
+contract ExpectRevertConstructor {
+    constructor(uint256 a) {
+        require(a < 100, "Value too large Constructor");
+    }
+
+    function a() public returns(uint256) {
+        return 1;
+    }
+}
+
 contract ExpectRevertCallee {
     function stringErr(uint256 a) public returns (uint256) {
         require(a < 100, "Value too largeCallee");
@@ -435,6 +457,12 @@ contract Prank {
 
     function payableBar(address expectedMsgSender) payable public {
         bar(expectedMsgSender);
+    }
+}
+
+contract PrankConstructor {
+    constructor(address expectedMsgSender) {
+        require(msg.sender == expectedMsgSender, "bad prank");
     }
 }
 

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -184,10 +184,10 @@ contract CheatCodes is DSTest {
     }
 
     function testPrankConstructor() public {
-        PrankConstructor prank = new PrankConstructor(address(this));
         address new_sender = address(1337);
         hevm.prank(new_sender);
         PrankConstructor prank2 = new PrankConstructor(address(1337));
+        PrankConstructor prank3 = new PrankConstructor(address(this));
     }
 
     function testPrankStart() public {
@@ -249,6 +249,7 @@ contract CheatCodes is DSTest {
     function testExpectRevertConstructor() public {
         hevm.expectRevert("Value too large Constructor");
         ExpectRevertConstructor target = new ExpectRevertConstructor(101);
+        ExpectRevertConstructor target2 = new ExpectRevertConstructor(99);
     }
 
     function testExpectRevertBuiltin() public {
@@ -463,6 +464,12 @@ contract Prank {
 contract PrankConstructor {
     constructor(address expectedMsgSender) {
         require(msg.sender == expectedMsgSender, "bad prank");
+    }
+
+    function bar(address expectedMsgSender) public {
+        require(msg.sender == expectedMsgSender, "bad prank");
+        InnerPrank inner = new InnerPrank();
+        inner.bar(address(this));
     }
 }
 


### PR DESCRIPTION
We weren't handling prepare -> create cheatcodes. This now matches the prepare -> call cheatcodes functionality

fixes https://github.com/gakonst/foundry/issues/362