### PR TITLE
[Bug] Hardhat console does not log ints

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1334,6 +1334,7 @@ mod tests {
         let expected = [
             "String",
             "1337",
+            "-20",
             "1245",
             "true"
         ]

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1321,6 +1321,29 @@ mod tests {
     }
 
     #[test]
+    fn console_logs_types() {
+        let mut evm = vm();
+
+        let compiled = COMPILED.find("ConsoleLogs").expect("could not find contract");
+        let (addr, _, _, _) =
+            evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
+
+        // after the evm call is done, we call `logs` and print it all to the user
+        let (_, _, _, logs) =
+            evm.call::<(), _, _>(Address::zero(), addr, "test_log_types()", (), 0.into()).unwrap();
+        let expected = [
+            "String",
+            "1337",
+            "1245",
+            "true"
+        ]
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+        assert_eq!(logs, expected);
+    }
+
+    #[test]
     fn logs_external_contract() {
         let mut evm = vm();
 

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -540,7 +540,7 @@ pub static HARDHAT_CONSOLE_SELECTOR_PATCHES: Lazy<HashMap<Selector, Selector>> =
         ([211, 42, 101, 72], [245, 188, 34, 73]),
         // log(uint256,uint256)
         ([108, 15, 105, 128], [246, 102, 113, 90]),
-        // log(uint256)
+        // log(uint256) and logUint(uint256)
         ([245, 177, 187, 169], [248, 44, 80, 241]),
         // log(string,address,uint256,uint256)
         ([218, 163, 148, 189], [248, 245, 27, 30]),
@@ -553,9 +553,7 @@ pub static HARDHAT_CONSOLE_SELECTOR_PATCHES: Lazy<HashMap<Selector, Selector>> =
         // log(bool,uint256,string,address)
         ([165, 199, 13, 41], [254, 221, 31, 255]),
         // logInt(int256)
-        ([78, 12, 29, 29], [101, 37, 181, 245]),
-        // logUint(uint256)
-        ([226, 35, 89, 127], [153, 5, 183, 68]),
+        ([78, 12, 29, 29], [101, 37, 181, 245])
     ])
 });
 

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -553,7 +553,7 @@ pub static HARDHAT_CONSOLE_SELECTOR_PATCHES: Lazy<HashMap<Selector, Selector>> =
         // log(bool,uint256,string,address)
         ([165, 199, 13, 41], [254, 221, 31, 255]),
         // logInt(int256)
-        ([155, 94, 97, 79], [101, 37, 181, 245]),
+        ([78, 12, 29, 29], [101, 37, 181, 245]),
         // logUint(uint256)
         ([226, 35, 89, 127], [153, 5, 183, 68]),
     ])

--- a/evm-adapters/testdata/ConsoleLogs.sol
+++ b/evm-adapters/testdata/ConsoleLogs.sol
@@ -15,6 +15,7 @@ contract ConsoleLogs {
 	function test_log_types() public {
 		console.logString("String");
 		console.logInt(1337);
+		console.logInt(-20);
 		console.logUint(1245);
 		console.logBool(true);
 	}

--- a/evm-adapters/testdata/ConsoleLogs.sol
+++ b/evm-adapters/testdata/ConsoleLogs.sol
@@ -11,4 +11,11 @@ contract ConsoleLogs {
 		console.log(1337, 1245);
 		console.log("Hi", 1337);
     }
+
+	function test_log_types() public {
+		console.logString("String");
+		console.logInt(1337);
+		console.logUint(1245);
+		console.logBool(true);
+	}
 }


### PR DESCRIPTION
`console.logInt` is not currently working. This test fails with:

 ```
 left: `["String", "1245", "true"]`,
 right: `["String", "1337", "1245", "true"]`
```