### PR TITLE
feat(forge): use from_occurences for verbosity

### DIFF
--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -159,7 +159,16 @@ pub struct EvmOpts {
     #[structopt(help = "enables the FFI cheatcode", long)]
     pub ffi: bool,
 
-    #[structopt(help = "verbosity of EVM output (0-3)", long, default_value = "0")]
+    #[structopt(
+        help = r#"Verbosity mode of EVM output as number of occurences of the `v` flag (-v, -vv, -vvv, etc.)
+    3: print test trace for failing tests
+    4: always print test trace, print setup for failing tests
+    5: always print test trace and setup
+"#,
+        long,
+        short,
+        parse(from_occurrences)
+    )]
     pub verbosity: u8,
 }
 


### PR DESCRIPTION
Ref #338 cc @wilsoncusack 

I tried to enable `from_occurrences` mode, however this mutually excludes `--verbosity <num>` which is a breaking change

personally, I'd prefer `-vvv` over `--verbosity 3`

maybe we can reduce the levels so that we start with what's now 3, and `-vvv` would be the highest verbosity mode @brockelmore @gakonst 