### PR TITLE
feat(forge): Add fuzz tracing on fail and correct verbosity

### DIFF
--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -359,16 +359,13 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
 
         // instantiate the fuzzed evm in line
         let evm = FuzzedExecutor::new(self.evm, runner, self.sender);
-        println!("starting fuzz");
         let FuzzTestResult { cases, test_error } = evm.fuzz(func, self.address, should_fail);
 
-        println!("done fuzzing");
         let mut traces: Option<Vec<CallTraceArena>> = None;
         let mut identified_contracts: Option<BTreeMap<Address, (String, Abi)>> = None;
 
         if prev {
             if let Some(ref error) = test_error {
-                println!("generating trace for fuzz");
                 // we want traces for a failed fuzz
                 if let TestError::Fail(_reason, bytes) = &error.test_error {
                     let _ = self.evm.set_tracing_enabled(true);

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -285,39 +285,7 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
         let mut traces: Option<Vec<CallTraceArena>> = None;
         let mut identified_contracts: Option<BTreeMap<Address, (String, Abi)>> = None;
 
-        let evm_traces = self.evm.traces();
-        if !evm_traces.is_empty() && self.evm.tracing_enabled() {
-            let mut ident = BTreeMap::new();
-            // create an iter over the traces
-            let mut trace_iter = evm_traces.into_iter();
-            let mut temp_traces = Vec::new();
-            if setup {
-                // grab the setup trace if it exists
-                let setup = trace_iter.next().expect("no setup trace");
-                setup.update_identified(
-                    0,
-                    known_contracts.expect("traces enabled but no identified_contracts"),
-                    &mut ident,
-                    self.evm,
-                );
-                temp_traces.push(setup);
-            }
-            // grab the test trace
-            let test_trace = trace_iter.next().expect("no test trace");
-            test_trace.update_identified(
-                0,
-                known_contracts.expect("traces enabled but no identified_contracts"),
-                &mut ident,
-                self.evm,
-            );
-            temp_traces.push(test_trace);
-
-            // pass back the identified contracts and traces
-            identified_contracts = Some(ident);
-            traces = Some(temp_traces);
-        }
-
-        self.evm.reset_traces();
+        self.update_traces(&mut traces, &mut identified_contracts, known_contracts, setup);
 
         let success = self.evm.check_success(self.address, &status, should_fail);
         let duration = Instant::now().duration_since(start);
@@ -355,6 +323,8 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
             self.evm.setup(self.address)?;
         }
 
+        let mut logs = self.init_logs.to_vec();
+
         let prev = self.evm.set_tracing_enabled(false);
 
         // instantiate the fuzzed evm in line
@@ -364,53 +334,22 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
         let mut traces: Option<Vec<CallTraceArena>> = None;
         let mut identified_contracts: Option<BTreeMap<Address, (String, Abi)>> = None;
 
-        if prev {
-            if let Some(ref error) = test_error {
-                // we want traces for a failed fuzz
-                if let TestError::Fail(_reason, bytes) = &error.test_error {
+        if let Some(ref error) = test_error {
+            // we want traces for a failed fuzz
+            if let TestError::Fail(_reason, bytes) = &error.test_error {
+                if prev {
                     let _ = self.evm.set_tracing_enabled(true);
-                    let _ = self.evm.call_raw(
-                        self.sender,
-                        self.address,
-                        bytes.clone(),
-                        0.into(),
-                        false,
-                    );
-                    let evm_traces = self.evm.traces();
-                    if !evm_traces.is_empty() {
-                        let mut ident = BTreeMap::new();
-                        // create an iter over the traces
-                        let mut trace_iter = evm_traces.into_iter();
-                        let mut temp_traces = Vec::new();
-                        if setup {
-                            // grab the setup trace if it exists
-                            let setup = trace_iter.next().expect("no setup trace");
-                            setup.update_identified(
-                                0,
-                                known_contracts
-                                    .expect("traces enabled but no identified_contracts"),
-                                &mut ident,
-                                self.evm,
-                            );
-                            temp_traces.push(setup);
-                        }
-                        // grab the test trace
-                        let test_trace = trace_iter.next().expect("no test trace");
-                        test_trace.update_identified(
-                            0,
-                            known_contracts.expect("traces enabled but no identified_contracts"),
-                            &mut ident,
-                            self.evm,
-                        );
-                        temp_traces.push(test_trace);
-
-                        // pass back the identified contracts and traces
-                        identified_contracts = Some(ident);
-                        traces = Some(temp_traces);
-                    }
-
-                    self.evm.reset_traces();
                 }
+                let (_retdata, status, _gas, execution_logs) =
+                    self.evm.call_raw(self.sender, self.address, bytes.clone(), 0.into(), false)?;
+                if <E as evm_adapters::Evm<S>>::is_fail(&status) {
+                    logs.extend(execution_logs);
+                    // add reverted logs
+                    logs.extend(self.evm.all_logs());
+                } else {
+                    logs.extend(execution_logs);
+                }
+                self.update_traces(&mut traces, &mut identified_contracts, known_contracts, setup);
             }
         }
 
@@ -444,11 +383,52 @@ impl<'a, S: Clone, E: Evm<S>> ContractRunner<'a, S, E> {
             reason,
             gas_used: cases.median_gas(),
             counterexample,
-            logs: vec![],
+            logs,
             kind: TestKind::Fuzz(cases),
             traces,
             identified_contracts,
         })
+    }
+
+    fn update_traces(
+        &mut self,
+        traces: &mut Option<Vec<CallTraceArena>>,
+        identified_contracts: &mut Option<BTreeMap<Address, (String, Abi)>>,
+        known_contracts: Option<&BTreeMap<String, (Abi, Vec<u8>)>>,
+        setup: bool,
+    ) {
+        let evm_traces = self.evm.traces();
+        if !evm_traces.is_empty() && self.evm.tracing_enabled() {
+            let mut ident = BTreeMap::new();
+            // create an iter over the traces
+            let mut trace_iter = evm_traces.into_iter();
+            let mut temp_traces = Vec::new();
+            if setup {
+                // grab the setup trace if it exists
+                let setup = trace_iter.next().expect("no setup trace");
+                setup.update_identified(
+                    0,
+                    known_contracts.expect("traces enabled but no identified_contracts"),
+                    &mut ident,
+                    self.evm,
+                );
+                temp_traces.push(setup);
+            }
+            // grab the test trace
+            let test_trace = trace_iter.next().expect("no test trace");
+            test_trace.update_identified(
+                0,
+                known_contracts.expect("traces enabled but no identified_contracts"),
+                &mut ident,
+                self.evm,
+            );
+            temp_traces.push(test_trace);
+
+            // pass back the identified contracts and traces
+            *identified_contracts = Some(ident);
+            *traces = Some(temp_traces);
+        }
+        self.evm.reset_traces();
     }
 }
 


### PR DESCRIPTION
Closes #332 

Works by grabbed the failed counterexample bytes, enabling tracing, and doing a raw call. Tested against failing fuzz test in solmate