### PR TITLE
fix(forge): fuzz state reset

### DIFF
--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -85,7 +85,9 @@ pub enum WalletType {
 
 #[derive(StructOpt, Debug, Clone)]
 #[cfg_attr(not(doc), allow(missing_docs))]
-#[cfg_attr(doc, doc = r#"
+#[cfg_attr(
+    doc,
+    doc = r#"
 The wallet options can either be:
 1. Ledger
 2. Trezor
@@ -93,7 +95,8 @@ The wallet options can either be:
 4. Keystore (via file path)
 5. Private Key (cleartext in CLI)
 6. Private Key (interactively via secure prompt)
-"#)]
+"#
+)]
 pub struct Wallet {
     #[structopt(long, short, help = "Interactive prompt to insert your private key")]
     pub interactive: bool,

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -50,6 +50,7 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
         func: &Function,
         address: Address,
         should_fail: bool,
+        init_state: &S,
     ) -> FuzzTestResult<E::ReturnReason>
     where
         // We need to be able to clone the state so as to snapshot it and reset
@@ -58,9 +59,6 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
         S: Clone,
     {
         let strat = fuzz_calldata(func);
-
-        // Snapshot the state before the test starts running
-        let pre_test_state = self.evm.borrow().state().clone();
 
         // stores the consumed gas and calldata of every successful fuzz call
         let fuzz_cases: RefCell<Vec<FuzzCase>> = RefCell::new(Default::default());
@@ -76,7 +74,7 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
             .run(&strat, |calldata| {
                 let mut evm = self.evm.borrow_mut();
                 // Before each test, we must reset to the initial state
-                evm.reset(pre_test_state.clone());
+                evm.reset(init_state.clone());
 
                 let (returndata, reason, gas, _) = evm
                     .call_raw(self.sender, address, calldata.clone(), 0.into(), false)
@@ -315,10 +313,11 @@ mod tests {
         let (addr, _, _, _) =
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
+        let init_state = evm.state().clone();
         let evm = fuzzvm(&mut evm);
 
         let func = compiled.abi.unwrap().function("testFuzzedRevert").unwrap();
-        let res = evm.fuzz(&func, addr, false);
+        let res = evm.fuzz(&func, addr, false, init_state);
         let error = res.test_error.unwrap();
         let revert_reason = error.revert_reason;
         assert_eq!(revert_reason, "fuzztest-revert");

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -317,7 +317,7 @@ mod tests {
         let evm = fuzzvm(&mut evm);
 
         let func = compiled.abi.unwrap().function("testFuzzedRevert").unwrap();
-        let res = evm.fuzz(&func, addr, false, init_state);
+        let res = evm.fuzz(&func, addr, false, &init_state);
         let error = res.test_error.unwrap();
         let revert_reason = error.revert_reason;
         assert_eq!(revert_reason, "fuzztest-revert");

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1360,6 +1360,7 @@ mod tests {
             .unwrap();
         assert_eq!(slot, 10.into());
 
+        let init_state = evm.state().clone();
         let evm = FuzzedExecutor::new(&mut evm, runner, Address::zero());
 
         let abi = compiled.abi.as_ref().unwrap();
@@ -1375,7 +1376,7 @@ mod tests {
                     evm.as_mut().call_unchecked(Address::zero(), addr, func, (), 0.into()).unwrap();
                 assert!(evm.as_mut().check_success(addr, &reason, should_fail));
             } else {
-                assert!(evm.fuzz(func, addr, should_fail).is_ok());
+                assert!(evm.fuzz(func, addr, should_fail, &init_state).is_ok());
             }
 
             evm.as_mut().reset(state.clone());


### PR DESCRIPTION
we weren't using the correct init state for fuzz tests