### PR TITLE
Add note that `remappings.txt` option exists to override automatic remappings

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -89,6 +89,8 @@ you can do it with the `--remappings` flag like below:
 $ forge build --remappings @openzeppelin/=node_modules/@openzeppelin/
 ```
 
+Alternatively you could provide a `remappings.txt` file in the project root.
+
 Most of the arguments can also be provided via environment variables, which you
 can find by looking for the `env` tooltip in the command's help menu
 (`forge build --help`).

--- a/cli/README.md
+++ b/cli/README.md
@@ -89,7 +89,22 @@ you can do it with the `--remappings` flag like below:
 $ forge build --remappings @openzeppelin/=node_modules/@openzeppelin/
 ```
 
-Alternatively you could provide a `remappings.txt` file in the project root.
+Alternatively you could provide a `remappings.txt` file in the project root
+containing a line separated list of your package names and the path to them. For
+example:
+
+```bash
+$ cat remappings.txt
+ds-test=lib/ds-test/src
+@openzeppelin=node_modules/openzeppelin-contracts/contracts
+```
+
+This then allows you to import the dependencies in your Solidity code like:
+
+```solidity
+import "ds-test/...";
+import "@openzeppelin/...";
+```
 
 Most of the arguments can also be provided via environment variables, which you
 can find by looking for the `env` tooltip in the command's help menu


### PR DESCRIPTION
It is quite common to have a `remappings.txt` file in DappTools projects but this always required some extra bash scripting to work.

An example can be found here: https://github.com/gakonst/dapptools-template/blob/master/remappings.txt