### PR TITLE
fix(cast): use correct description for send

### DIFF
--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -84,13 +84,16 @@ pub enum WalletType {
 }
 
 #[derive(StructOpt, Debug, Clone)]
-/// The wallet options can either be:
-/// 1. Ledger
-/// 2. Trezor
-/// 3. Mnemonic (via file path)
-/// 4. Keystore (via file path)
-/// 5. Private Key (cleartext in CLI)
-/// 6. Private Key (interactively via secure prompt)
+#[cfg_attr(not(doc), allow(missing_docs))]
+#[cfg_attr(doc, doc = r#"
+The wallet options can either be:
+1. Ledger
+2. Trezor
+3. Mnemonic (via file path)
+4. Keystore (via file path)
+5. Private Key (cleartext in CLI)
+6. Private Key (interactively via secure prompt)
+"#)]
 pub struct Wallet {
     #[structopt(long, short, help = "Interactive prompt to insert your private key")]
     pub interactive: bool,


### PR DESCRIPTION
The CLI description for send is incorrect, it's [the docstring for the Wallet struct](https://github.com/gakonst/foundry/blob/3e8c9979e2b8836fccdb16e10be9a21862a9c81a/cli/src/opts/mod.rs#L87). You can see this by running `cast help send`.

I thought https://github.com/gakonst/foundry/pull/369 introduced the issue, but it seems that there is an [open bug](https://github.com/TeXitoi/structopt/issues/333) in `structopt` that [0cc47662aab7ba4475996c141b9e1d8e64df84f4](https://github.com/gakonst/foundry/commit/0cc47662aab7ba4475996c141b9e1d8e64df84f4) ran into.

This PR implements the [workaround](https://github.com/TeXitoi/structopt/issues/333#issuecomment-712265332) from that issue. If this isn't a good solution, it looks like there might also be a way around by using `clap` directly to override `app.about` after it's set incorrectly (based on the generated output).