### PR TITLE
[Bug] Forge update not pulling upstream changes from submodules

### DIFF
--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -36,7 +36,7 @@ fn main() -> eyre::Result<()> {
         Subcommands::Update { lib } => {
             let mut cmd = Command::new("git");
 
-            cmd.args(&["submodule", "update", "--init", "--recursive"]);
+            cmd.args(&["submodule", "update", "--remote", "--init", "--recursive"]);
 
             // if a lib is specified, open it
             if let Some(lib) = lib {


### PR DESCRIPTION
Forge update is currently not pulling upstream changes from submodules. Adding the `--remote` flag fixes the issue. More info can be found in the [submodule documentation](https://git-scm.com/book/en/v2/Git-Tools-Submodules).

Tested with my on project and works as expected after the change 