### PR TITLE
Use dunce::canonicalize instead of std canonicalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,7 @@ dependencies = [
  "ansi_term",
  "cast",
  "color-eyre",
+ "dunce",
  "ethers",
  "evm",
  "evm-adapters",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ foundry-utils = { path = "../utils" }
 forge = { path = "../forge" }
 cast = { path = "../cast" }
 evm-adapters = { path = "../evm-adapters" }
-
+dunce = "1.0.2"
 # ethers = "0.5"
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 eyre = "0.6.5"

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -296,7 +296,7 @@ async fn main() -> eyre::Result<()> {
                         let address = SimpleCast::checksum_address(&key.address())?;
                         let filepath = format!(
                             "{}/{}",
-                            std::fs::canonicalize(path)?
+                            dunce::canonicalize(path)?
                                 .into_os_string()
                                 .into_string()
                                 .expect("failed to canonicalize file path"),

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -139,7 +139,7 @@ impl BuildArgs {
         let root = self.root.clone().unwrap_or_else(|| {
             utils::find_git_root_path().unwrap_or_else(|_| std::env::current_dir().unwrap())
         });
-        let root = std::fs::canonicalize(&root)?;
+        let root = dunce::canonicalize(&root)?;
 
         // 2. Set the contracts dir
         let contracts = self.contracts_path(&root);

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -123,7 +123,7 @@ fn get_artifact_from_path(
     name: String,
 ) -> eyre::Result<(Abi, BytecodeObject, BytecodeObject)> {
     // Get sources from the requested location
-    let abs_path = std::fs::canonicalize(PathBuf::from(path))?;
+    let abs_path = dunce::canonicalize(PathBuf::from(path))?;
     let mut sources = Sources::new();
     sources.insert(abs_path.clone(), Source::read(&abs_path)?);
 

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -54,7 +54,7 @@ fn main() -> eyre::Result<()> {
         }
         Subcommands::Remappings { lib_paths, root } => {
             let root = root.unwrap_or_else(|| std::env::current_dir().unwrap());
-            let root = std::fs::canonicalize(root)?;
+            let root = dunce::canonicalize(root)?;
 
             let lib_paths = if lib_paths.is_empty() { vec![root.join("lib")] } else { lib_paths };
             let remappings: Vec<_> = lib_paths.iter().flat_map(Remapping::find_many).collect();
@@ -66,7 +66,7 @@ fn main() -> eyre::Result<()> {
             if !root.exists() {
                 std::fs::create_dir_all(&root)?;
             }
-            let root = std::fs::canonicalize(root)?;
+            let root = dunce::canonicalize(root)?;
 
             // if a template is provided, then this command is just an alias to `git clone <url>
             // <path>`


### PR DESCRIPTION
Fixes both https://github.com/gakonst/foundry/issues/378 and https://github.com/gakonst/foundry/issues/360

It changes the output mapping from:

```sh
$ forge remappings
ds-test/=\\?\C:\Users\foo Bar\Projects\zerosnacks\foobar\lib\ds-test\src/
```

to:

```sh
$ forge remappings
ds-test/=C:\Users\foo Bar\Projects\zerosnacks\foobar\lib\ds-test\src/
```

allowing the automatic remapping to work correctly.