### PR TITLE
Revert "fix(forge): fuzz state reset"

### DIFF
--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -85,7 +85,9 @@ pub enum WalletType {
 
 #[derive(StructOpt, Debug, Clone)]
 #[cfg_attr(not(doc), allow(missing_docs))]
-#[cfg_attr(doc, doc = r#"
+#[cfg_attr(
+    doc,
+    doc = r#"
 The wallet options can either be:
 1. Ledger
 2. Trezor
@@ -93,7 +95,8 @@ The wallet options can either be:
 4. Keystore (via file path)
 5. Private Key (cleartext in CLI)
 6. Private Key (interactively via secure prompt)
-"#)]
+"#
+)]
 pub struct Wallet {
     #[structopt(long, short, help = "Interactive prompt to insert your private key")]
     pub interactive: bool,

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -85,9 +85,7 @@ pub enum WalletType {
 
 #[derive(StructOpt, Debug, Clone)]
 #[cfg_attr(not(doc), allow(missing_docs))]
-#[cfg_attr(
-    doc,
-    doc = r#"
+#[cfg_attr(doc, doc = r#"
 The wallet options can either be:
 1. Ledger
 2. Trezor
@@ -95,8 +93,7 @@ The wallet options can either be:
 4. Keystore (via file path)
 5. Private Key (cleartext in CLI)
 6. Private Key (interactively via secure prompt)
-"#
-)]
+"#)]
 pub struct Wallet {
     #[structopt(long, short, help = "Interactive prompt to insert your private key")]
     pub interactive: bool,

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1378,7 +1378,6 @@ mod tests {
             .unwrap();
         assert_eq!(slot, 10.into());
 
-        let init_state = evm.state().clone();
         let evm = FuzzedExecutor::new(&mut evm, runner, Address::zero());
 
         let abi = compiled.abi.as_ref().unwrap();
@@ -1394,7 +1393,7 @@ mod tests {
                     evm.as_mut().call_unchecked(Address::zero(), addr, func, (), 0.into()).unwrap();
                 assert!(evm.as_mut().check_success(addr, &reason, should_fail));
             } else {
-                assert!(evm.fuzz(func, addr, should_fail, &init_state).is_ok());
+                assert!(evm.fuzz(func, addr, should_fail).is_ok());
             }
 
             evm.as_mut().reset(state.clone());


### PR DESCRIPTION
Reverts gakonst/foundry#377

Turns out the Solmate test failure was a false positive. The issue is in dapptools, which doesn't test for 0-length arrays. Forge tests for 0-length ones, which cause the Solmate test to fail (below we see the failing test case):

```solidity
  function testFailSafeBatchTransferInsufficientBalanceZeroLen() public {
        ERC1155User from = new ERC1155User(token);

        uint256[] memory ids = new uint256[](0);
        uint256[] memory mintAmounts = new uint256[](0);
        uint256[] memory transferAmounts = new uint256[](0);

        token.batchMint(address(from), ids, mintAmounts, "");

        from.setApprovalForAll(address(this), true);

        token.safeBatchTransferFrom(address(from), address(0xBEEF), ids, transferAmounts, "");
    }
```