### PR TITLE
feat: `cast call` with ABI resolution and addressbook

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -45,7 +45,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    ///
+    /// 
     /// use cast::Cast;
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -45,7 +45,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    /// 
+    ///
     /// use cast::Cast;
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};
@@ -191,7 +191,10 @@ where
             NameOrAddress::Address(addr) => addr,
         };
 
-        let to = match to.into() {
+        // Queries the addressbook for the address if present.
+        let to = foundry_utils::resolve_addr(to, chain)?;
+
+        let to = match to {
             NameOrAddress::Name(ref ens_name) => self.provider.resolve_name(ens_name).await?,
             NameOrAddress::Address(addr) => addr,
         };

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -132,9 +132,20 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).block_number().await?);
         }
-        Subcommands::Call { rpc_url, address, sig, args } => {
-            let provider = Provider::try_from(rpc_url)?;
-            println!("{}", Cast::new(provider).call(address, &sig, args).await?);
+        Subcommands::Call { eth, address, sig, args } => {
+            let provider = Provider::try_from(eth.rpc_url()?)?;
+            println!(
+                "{}",
+                Cast::new(provider)
+                    .call(
+                        eth.sender().await,
+                        address,
+                        (&sig, args),
+                        eth.chain,
+                        eth.etherscan_api_key
+                    )
+                    .await?
+            );
         }
         Subcommands::Calldata { sig, args } => {
             println!("{}", SimpleCast::calldata(sig, &args)?);
@@ -158,7 +169,7 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
-        Subcommands::SendTx { eth, to, sig, cast_async, args, chain, etherscan_api_key } => {
+        Subcommands::SendTx { eth, to, sig, cast_async, args } => {
             let provider = Provider::try_from(eth.rpc_url()?)?;
             let chain_id = Cast::new(&provider).chain_id().await?;
 
@@ -170,8 +181,8 @@ async fn main() -> eyre::Result<()> {
                             signer.address(),
                             to,
                             (sig, args),
-                            chain,
-                            etherscan_api_key,
+                            eth.chain,
+                            eth.etherscan_api_key,
                             cast_async,
                         )
                         .await?;
@@ -182,8 +193,8 @@ async fn main() -> eyre::Result<()> {
                             signer.address(),
                             to,
                             (sig, args),
-                            chain,
-                            etherscan_api_key,
+                            eth.chain,
+                            eth.etherscan_api_key,
                             cast_async,
                         )
                         .await?;
@@ -194,8 +205,8 @@ async fn main() -> eyre::Result<()> {
                             signer.address(),
                             to,
                             (sig, args),
-                            chain,
-                            etherscan_api_key,
+                            eth.chain,
+                            eth.etherscan_api_key,
                             cast_async,
                         )
                         .await?;
@@ -203,25 +214,24 @@ async fn main() -> eyre::Result<()> {
                 }
             } else {
                 let from = eth.from.expect("No ETH_FROM or signer specified");
-                cast_send(provider, from, to, (sig, args), chain, etherscan_api_key, cast_async)
-                    .await?;
+                cast_send(
+                    provider,
+                    from,
+                    to,
+                    (sig, args),
+                    eth.chain,
+                    eth.etherscan_api_key,
+                    cast_async,
+                )
+                .await?;
             }
         }
-        Subcommands::Estimate { eth, to, sig, args, chain, etherscan_api_key } => {
+        Subcommands::Estimate { eth, to, sig, args } => {
             let provider = Provider::try_from(eth.rpc_url()?)?;
             let cast = Cast::new(&provider);
-            // chain id does not matter here, we're just trying to get the address
-            let from = if let Some(signer) = eth.signer(0.into()).await? {
-                match signer {
-                    WalletType::Ledger(signer) => signer.address(),
-                    WalletType::Local(signer) => signer.address(),
-                    WalletType::Trezor(signer) => signer.address(),
-                }
-            } else {
-                eth.from.expect("No ETH_FROM or signer specified")
-            };
+            let from = eth.sender().await;
             let gas = cast
-                .estimate(from, to, Some((sig.as_str(), args)), chain, etherscan_api_key)
+                .estimate(from, to, Some((sig.as_str(), args)), eth.chain, eth.etherscan_api_key)
                 .await?;
             println!("{}", gas);
         }
@@ -398,11 +408,14 @@ async fn main() -> eyre::Result<()> {
                 );
             }
             WalletSubcommands::Address { wallet } => {
+                // TODO: Figure out better way to get wallet only.
                 let wallet = EthereumOpts {
                     wallet,
                     from: None,
                     rpc_url: Some("http://localhost:8545".to_string()),
                     flashbots: false,
+                    chain: Chain::Mainnet,
+                    etherscan_api_key: None,
                 }
                 .signer(0.into())
                 .await?
@@ -416,11 +429,14 @@ async fn main() -> eyre::Result<()> {
                 println!("Address: {}", SimpleCast::checksum_address(&addr)?);
             }
             WalletSubcommands::Sign { message, wallet } => {
+                // TODO: Figure out better way to get wallet only.
                 let wallet = EthereumOpts {
                     wallet,
                     from: None,
                     rpc_url: Some("http://localhost:8545".to_string()),
                     flashbots: false,
+                    chain: Chain::Mainnet,
+                    etherscan_api_key: None,
                 }
                 .signer(0.into())
                 .await?

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -19,7 +19,6 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::{Address, Chain, NameOrAddress, Signature, U256},
 };
-use foundry_utils::resolve_addr;
 use rayon::prelude::*;
 use regex::RegexSet;
 use rustc_hex::ToHex;
@@ -501,7 +500,6 @@ where
     let sig = args.0;
     let params = args.1;
     let params = if !sig.is_empty() { Some((&sig[..], params)) } else { None };
-    let to = resolve_addr(to, chain)?;
     let pending_tx = cast.send(from, to, params, chain, etherscan_api_key).await?;
     let tx_hash = *pending_tx;
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use ethers::types::{Address, BlockId, BlockNumber, Chain, NameOrAddress, H256};
+use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256};
 use structopt::StructOpt;
 
 use super::{EthereumOpts, Wallet};
@@ -87,8 +87,8 @@ pub enum Subcommands {
         address: NameOrAddress,
         sig: String,
         args: Vec<String>,
-        #[structopt(long, env = "ETH_RPC_URL")]
-        rpc_url: String,
+        #[structopt(flatten)]
+        eth: EthereumOpts,
     },
     #[structopt(about = "Pack a signature and an argument list into hexadecimal calldata.")]
     Calldata {
@@ -137,10 +137,6 @@ pub enum Subcommands {
         args: Vec<String>,
         #[structopt(long, env = "CAST_ASYNC")]
         cast_async: bool,
-        #[structopt(long, env = "ETHERSCAN_API_KEY")]
-        etherscan_api_key: Option<String>,
-        #[structopt(long, env = "CHAIN", default_value = "mainnet")]
-        chain: Chain,
         #[structopt(flatten)]
         eth: EthereumOpts,
     },
@@ -153,10 +149,6 @@ pub enum Subcommands {
         sig: String,
         #[structopt(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
-        #[structopt(long, env = "ETHERSCAN_API_KEY")]
-        etherscan_api_key: Option<String>,
-        #[structopt(long, env = "CHAIN", default_value = "mainnet")]
-        chain: Chain,
         #[structopt(flatten)]
         eth: EthereumOpts,
     },


### PR DESCRIPTION
Using the addressbook from #397 , now we can do:

```
cast call dai totalSupply
8927554231883212873269706303
```

```
cast call dai balanceOf 0xd8da6bf26964af9d7eed9e03e53415d37aa96045`
2501000000000000000000
```

We can also compose with other commands:
```
cast call dai balanceOf `cast resolve-name vitalik.eth`
```

This requires 1) Setting the ETH_RPC_URL, 2) Setting the ETHERSCAN_API_KEY