### PR TITLE
Expand `forge test --match` interface

### DIFF
--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -11,7 +11,6 @@ use crate::{
 use ansi_term::Colour;
 use ethers::solc::{ArtifactOutput, Project};
 use forge::{MultiContractRunnerBuilder, TestFilter};
-use regex::Regex;
 use std::collections::BTreeMap;
 use structopt::{
     StructOpt,
@@ -52,7 +51,7 @@ pub struct Filter {
     contract_pattern_inverse: Option<regex::Regex>,
 }
 
-impl forge::TestFilter for Filter {
+impl TestFilter for Filter {
     fn matches_test(&self, test_name: &str) -> bool {
         let mut ok = true;
         // Handle the deprecated option match

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -13,9 +13,48 @@ use ethers::solc::{ArtifactOutput, Project};
 use forge::MultiContractRunnerBuilder;
 use regex::Regex;
 use std::collections::BTreeMap;
-use structopt::StructOpt;
+use structopt::{
+    StructOpt,
+    clap::AppSettings
+};
 
 #[derive(Debug, Clone, StructOpt)]
+pub struct Filter {
+    #[structopt(
+        long = "--match",
+        short = "-m",
+        help = "only run test methods matching regex (deprecated, see --match-test, --match-contract)",
+    )]
+    pattern: Option<regex::Regex>,
+
+    #[structopt(
+        long = "--match-test",
+        help = "only run test methods matching regex",
+    )]
+    test_pattern: Option<regex::Regex>,
+
+    #[structopt(
+        long = "--no-match-test",
+        help = "only run test methods not matching regex",
+    )]
+    test_pattern_inverse: Option<regex::Regex>,
+
+    #[structopt(
+        long = "--match-contract",
+        help = "only run test methods in contracts matching regex",
+    )]
+    contract_pattern: Option<regex::Regex>,
+
+    #[structopt(
+        long = "--no-match-contract",
+        help = "only run test methods in contracts not matching regex",
+    )]
+    contract_pattern_inverse: Option<regex::Regex>,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+// This is required to group Filter options in help output
+#[structopt(global_settings = &[AppSettings::DeriveDisplayOrder])]
 pub struct TestArgs {
     #[structopt(help = "print the test results in json format", long, short)]
     json: bool,
@@ -23,13 +62,8 @@ pub struct TestArgs {
     #[structopt(flatten)]
     evm_opts: EvmOpts,
 
-    #[structopt(
-        long = "--match",
-        short = "-m",
-        help = "only run test methods matching regex",
-        default_value = ".*"
-    )]
-    pattern: regex::Regex,
+    #[structopt(flatten)]
+    filter: Filter,
 
     #[structopt(flatten)]
     opts: BuildArgs,

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -23,21 +23,31 @@ pub struct Filter {
     )]
     pattern: Option<regex::Regex>,
 
-    #[structopt(long = "--match-test", help = "only run test methods matching regex")]
+    #[structopt(
+        long = "--match-test",
+        help = "only run test methods matching regex",
+        conflicts_with = "pattern"
+    )]
     test_pattern: Option<regex::Regex>,
 
-    #[structopt(long = "--no-match-test", help = "only run test methods not matching regex")]
+    #[structopt(
+        long = "--no-match-test",
+        help = "only run test methods not matching regex",
+        conflicts_with = "pattern"
+    )]
     test_pattern_inverse: Option<regex::Regex>,
 
     #[structopt(
         long = "--match-contract",
-        help = "only run test methods in contracts matching regex"
+        help = "only run test methods in contracts matching regex",
+        conflicts_with = "pattern"
     )]
     contract_pattern: Option<regex::Regex>,
 
     #[structopt(
         long = "--no-match-contract",
-        help = "only run test methods in contracts not matching regex"
+        help = "only run test methods in contracts not matching regex",
+        conflicts_with = "pattern"
     )]
     contract_pattern_inverse: Option<regex::Regex>,
 }

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -12,41 +12,32 @@ use ansi_term::Colour;
 use ethers::solc::{ArtifactOutput, Project};
 use forge::{MultiContractRunnerBuilder, TestFilter};
 use std::collections::BTreeMap;
-use structopt::{
-    StructOpt,
-    clap::AppSettings
-};
+use structopt::{clap::AppSettings, StructOpt};
 
 #[derive(Debug, Clone, StructOpt)]
 pub struct Filter {
     #[structopt(
         long = "--match",
         short = "-m",
-        help = "only run test methods matching regex (deprecated, see --match-test, --match-contract)",
+        help = "only run test methods matching regex (deprecated, see --match-test, --match-contract)"
     )]
     pattern: Option<regex::Regex>,
 
-    #[structopt(
-        long = "--match-test",
-        help = "only run test methods matching regex",
-    )]
+    #[structopt(long = "--match-test", help = "only run test methods matching regex")]
     test_pattern: Option<regex::Regex>,
 
-    #[structopt(
-        long = "--no-match-test",
-        help = "only run test methods not matching regex",
-    )]
+    #[structopt(long = "--no-match-test", help = "only run test methods not matching regex")]
     test_pattern_inverse: Option<regex::Regex>,
 
     #[structopt(
         long = "--match-contract",
-        help = "only run test methods in contracts matching regex",
+        help = "only run test methods in contracts matching regex"
     )]
     contract_pattern: Option<regex::Regex>,
 
     #[structopt(
         long = "--no-match-contract",
-        help = "only run test methods in contracts not matching regex",
+        help = "only run test methods in contracts not matching regex"
     )]
     contract_pattern_inverse: Option<regex::Regex>,
 }

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -4,6 +4,11 @@ pub use runner::{ContractRunner, TestKind, TestKindGas, TestResult};
 mod multi_runner;
 pub use multi_runner::{MultiContractRunner, MultiContractRunnerBuilder};
 
+pub trait TestFilter {
+    fn matches_test(&self, test_name: &str) -> bool;
+    fn matches_contract(&self, contract_name: &str) -> bool;
+}
+
 #[cfg(test)]
 pub mod test_helpers {
     use ethers::{

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -11,10 +11,12 @@ pub trait TestFilter {
 
 #[cfg(test)]
 pub mod test_helpers {
+    use super::*;
     use ethers::{
         prelude::Lazy,
         solc::{CompilerOutput, Project, ProjectPathsConfig},
     };
+    use regex::Regex;
 
     pub static COMPILED: Lazy<CompilerOutput> = Lazy::new(|| {
         // NB: should we add a test-helper function that makes creating these
@@ -24,4 +26,28 @@ pub mod test_helpers {
         let project = Project::builder().paths(paths).ephemeral().no_artifacts().build().unwrap();
         project.compile().unwrap().output()
     });
+
+    pub struct Filter {
+        test_regex: Regex,
+        contract_regex: Regex,
+    }
+
+    impl Filter {
+        pub fn new(test_pattern: &str, contract_pattern: &str) -> Self {
+            return Filter {
+                test_regex: Regex::new(test_pattern).unwrap(),
+                contract_regex: Regex::new(contract_pattern).unwrap(),
+            }
+        }
+    }
+
+    impl TestFilter for Filter {
+        fn matches_test(&self, test_name: &str) -> bool {
+            self.test_regex.is_match(test_name)
+        }
+
+        fn matches_contract(&self, contract_name: &str) -> bool {
+            self.contract_regex.is_match(contract_name)
+        }
+    }
 }

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -187,6 +187,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::Filter;
     use ethers::solc::ProjectPathsConfig;
     use std::path::PathBuf;
 
@@ -212,7 +213,7 @@ mod tests {
 
     fn test_multi_runner<S: Clone, E: Evm<S>>(evm: E) {
         let mut runner = runner(evm);
-        let results = runner.test(Regex::new(".*").unwrap()).unwrap();
+        let results = runner.test(&Filter::new(".*", ".*")).unwrap();
 
         // 6 contracts being built
         assert_eq!(results.keys().len(), 5);
@@ -222,7 +223,7 @@ mod tests {
         }
 
         // can also filter
-        let only_gm = runner.test(Regex::new("testGm.*").unwrap()).unwrap();
+        let only_gm = runner.test(&Filter::new("testGm.*", ".*")).unwrap();
         assert_eq!(only_gm.len(), 1);
 
         assert_eq!(only_gm["GmTest"].len(), 1);
@@ -239,7 +240,7 @@ mod tests {
             let evm = vm();
 
             let mut runner = runner(evm);
-            let results = runner.test(Regex::new(".*").unwrap()).unwrap();
+            let results = runner.test(&Filter::new(".*", ".*")).unwrap();
 
             let reasons = results["DebugLogsTest"]
                 .iter()

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -1,8 +1,4 @@
-use crate::{
-    runner::TestResult,
-    ContractRunner,
-    TestFilter,
-};
+use crate::{runner::TestResult, ContractRunner, TestFilter};
 
 use ethers::solc::Artifact;
 

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -1,3 +1,5 @@
+use crate::TestFilter;
+
 use ethers::{
     abi::{Abi, Function, Token},
     types::{Address, Bytes},
@@ -9,7 +11,6 @@ use evm_adapters::{
     Evm, EvmError,
 };
 use eyre::{Context, Result};
-use regex::Regex;
 use std::{collections::BTreeMap, fmt, marker::PhantomData, time::Instant};
 
 use proptest::test_runner::{TestError, TestRunner};
@@ -171,7 +172,7 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
     /// Runs all tests for a contract whose names match the provided regular expression
     pub fn run_tests(
         &mut self,
-        regex: &Regex,
+        filter: &impl TestFilter,
         fuzzer: Option<&mut TestRunner>,
         init_state: &S,
         known_contracts: Option<&BTreeMap<String, (Abi, Vec<u8>)>>,
@@ -184,7 +185,7 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
             .functions()
             .into_iter()
             .filter(|func| func.name.starts_with("test"))
-            .filter(|func| regex.is_match(&func.name))
+            .filter(|func| filter.matches_test(&func.name))
             .collect::<Vec<_>>();
 
         // run all unit tests

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -397,13 +397,11 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::COMPILED;
+    use crate::test_helpers::{Filter, COMPILED};
     use ethers::solc::artifacts::CompactContractRef;
     use evm_adapters::sputnik::helpers::vm;
 
     mod sputnik {
-        use std::str::FromStr;
-
         use foundry_utils::get_func;
         use proptest::test_runner::Config as FuzzConfig;
 
@@ -433,12 +431,7 @@ mod tests {
             cfg.failure_persistence = None;
             let mut fuzzer = TestRunner::new(cfg);
             let results = runner
-                .run_tests(
-                    &Regex::from_str("testGreeting").unwrap(),
-                    Some(&mut fuzzer),
-                    &init_state,
-                    None,
-                )
+                .run_tests(&Filter::new("testGreeting", ".*"), Some(&mut fuzzer), &init_state, None)
                 .unwrap();
             assert!(results["testGreeting()"].success);
             assert!(results["testGreeting(string)"].success);
@@ -462,12 +455,7 @@ mod tests {
             cfg.failure_persistence = None;
             let mut fuzzer = TestRunner::new(cfg);
             let results = runner
-                .run_tests(
-                    &Regex::from_str("testFuzz.*").unwrap(),
-                    Some(&mut fuzzer),
-                    &init_state,
-                    None,
-                )
+                .run_tests(&Filter::new("testFuzz.*", ".*"), Some(&mut fuzzer), &init_state, None)
                 .unwrap();
             for (_, res) in results {
                 assert!(!res.success);
@@ -566,7 +554,7 @@ mod tests {
         let mut runner =
             ContractRunner::new(&mut evm, compiled.abi.as_ref().unwrap(), addr, None, &[]);
 
-        let res = runner.run_tests(&".*".parse().unwrap(), None, &init_state, None).unwrap();
+        let res = runner.run_tests(&Filter::new(".*", ".*"), None, &init_state, None).unwrap();
         assert!(!res.is_empty());
         assert!(res.iter().all(|(_, result)| result.success));
     }


### PR DESCRIPTION
From issue: #227 

This PR deprecates `forge test --match` and expands the match interface to 

`--match-test`
`--no-match-test`
`--match-contract`
`--no-match-contract`

to allow for more granular test matching.

Internally, test runners have `Regex` replaced with `trait/impl TestFilter` to allow for custom matching logic in client code.

Conflicts have been added between `--match` and the new options to prevent mix/match of these. However, `--match` is effectively aliased to `--match-test` so there are no breaking changes.

Affected tests have been updated.

Any / all input welcome.