### PR TITLE
feat: add etherscan-source to cast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "eyre",
  "foundry-utils",
  "hex",
+ "reqwest",
  "rustc-hex",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,12 +511,12 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.2.25",
  "ethers-core",
+ "ethers-etherscan",
  "ethers-providers",
  "ethers-signers",
  "eyre",
  "foundry-utils",
  "hex",
- "reqwest",
  "rustc-hex",
  "serde_json",
 ]

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -16,6 +16,7 @@ rustc-hex = "2.1.0"
 serde_json = "1.0.67"
 chrono = "0.2"
 hex = "0.4.3"
+reqwest = "0.11.8"
 
 [features]
 default = ["ledger", "trezor"]

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -11,12 +11,12 @@ foundry-utils = { path = "../utils" }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 eyre = "0.6.5"
 rustc-hex = "2.1.0"
 serde_json = "1.0.67"
 chrono = "0.2"
 hex = "0.4.3"
-reqwest = "0.11.8"
 
 [features]
 default = ["ledger", "trezor"]

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -866,7 +866,7 @@ impl SimpleCast {
     /// ```
     /// # use cast::SimpleCast as Cast;
     /// # use ethers_core::types::Chain;
-    /// 
+    ///
     /// # async fn foo() -> eyre::Result<()> {
     ///     assert_eq!(
     ///             "/*

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -12,7 +12,6 @@ use ethers_providers::{Middleware, PendingTransaction};
 use eyre::{Context, Result};
 use rustc_hex::{FromHexIter, ToHex};
 use std::str::FromStr;
-use reqwest;
 
 use foundry_utils::{encode_args, get_func, get_func_etherscan, to_table};
 
@@ -861,62 +860,68 @@ impl SimpleCast {
         Ok(format!("0x{}", calldata.to_hex::<String>()))
     }
 
-	/// Fetches source code of verified contracts from etherscan.
+    /// Fetches source code of verified contracts from etherscan.
     ///
     /// ```
     /// # use cast::SimpleCast as Cast;
     ///
     /// # fn main() -> eyre::Result<()> {
     ///     assert_eq!(
-	/// 		"{{\r\n  \"language\": \"Solidity\",\r\n  
-	/// 			\"sources\": {\r\n    \"Demo.sol\": {\r\n      
-	/// 			\"content\": \"pragma solidity ^0.8.6;\\r\\n\\r\\ncontract Demo {\\r\\n    
-	/// 			function foo() public pure returns(string memory) {\\r\\n        
-	/// 			return \\\"First contribution to Foundry!\\\";\\r\\n    }\\r\\n}\"\r\n    }\r\n  },\r\n  
-	/// 			\"settings\": {\r\n    \"optimizer\": {\r\n      \"enabled\": false,\r\n      \"runs\": 200\r\n    },
-	/// 			\r\n    \"outputSelection\": {\r\n      \"*\": {\r\n        \"*\": [\r\n          \"evm.bytecode\",\r\n          
-	/// 			\"evm.deployedBytecode\",\r\n          \"devdoc\",\r\n          \"userdoc\",\r\n          \"metadata\",\r\n          
-	/// 			\"abi\"\r\n        ]\r\n      }\r\n    }\r\n  }\r\n}}",
+    ///             "{{\r\n  \"language\": \"Solidity\",\r\n  
+    ///             \"sources\": {\r\n    \"Demo.sol\": {\r\n      
+    ///             \"content\": \"pragma solidity ^0.8.6;\\r\\n\\r\\ncontract Demo {\\r\\n    
+    ///             function foo() public pure returns(string memory) {\\r\\n        
+    ///             return \\\"First contribution to Foundry!\\\";\\r\\n    }\\r\\n}\"\r\n    }\r\n  },\r\n  
+    ///             \"settings\": {\r\n    \"optimizer\": {\r\n      \"enabled\": false,\r\n      \"runs\": 200\r\n    },
+    ///             \r\n    \"outputSelection\": {\r\n      \"*\": {\r\n        \"*\": [\r\n          \"evm.bytecode\",\r\n          
+    ///             \"evm.deployedBytecode\",\r\n          \"devdoc\",\r\n          \"userdoc\",\r\n          \"metadata\",\r\n          
+    ///             \"abi\"\r\n        ]\r\n      }\r\n    }\r\n  }\r\n}}",
     ///         Cast::etherscan_source(Chain::Ropsten, "0x6C3ecefeaE570BFb889d277e8207b18130d7FF2B", "etherscan-api-key").unwrap().as_str()
     ///     );
     /// #    Ok(())
     /// # }
     /// ```
-	pub async fn etherscan_source(
-		chain: Chain,
-		contract_address: String,
-		etherscan_api_key: String) -> Result<String> {
-			let base_url = match chain {
-								Chain::Mainnet => "https://api.etherscan.io/api?",
-								// Chain::Ropsten | Chain::Kovan | Chain::Rinkeby | Chain::Goerli => base_url = format!("https://api-{chain}.etherscan.io/api?", chain = chain.to_string().as_str()),
-								Chain::Ropsten => "https://api-ropsten.etherscan.io/api?",
-								Chain::Kovan => "https://api-kovan.etherscan.io/api?",
-								Chain::Rinkeby => "https://api-rinkeby.etherscan.io/api?",
-								Chain::Goerli => "https://api-goerli.etherscan.io/api?",
-								Chain::Polygon => "https://api.polygonscan.com/api?",
-								Chain::PolygonMumbai => "https://api-testnet.polygonscan.com/api?",
-								_ => return Err(eyre::eyre!("source fetching only works on mainnet, ropsten, kovan, rinkeby, goerli, polygon, and polygon-mumbai.")),
-							};
+    pub async fn etherscan_source(
+        chain: Chain,
+        contract_address: String,
+        etherscan_api_key: String,
+    ) -> Result<String> {
+        let base_url = match chain {
+                                Chain::Mainnet => "https://api.etherscan.io/api?",
+                                // Chain::Ropsten | Chain::Kovan | Chain::Rinkeby | Chain::Goerli => base_url = format!("https://api-{chain}.etherscan.io/api?", chain = chain.to_string().as_str()),
+                                Chain::Ropsten => "https://api-ropsten.etherscan.io/api?",
+                                Chain::Kovan => "https://api-kovan.etherscan.io/api?",
+                                Chain::Rinkeby => "https://api-rinkeby.etherscan.io/api?",
+                                Chain::Goerli => "https://api-goerli.etherscan.io/api?",
+                                Chain::Polygon => "https://api.polygonscan.com/api?",
+                                Chain::PolygonMumbai => "https://api-testnet.polygonscan.com/api?",
+                                _ => return Err(eyre::eyre!("source fetching only works on mainnet, ropsten, kovan, rinkeby, goerli, polygon, and polygon-mumbai.")),
+                            };
 
-			let url = format!("{base_url}module=contract&action=getsourcecode&address={addr}&apikey={api_key}",
-								base_url = base_url,
-								addr = contract_address,
-								api_key = etherscan_api_key);
+        let url = format!(
+            "{base_url}module=contract&action=getsourcecode&address={addr}&apikey={api_key}",
+            base_url = base_url,
+            addr = contract_address,
+            api_key = etherscan_api_key
+        );
 
-			let response = reqwest::get(&url).await?.text().await?;
-			let json: serde_json::Value = serde_json::from_str(&response)?;
+        let response = reqwest::get(&url).await?.text().await?;
+        let json: serde_json::Value = serde_json::from_str(&response)?;
 
-			if json["status"].as_str() == Some("0") {
-				return Err(eyre::eyre!("etherscan api returned error: {}", json["result"].as_str().unwrap()));
-			}
-			
-			// Don't know why this doesn't work
-			// if json["result"][0]["SourceCode"].to_string().is_empty() {
-			// 	return Err(eyre::eyre!("unverified contract"));
-			// }
+        if json["status"].as_str() == Some("0") {
+            return Err(eyre::eyre!(
+                "etherscan api returned error: {}",
+                json["result"].as_str().unwrap()
+            ))
+        }
 
-			Ok(json["result"][0]["SourceCode"].to_string())
-		}
+        // Don't know why this doesn't work
+        // if json["result"][0]["SourceCode"].to_string().is_empty() {
+        // 	return Err(eyre::eyre!("unverified contract"));
+        // }
+
+        Ok(json["result"][0]["SourceCode"].to_string())
+    }
 }
 
 fn strip_0x(s: &str) -> &str {

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -882,8 +882,8 @@ impl SimpleCast {
         contract_address: String,
         etherscan_api_key: String,
     ) -> Result<String> {
-        let client = Client::new(chain, etherscan_api_key).unwrap();
-        let meta = client.contract_source_code(contract_address.parse().unwrap()).await.unwrap();
+        let client = Client::new(chain, etherscan_api_key)?;
+        let meta = client.contract_source_code(contract_address.parse()?).await?;
         let code = meta.source_code();
 
         if code.is_empty() {

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -862,11 +862,25 @@ impl SimpleCast {
     }
 
 	pub async fn etherscan_source(
+		chain: Chain,
 		contract_address: &str,
 		etherscan_api_key: &str) -> Result<String> {
-			let url = format!("https://api.etherscan.io/api?module=contract&action=getsourcecode&address={contract_address}&apikey={api_key}",
-			contract_address = contract_address,
-						api_key = etherscan_api_key);
+			let base_url = match chain {
+								Chain::Mainnet => "https://api.etherscan.io/api?",
+								// Chain::Ropsten | Chain::Kovan | Chain::Rinkeby | Chain::Goerli => base_url = format!("https://api-{chain}.etherscan.io/api?", chain = chain.to_string().as_str()),
+								Chain::Ropsten => "https://api-ropsten.etherscan.io/api?",
+								Chain::Kovan => "https://api-kovan.etherscan.io/api?",
+								Chain::Rinkeby => "https://api-rinkeby.etherscan.io/api?",
+								Chain::Goerli => "https://api-goerli.etherscan.io/api?",
+								Chain::Polygon => "https://api.polygonscan.com/api?",
+								Chain::PolygonMumbai => "https://api-testnet.polygonscan.com/api?",
+								_ => panic!("Chain not supported"),
+							};
+
+			let url = format!("{base_url}module=contract&action=getsourcecode&address={addr}&apikey={api_key}",
+								base_url = base_url,
+								addr = contract_address,
+								api_key = etherscan_api_key);
 
 			let response = reqwest::get(&url).await?.text().await?;
 			let json: serde_json::Value = serde_json::from_str(&response)?;

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -868,7 +868,15 @@ impl SimpleCast {
     ///
     /// # fn main() -> eyre::Result<()> {
     ///     assert_eq!(
-	/// 		"{{\r\n  \"language\": \"Solidity\",\r\n...",
+	/// 		"{{\r\n  \"language\": \"Solidity\",\r\n  
+	/// 			\"sources\": {\r\n    \"Demo.sol\": {\r\n      
+	/// 			\"content\": \"pragma solidity ^0.8.6;\\r\\n\\r\\ncontract Demo {\\r\\n    
+	/// 			function foo() public pure returns(string memory) {\\r\\n        
+	/// 			return \\\"First contribution to Foundry!\\\";\\r\\n    }\\r\\n}\"\r\n    }\r\n  },\r\n  
+	/// 			\"settings\": {\r\n    \"optimizer\": {\r\n      \"enabled\": false,\r\n      \"runs\": 200\r\n    },
+	/// 			\r\n    \"outputSelection\": {\r\n      \"*\": {\r\n        \"*\": [\r\n          \"evm.bytecode\",\r\n          
+	/// 			\"evm.deployedBytecode\",\r\n          \"devdoc\",\r\n          \"userdoc\",\r\n          \"metadata\",\r\n          
+	/// 			\"abi\"\r\n        ]\r\n      }\r\n    }\r\n  }\r\n}}",
     ///         Cast::etherscan_source(Chain::Ropsten, "0x6C3ecefeaE570BFb889d277e8207b18130d7FF2B", "etherscan-api-key").unwrap().as_str()
     ///     );
     /// #    Ok(())

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -337,6 +337,9 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).nonce(who, block).await?);
         }
+		Subcommands::EtherscanSource { chain, address, etherscan_api_key } => {
+			println!("{}", SimpleCast::etherscan_source(chain, address, etherscan_api_key).await?);
+		}
         Subcommands::Wallet { command } => match command {
             WalletSubcommands::New { path, password, unsafe_password } => {
                 let mut rng = thread_rng();

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -337,9 +337,9 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).nonce(who, block).await?);
         }
-		Subcommands::EtherscanSource { chain, address, etherscan_api_key } => {
-			println!("{}", SimpleCast::etherscan_source(chain, address, etherscan_api_key).await?);
-		}
+        Subcommands::EtherscanSource { chain, address, etherscan_api_key } => {
+            println!("{}", SimpleCast::etherscan_source(chain, address, etherscan_api_key).await?);
+        }
         Subcommands::Wallet { command } => match command {
             WalletSubcommands::New { path, password, unsafe_password } => {
                 let mut rng = thread_rng();

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -292,6 +292,16 @@ pub enum Subcommands {
         #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
+    #[clap(name = "etherscan-source")]
+    #[clap(about = "Prints the source code of a contract from Etherscan")]
+    EtherscanSource {
+        #[clap(long, env = "CHAIN", default_value = "mainnet")]
+        chain: Chain,
+        #[clap(help = "the contract address")]
+        address: String,
+        #[clap(long, env = "ETHERSCAN_API_KEY")]
+        etherscan_api_key: String,
+    },
     #[clap(name = "wallet", about = "Set of wallet management utilities")]
     Wallet {
         #[clap(subcommand)]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use clap::{Parser, Subcommand};
-use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256};
+use ethers::types::{Address, BlockId, BlockNumber, Chain, NameOrAddress, H256};
 
 use super::{EthereumOpts, Wallet};
 


### PR DESCRIPTION
Ports `seth etherscan-source` to `cast`

`$ cast etherscan-source --chain <chain> <contract-address> --etherscan-api-key <api-key>`

Fixes required -

1. Escape sequence characters are not interpreted.
2. Probably better to use `NameOrAddress` type for contract address, but I was unable to figure it out.

Would appreciate any feedback as I am only starting out with rust.