### PR TITLE
feat(cast): add --flashbots to use flashbots rpc url

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -160,12 +160,11 @@ async fn main() -> eyre::Result<()> {
             println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
         Subcommands::SendTx { eth, to, sig, cast_async, flashbots, args } => {
-            let provider;
-            if flashbots {
-                provider = Provider::try_from(FLASHBOTS_URL)?;
+            let provider = if flashbots {
+                Provider::try_from(FLASHBOTS_URL)?
             } else {
-                provider = Provider::try_from(eth.rpc_url.as_str())?;
-            }
+                Provider::try_from(eth.rpc_url.as_str())?
+            };
             let chain_id = Cast::new(&provider).chain_id().await?;
 
             if let Some(signer) = eth.signer_with(chain_id, provider.clone()).await? {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -32,6 +32,8 @@ use structopt::StructOpt;
 
 use crate::utils::read_secret;
 
+const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
+
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     color_eyre::install()?;
@@ -157,8 +159,13 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
-        Subcommands::SendTx { eth, to, sig, cast_async, args } => {
-            let provider = Provider::try_from(eth.rpc_url.as_str())?;
+        Subcommands::SendTx { eth, to, sig, cast_async, flashbots, args } => {
+            let provider;
+            if flashbots {
+                provider = Provider::try_from(FLASHBOTS_URL)?;
+            } else {
+                provider = Provider::try_from(eth.rpc_url.as_str())?;
+            }
             let chain_id = Cast::new(&provider).chain_id().await?;
 
             if let Some(signer) = eth.signer_with(chain_id, provider.clone()).await? {

--- a/cli/src/cmd/create.rs
+++ b/cli/src/cmd/create.rs
@@ -42,7 +42,7 @@ impl Cmd for CreateArgs {
         let (abi, bin, _) = super::read_artifact(&project, compiled, self.contract.clone())?;
 
         // Add arguments to constructor
-        let provider = Provider::<Http>::try_from(self.eth.rpc_url.as_str())?;
+        let provider = Provider::<Http>::try_from(self.eth.rpc_url()?)?;
         let params = match abi.constructor {
             Some(ref v) => self.parse_constructor_args(v)?,
             None => vec![],

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -139,6 +139,8 @@ pub enum Subcommands {
         cast_async: bool,
         #[structopt(flatten)]
         eth: EthereumOpts,
+        #[structopt(long, help="use the flashbots RPC URL")]
+        flashbots: bool,
     },
     #[structopt(name = "estimate")]
     #[structopt(about = "Estimate the gas cost of a transaction from <from> to <to> with <data>")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -139,8 +139,6 @@ pub enum Subcommands {
         cast_async: bool,
         #[structopt(flatten)]
         eth: EthereumOpts,
-        #[structopt(long, help="use the flashbots RPC URL")]
-        flashbots: bool,
     },
     #[structopt(name = "estimate")]
     #[structopt(about = "Estimate the gas cost of a transaction from <from> to <to> with <data>")]

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -15,22 +15,27 @@ use ethers::{
 use eyre::Result;
 use structopt::StructOpt;
 
+const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
+
 #[derive(StructOpt, Debug, Clone)]
 pub struct EthereumOpts {
     #[structopt(env = "ETH_RPC_URL", long = "rpc-url", help = "The tracing / archival node's URL")]
-    pub rpc_url: String,
+    pub rpc_url: Option<String>,
 
     #[structopt(env = "ETH_FROM", short, long = "from", help = "The sender account")]
     pub from: Option<Address>,
 
     #[structopt(flatten)]
     pub wallet: Wallet,
+
+    #[structopt(long, help="Use the flashbots RPC URL")]
+    pub flashbots: bool,
 }
 
 impl EthereumOpts {
     #[allow(unused)]
     pub async fn signer(&self, chain_id: U256) -> eyre::Result<Option<WalletType>> {
-        self.signer_with(chain_id, Provider::try_from(self.rpc_url.as_str())?).await
+        self.signer_with(chain_id, Provider::try_from(self.rpc_url()?)?).await
     }
 
     /// Returns a [`SignerMiddleware`] corresponding to the provided private key, mnemonic or hw
@@ -72,6 +77,14 @@ impl EthereumOpts {
             let local = local.with_chain_id(chain_id.as_u64());
 
             Ok(Some(WalletType::Local(SignerMiddleware::new(provider, local))))
+        }
+    }
+
+    pub fn rpc_url(&self) -> Result<&str> {
+        if self.flashbots {
+            Ok(FLASHBOTS_URL)
+        } else {
+            self.rpc_url.as_deref().ok_or_else(|| eyre::Error::msg("no Ethereum RPC provided, maybe you forgot to set the --rpc-url or the ETH_RPC_URL parameter? Alternatively, consider using the --flashbots flag to get frontrunning protection"))
         }
     }
 }

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -28,7 +28,7 @@ pub struct EthereumOpts {
     #[structopt(flatten)]
     pub wallet: Wallet,
 
-    #[structopt(long, help = "Use the flashbots RPC URL")]
+    #[structopt(long, help = "Use the flashbots RPC URL (https://rpc.flashbots.net)")]
     pub flashbots: bool,
 }
 

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -28,7 +28,7 @@ pub struct EthereumOpts {
     #[structopt(flatten)]
     pub wallet: Wallet,
 
-    #[structopt(long, help="Use the flashbots RPC URL")]
+    #[structopt(long, help = "Use the flashbots RPC URL")]
     pub flashbots: bool,
 }
 


### PR DESCRIPTION
Saw this so I thought I'd give it a shot: https://twitter.com/gakonst/status/1478463108100366339.

Sadly, I am missing something with how `structopt` works, since the output is messed up:

```
cast-send 0.1.0
The wallet options can either be: 1. Ledger 2. Trezor 3. Mnemonic (via file path) 4. Keystore (via file path) 5. Private
Key (cleartext in CLI) 6. Private Key (interactively via secure prompt)

USAGE:
    cast send [FLAGS] [OPTIONS] <to> <sig> --rpc-url <rpc-url> [args]...

FLAGS:
        --flashbots      use the flashbots RPC URL
    -h, --help           Prints help information
    -i, --interactive    Interactive prompt to insert your private key
```

If you have any thoughts let me know, figured I'd push this up while I try to figure it out.

EDIT: I had a stale cast binary when I started, just bisected and the bad output ("The wallet options can either be...") is from: [0cc47662aab7ba4475996c141b9e1d8e64df84f4](https://github.com/gakonst/foundry/commit/0cc47662aab7ba4475996c141b9e1d8e64df84f4) (which I probably should have figured out from the text 🤦‍♂️).

~Still confused by structopt (how does it determine FLAGS vs OPTIONS? Why is the Wallet docstring populating the send description? etc.)~
