### PR TITLE
chore: replace structopt with clap3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,13 +584,50 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1957aa4a5fb388f0a0a73ce7556c5b42025b874e5cdc2c670775e346e97adec0"
+dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+ "terminal_size",
+ "textwrap 0.14.2",
+ "unicase",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a394f7ec0715b42a4e52b294984c27c9a61f77c8d82f7774c5198350be143f19"
+dependencies = [
+ "clap 3.0.6",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error 1.0.4",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1140,7 +1177,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1698,6 +1735,8 @@ version = "0.1.0"
 dependencies = [
  "ansi_term",
  "cast",
+ "clap 3.0.6",
+ "clap_complete",
  "color-eyre",
  "dunce",
  "ethers",
@@ -1717,7 +1756,6 @@ dependencies = [
  "rustc-hex",
  "semver",
  "serde_json",
- "structopt",
  "tempdir",
  "tokio",
  "tracing",
@@ -2008,6 +2046,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -2669,6 +2713,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4048,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
@@ -4058,7 +4111,7 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -4069,7 +4122,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
@@ -4082,7 +4135,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4199,6 +4252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4214,6 +4276,16 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "terminal_size",
  "unicode-width",
 ]
 
@@ -4570,6 +4642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4641,12 +4722,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ cast call 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 "totalSupply()(uint256)" --
 
 More documentation can be found in the [cast package](./cast/README.md).
 
+## Autocompletion
+
+You can generate autocompletion shell scripts for bash, elvish, fish, powershell, and zsh.
+
+Example (zsh / [oh-my-zsh](https://ohmyz.sh/))
+
+```
+mkdir -p ~/.oh-my-zsh/completions
+forge completions zsh > ~/.oh-my-zsh/completions/_forge
+cast completions zsh > ~/.oh-my-zsh/completions/_cast
+source ~/.vimrc
+```
+
 ## Contributing
 
 ### Directory structure

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example (zsh / [oh-my-zsh](https://ohmyz.sh/))
 mkdir -p ~/.oh-my-zsh/completions
 forge completions zsh > ~/.oh-my-zsh/completions/_forge
 cast completions zsh > ~/.oh-my-zsh/completions/_cast
-source ~/.vimrc
+source ~/.zshrc
 ```
 
 ## Contributing

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,13 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "0.3.23"
+clap = { version = "3.0.6", features = [
+    "derive",
+    "env",
+    "unicode",
+    "wrap_help",
+] }
+clap_complete = "3.0.2"
 foundry-utils = { path = "../utils" }
 forge = { path = "../forge" }
 cast = { path = "../cast" }
@@ -31,7 +37,7 @@ rayon = "1.5"
 
 ## EVM Implementations
 # evm = { version = "0.30.1" }
-sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true }
+sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm", optional = true }
 evmodin = { git = "https://github.com/vorot93/evmodin", optional = true }
 proptest = "1.0.0"
 glob = "0.3.0"
@@ -59,7 +65,7 @@ evmodin-evm = [
     "evm-adapters/evmodin",
     # needed to make the `HostExt` implementation for MockedHost accessible
     # to this package
-    "evm-adapters/evmodin-helpers"
+    "evm-adapters/evmodin-helpers",
 ]
 
 [[bin]]

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Foundry CLIs
 
-The CLIs are written using [structopt](https://docs.rs/structopt).
+The CLIs are written using [clap's](https://docs.rs/clap) [derive feature](https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md).
 
 Debug logs are printed with
 [`tracing`](https://docs.rs/tracing/0.1.29/tracing/). You can configure the

--- a/cli/README.md
+++ b/cli/README.md
@@ -24,15 +24,19 @@ FLAGS:
 
 SUBCOMMANDS:
     build              build your smart contracts
-    clean              removes the build artifacts and cache directories completions
+    clean              removes the build artifacts and cache directories
+    completions        generate shell completions script
     create             deploy a compiled contract
-    help               Prints this message or the help of the given subcommand(s)
+    help               Print this message or the help of the given subcommand(s)
     init               initializes a new forge sample repository
     install            installs one or more dependencies as git submodules
     remappings         prints the automatically inferred remappings for this repository
+    remove             removes one or more dependencies from git submodules
+    run                run a single smart contract as a script
+    snapshot           creates a snapshot of each test's gas usage
     test               test your smart contracts
     update             fetches all upstream lib changes
-    verify-contract    build your smart contracts. Requires `ETHERSCAN_API_KEY` to be set.
+    verify-contract    verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set.
 ```
 
 The subcommands are also aliased to their first letter, e.g. you can do
@@ -43,27 +47,45 @@ The subcommands are also aliased to their first letter, e.g. you can do
 The `build` subcommand proceeds to compile your smart contracts.
 
 ```
-forge-build 0.1.0
+forge-build
 build your smart contracts
 
 USAGE:
-    forge build [FLAGS] [OPTIONS]
-
-FLAGS:
-        --force             force recompilation of the project, deletes the cache and artifacts folders
-    -h, --help              Prints help information
-        --no-auto-detect    if set to true, skips auto-detecting solc and uses what is in the user's $PATH
-    -V, --version           Prints version information
+    forge build [OPTIONS]
 
 OPTIONS:
-    -c, --contracts <contracts>              the directory relative to the root under which the smart contrats are [env:
-                                             DAPP_SRC=]
-        --evm-version <evm-version>          choose the evm version [default: london]
-        --lib-paths <lib-paths>...           the paths where your libraries are installed
-    -o, --out <out-path>                     path to where the contract artifacts are stored
-    -r, --remappings <remappings>...         the remappings
-        --remappings-env <remappings-env>     [env: DAPP_REMAPPINGS=]
-        --root <root>                        the project's root path, default being the current working directory
+    -c, --contracts <CONTRACTS>
+            the directory relative to the root under which the smart contracts are [env: DAPP_SRC=]
+        --evm-version <EVM_VERSION>
+            choose the evm version [default: london]
+        --force
+            force recompilation of the project, deletes the cache and artifacts folders
+    -h, --help
+            Print help information
+        --hardhat
+            uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-
+            paths node_modules`
+        --ignored-error-codes <IGNORED_ERROR_CODES>
+            ignore warnings with specific error codes
+        --lib-paths <LIB_PATHS>
+            the paths where your libraries are installed
+        --libraries <LIBRARIES>
+            add linked libraries
+        --no-auto-detect
+            if set to true, skips auto-detecting solc and uses what is in the user's $PATH
+    -o, --out <OUT_PATH>
+            path to where the contract artifacts are stored
+        --optimize
+            activate the solidity optimizer
+        --optimize-runs <OPTIMIZE_RUNS>
+            optimizer parameter runs [default: 200]
+    -r, --remappings <REMAPPINGS>
+            the remappings
+        --remappings-env <REMAPPINGS_ENV>
+            [env: DAPP_REMAPPINGS=]
+        --root <ROOT>
+            the project's root path. By default, this is the root directory of the current Git repository or the current
+            working directory if it is not part of a Git repository
 ```
 
 By default, it will auto-detect the solc pragma version requirement per-file and
@@ -123,72 +145,100 @@ configure any blockchain context related variables such as the block coinbase,
 difficulty etc.
 
 ```
-forge-test 0.1.0
+forge-test
 test your smart contracts
 
 USAGE:
-    forge test [FLAGS] [OPTIONS]
-
-FLAGS:
-        --ffi               enables the FFI cheatcode
-        --force             force recompilation of the project, deletes the cache and artifacts folders
-    -h, --help              Prints help information
-    -j, --json              print the test results in json format
-        --no-auto-detect    if set to true, skips auto-detecting solc and uses what is in the user's $PATH
-    -V, --version           Prints version information
+    forge test [OPTIONS]
 
 OPTIONS:
-        --allow-failure <allow-failure>
+    -j, --json
+            print the test results in json format
+        --gas-limit <GAS_LIMIT>
+            the block gas limit [default: 18446744073709551615]
+        --chain-id <CHAIN_ID>
+            the chainid opcode value [default: 1]
+        --gas-price <GAS_PRICE>
+            the tx.gasprice value during EVM execution [default: 0]
+        --block-base-fee-per-gas <BLOCK_BASE_FEE_PER_GAS>
+            the base fee in a block [default: 0]
+        --tx-origin <TX_ORIGIN>
+            the tx.origin value during EVM execution [default: 0x0000000000000000000000000000000000000000]
+        --block-coinbase <BLOCK_COINBASE>
+            the block.coinbase value during EVM execution [default: 0x0000000000000000000000000000000000000000]
+        --block-timestamp <BLOCK_TIMESTAMP>
+            the block.timestamp value during EVM execution [env: DAPP_TEST_TIMESTAMP=] [default: 0]
+        --block-number <BLOCK_NUMBER>
+            the block.number value during EVM execution [env: DAPP_TEST_NUMBER=] [default: 0]
+        --block-difficulty <BLOCK_DIFFICULTY>
+            the block.difficulty value during EVM execution [default: 0]
+        --block-gas-limit <BLOCK_GAS_LIMIT>
+            the block.gaslimit value during EVM execution
+    -e, --evm-type <EVM_TYPE>
+            the EVM type you want to use (e.g. sputnik, evmodin) [default: sputnik]
+    -f, --fork-url <FORK_URL>
+            fetch state over a remote instead of starting from empty state
+        --fork-block-number <FORK_BLOCK_NUMBER>
+            pins the block number for the state fork [env: DAPP_FORK_BLOCK=]
+        --initial-balance <INITIAL_BALANCE>
+            the initial balance of each deployed test contract [default: 0xffffffffffffffffffffffff]
+        --sender <SENDER>
+            the address which will be executing all tests [env: DAPP_TEST_ADDRESS=] [default:
+            0x0000000000000000000000000000000000000000]
+        --ffi
+            enables the FFI cheatcode
+    -v, --verbosity
+            Verbosity mode of EVM output as number of occurences of the `v` flag (-v, -vv, -vvv, etc.)
+                3: print test trace for failing tests
+                4: always print test trace, print setup for failing tests
+                5: always print test trace and setup
+        --debug
+            enable debugger
+    -m, --match <PATTERN>
+            only run test methods matching regex (deprecated, see --match-test, --match-contract)
+        --match-test <TEST_PATTERN>
+            only run test methods matching regex
+        --no-match-test <TEST_PATTERN_INVERSE>
+            only run test methods not matching regex
+        --match-contract <CONTRACT_PATTERN>
+            only run test methods in contracts matching regex
+        --no-match-contract <CONTRACT_PATTERN_INVERSE>
+            only run test methods in contracts not matching regex
+        --root <ROOT>
+            the project's root path. By default, this is the root directory of the current Git repository or the current
+            working directory if it is not part of a Git repository
+    -c, --contracts <CONTRACTS>
+            the directory relative to the root under which the smart contracts are [env: DAPP_SRC=]
+    -r, --remappings <REMAPPINGS>
+            the remappings
+        --remappings-env <REMAPPINGS_ENV>
+            [env: DAPP_REMAPPINGS=]
+        --lib-paths <LIB_PATHS>
+            the paths where your libraries are installed
+    -o, --out <OUT_PATH>
+            path to where the contract artifacts are stored
+        --evm-version <EVM_VERSION>
+            choose the evm version [default: london]
+        --optimize
+            activate the solidity optimizer
+        --optimize-runs <OPTIMIZE_RUNS>
+            optimizer parameter runs [default: 200]
+        --ignored-error-codes <IGNORED_ERROR_CODES>
+            ignore warnings with specific error codes
+        --no-auto-detect
+            if set to true, skips auto-detecting solc and uses what is in the user's $PATH
+        --force
+            force recompilation of the project, deletes the cache and artifacts folders
+        --hardhat
+            uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-
+            paths node_modules`
+        --libraries <LIBRARIES>
+            add linked libraries
+        --allow-failure
             if set to true, the process will exit with an exit code = 0, even if the tests fail [env:
             FORGE_ALLOW_FAILURE=]
-        --block-base-fee-per-gas <block-base-fee-per-gas>    the base fee in a block [default: 0]
-        --block-coinbase <block-coinbase>
-            the block.coinbase value during EVM execution [default: 0x0000000000000000000000000000000000000000]
-
-        --block-difficulty <block-difficulty>
-            the block.difficulty value during EVM execution [default: 0]
-
-        --block-gas-limit <block-gas-limit>                  the block.gaslimit value during EVM execution
-        --block-number <block-number>
-            the block.number value during EVM execution [env: DAPP_TEST_NUMBER=]  [default: 0]
-
-        --block-timestamp <block-timestamp>
-            the block.timestamp value during EVM execution [env: DAPP_TEST_TIMESTAMP=]  [default: 0]
-
-        --chain-id <chain-id>                                the chainid opcode value [default: 1]
-    -c, --contracts <contracts>
-            the directory relative to the root under which the smart contrats are [env: DAPP_SRC=]
-
-    -e, --evm-type <evm-type>
-            the EVM type you want to use (e.g. sputnik, evmodin) [default: sputnik]
-
-        --evm-version <evm-version>                          choose the evm version [default: london]
-        --fork-block-number <fork-block-number>
-            pins the block number for the state fork [env: DAPP_FORK_BLOCK=]
-
-    -f, --fork-url <fork-url>
-            fetch state over a remote instead of starting from empty state [env: ETH_RPC_URL=]
-
-        --gas-limit <gas-limit>                              the block gas limit [default: 18446744073709551615]
-        --gas-price <gas-price>                              the tx.gasprice value during EVM execution [default: 0]
-        --initial-balance <initial-balance>
-            the initial balance of each deployed test contract [default: 0xffffffffffffffffffffffff]
-
-        --lib-paths <lib-paths>...                           the paths where your libraries are installed
-    -o, --out <out-path>                                     path to where the contract artifacts are stored
-    -m, --match <pattern>                                    only run test methods matching regex [default: .*]
-    -r, --remappings <remappings>...                         the remappings
-        --remappings-env <remappings-env>                     [env: DAPP_REMAPPINGS=]
-        --root <root>
-            the project's root path, default being the current working directory
-
-        --sender <sender>
-            the address which will be executing all tests [env: DAPP_TEST_ADDRESS=]  [default:
-            0x0000000000000000000000000000000000000000]
-        --tx-origin <tx-origin>
-            the tx.origin value during EVM execution [default: 0x0000000000000000000000000000000000000000]
-
-        --verbosity <verbosity>                              verbosity of 'forge test' output (0-3) [default: 0]
+    -h, --help
+            Print help information
 ```
 
 Here's how the CLI output looks like when used with
@@ -231,6 +281,67 @@ no files changed, compilation skippped.
 {"\"Gm.json\":Gm":{"testNonOwnerCannotGm":{"success":true,"reason":null,"gas_used":3782,"counterexample":null,"logs":[]},"testOwnerCannotGmOnBadBlocks":{"success":true,"reason":null,"gas_used":7771,"counterexample":null,"logs":[]},"testOwnerCanGmOnGoodBlocks":{"success":true,"reason":null,"gas_used":31696,"counterexample":null,"logs":[]}},"\"Greet.json\":Greet":{"testWorksForAllGreetings":{"success":true,"reason":null,"gas_used":null,"counterexample":null,"logs":[]},"testCannotGm":{"success":true,"reason":null,"gas_used":6819,"counterexample":null,"logs":[]},"testCanSetGreeting":{"success":true,"reason":null,"gas_used":31070,"counterexample":null,"logs":[]}}}
 ```
 
-```
+## cast
 
+```
+foundry-cli
+Perform Ethereum RPC calls from the comfort of your command line.
+
+USAGE:
+    cast <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    --abi-decode             Decode ABI-encoded hex output data. Pass --input to decode as input, or use
+                             `--calldata-decode`
+    --calldata-decode        Decode ABI-encoded hex input data. Use `--abi-decode` to decode output data
+    --from-utf8              convert text data into hexdata
+    --from-wei               convert wei into an ETH amount
+    --max-int                maximum i256 value
+    --max-uint               maximum u256 value
+    --min-int                minimum i256 value
+    --to-ascii               convert hex data to text data
+    --to-bytes32             left-pads a hex bytes string to 32 bytes)
+    --to-checksum-address    convert an address to a checksummed format (EIP-55)
+    --to-dec                 convert hex value into decimal number
+    --to-fix                 convert integers into fixed point with specified decimals
+    --to-hex                 convert a decimal number into hex
+    --to-hexdata             [<hex>|</path>|<@tag>]
+                                 Output lowercase, 0x-prefixed hex, converting from the
+                                 input, which can be:
+                                   - mixed case hex with or without 0x prefix
+                                   - 0x prefixed hex, concatenated with a ':'
+                                   - absolute path to file
+                                   - @tag, where $TAG is defined in environment variables
+    --to-uint256             convert a number into uint256 hex string with 0x prefix
+    --to-wei                 convert an ETH amount into wei
+    4byte                    Fetches function signatures given the selector from 4byte.directory
+    4byte-decode             Decodes transaction calldata by fetching the signature using 4byte.directory
+    abi-encode
+    age                      Prints the timestamp of a block
+    balance                  Print the balance of <account> in wei
+    basefee                  Print the basefee of a block
+    block                    Prints information about <block>. If <field> is given, print only the value of that
+                             field
+    block-number             Prints latest block number
+    call                     Perform a local call to <to> without publishing a transaction.
+    calldata                 Pack a signature and an argument list into hexadecimal calldata.
+    chain                    Prints symbolic name of current blockchain by checking genesis hash
+    chain-id                 returns ethereum chain id
+    code                     Prints the bytecode at <address>
+    completions              generate shell completions script
+    estimate                 Estimate the gas cost of a transaction from <from> to <to> with <data>
+    gas-price                Prints current gas price of target chain
+    help                     Print this message or the help of the given subcommand(s)
+    keccak                   Keccak-256 hashes arbitrary data
+    lookup-address           Returns the name the provided address resolves to
+    namehash                 returns ENS namehash of provided name
+    nonce                    Prints the number of transactions sent from <address>
+    resolve-name             Returns the address the provided ENS name resolves to
+    send                     Publish a transaction signed by <from> to call <to> with <data>
+    storage                  Show the raw value of a contract's storage slot
+    tx                       Show information about the transaction <tx-hash>
+    wallet                   Set of wallet management utilities
 ```

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -29,7 +29,8 @@ use std::{
     time::Instant,
 };
 
-use clap::Parser;
+use clap::{IntoApp, Parser};
+use clap_complete::generate;
 
 use crate::utils::read_secret;
 
@@ -463,6 +464,9 @@ async fn main() -> eyre::Result<()> {
                 }
             }
         },
+        Subcommands::Completions { shell } => {
+            generate(shell, &mut Opts::into_app(), "cast", &mut std::io::stdout())
+        }
     };
 
     Ok(())

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -28,7 +28,8 @@ use std::{
     str::FromStr,
     time::Instant,
 };
-use structopt::StructOpt;
+
+use clap::Parser;
 
 use crate::utils::read_secret;
 
@@ -36,7 +37,7 @@ use crate::utils::read_secret;
 async fn main() -> eyre::Result<()> {
     color_eyre::install()?;
 
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
     match opts.sub {
         Subcommands::MaxInt => {
             println!("{}", SimpleCast::max_int()?);

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -16,58 +16,58 @@ use std::{
 
 use crate::{cmd::Cmd, opts::forge::CompilerArgs, utils};
 
+use clap::Parser;
 #[cfg(feature = "evmodin-evm")]
 use evmodin::util::mocked_host::MockedHost;
 #[cfg(feature = "sputnik-evm")]
 use sputnik::backend::MemoryVicinity;
-use structopt::StructOpt;
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct BuildArgs {
-    #[structopt(
+    #[clap(
         help = "the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
         long
     )]
     pub root: Option<PathBuf>,
 
-    #[structopt(
+    #[clap(
         help = "the directory relative to the root under which the smart contracts are",
         long,
         short
     )]
-    #[structopt(env = "DAPP_SRC")]
+    #[clap(env = "DAPP_SRC")]
     pub contracts: Option<PathBuf>,
 
-    #[structopt(help = "the remappings", long, short)]
+    #[clap(help = "the remappings", long, short)]
     pub remappings: Vec<ethers::solc::remappings::Remapping>,
-    #[structopt(long = "remappings-env", env = "DAPP_REMAPPINGS")]
+    #[clap(long = "remappings-env", env = "DAPP_REMAPPINGS")]
     pub remappings_env: Option<String>,
 
-    #[structopt(help = "the paths where your libraries are installed", long)]
+    #[clap(help = "the paths where your libraries are installed", long)]
     pub lib_paths: Vec<PathBuf>,
 
-    #[structopt(help = "path to where the contract artifacts are stored", long = "out", short)]
+    #[clap(help = "path to where the contract artifacts are stored", long = "out", short)]
     pub out_path: Option<PathBuf>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub compiler: CompilerArgs,
 
-    #[structopt(help = "ignore warnings with specific error codes", long)]
+    #[clap(help = "ignore warnings with specific error codes", long)]
     pub ignored_error_codes: Vec<u64>,
 
-    #[structopt(
+    #[clap(
         help = "if set to true, skips auto-detecting solc and uses what is in the user's $PATH ",
         long
     )]
     pub no_auto_detect: bool,
 
-    #[structopt(
+    #[clap(
         help = "force recompilation of the project, deletes the cache and artifacts folders",
         long
     )]
     pub force: bool,
 
-    #[structopt(
+    #[clap(
         help = "uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-paths node_modules`",
         long,
         conflicts_with = "contracts",
@@ -75,7 +75,7 @@ pub struct BuildArgs {
     )]
     pub hardhat: bool,
 
-    #[structopt(help = "add linked libraries", long)]
+    #[clap(help = "add linked libraries", long)]
     pub libraries: Vec<String>,
 }
 
@@ -262,37 +262,37 @@ impl FromStr for EvmType {
     }
 }
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct Env {
     // structopt does not let use `u64::MAX`:
     // https://doc.rust-lang.org/std/primitive.u64.html#associatedconstant.MAX
-    #[structopt(help = "the block gas limit", long, default_value = "18446744073709551615")]
+    #[clap(help = "the block gas limit", long, default_value = "18446744073709551615")]
     pub gas_limit: u64,
 
-    #[structopt(help = "the chainid opcode value", long, default_value = "1")]
+    #[clap(help = "the chainid opcode value", long, default_value = "1")]
     pub chain_id: u64,
 
-    #[structopt(help = "the tx.gasprice value during EVM execution", long, default_value = "0")]
+    #[clap(help = "the tx.gasprice value during EVM execution", long, default_value = "0")]
     pub gas_price: u64,
 
-    #[structopt(help = "the base fee in a block", long, default_value = "0")]
+    #[clap(help = "the base fee in a block", long, default_value = "0")]
     pub block_base_fee_per_gas: u64,
 
-    #[structopt(
+    #[clap(
         help = "the tx.origin value during EVM execution",
         long,
         default_value = "0x0000000000000000000000000000000000000000"
     )]
     pub tx_origin: Address,
 
-    #[structopt(
+    #[clap(
     help = "the block.coinbase value during EVM execution",
     long,
     // TODO: It'd be nice if we could use Address::zero() here.
     default_value = "0x0000000000000000000000000000000000000000"
     )]
     pub block_coinbase: Address,
-    #[structopt(
+    #[clap(
         help = "the block.timestamp value during EVM execution",
         long,
         default_value = "0",
@@ -300,18 +300,14 @@ pub struct Env {
     )]
     pub block_timestamp: u64,
 
-    #[structopt(help = "the block.number value during EVM execution", long, default_value = "0")]
-    #[structopt(env = "DAPP_TEST_NUMBER")]
+    #[clap(help = "the block.number value during EVM execution", long, default_value = "0")]
+    #[clap(env = "DAPP_TEST_NUMBER")]
     pub block_number: u64,
 
-    #[structopt(
-        help = "the block.difficulty value during EVM execution",
-        long,
-        default_value = "0"
-    )]
+    #[clap(help = "the block.difficulty value during EVM execution", long, default_value = "0")]
     pub block_difficulty: u64,
 
-    #[structopt(help = "the block.gaslimit value during EVM execution", long)]
+    #[clap(help = "the block.gaslimit value during EVM execution", long)]
     pub block_gas_limit: Option<u64>,
     // TODO: Add configuration option for base fee.
 }

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -264,9 +264,7 @@ impl FromStr for EvmType {
 
 #[derive(Debug, Clone, Parser)]
 pub struct Env {
-    // structopt does not let use `u64::MAX`:
-    // https://doc.rust-lang.org/std/primitive.u64.html#associatedconstant.MAX
-    #[clap(help = "the block gas limit", long, default_value = "18446744073709551615")]
+    #[clap(help = "the block gas limit", long, default_value_t = u64::MAX)]
     pub gas_limit: u64,
 
     #[clap(help = "the chainid opcode value", long, default_value = "1")]

--- a/cli/src/cmd/create.rs
+++ b/cli/src/cmd/create.rs
@@ -12,21 +12,21 @@ use eyre::Result;
 use foundry_utils::parse_tokens;
 
 use crate::opts::forge::ContractInfo;
+use clap::Parser;
 use std::sync::Arc;
-use structopt::StructOpt;
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct CreateArgs {
-    #[structopt(long, help = "constructor args calldata arguments.")]
+    #[clap(long, help = "constructor args calldata arguments.")]
     constructor_args: Vec<String>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     opts: BuildArgs,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     eth: EthereumOpts,
 
-    #[structopt(help = "contract source info `<path>:<contractname>` or `<contractname>`")]
+    #[clap(help = "contract source info `<path>:<contractname>` or `<contractname>`")]
     contract: ContractInfo,
 }
 

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -19,7 +19,7 @@ use ethers::{
 use std::path::PathBuf;
 
 /// Common trait for all cli commands
-pub trait Cmd: structopt::StructOpt + Sized {
+pub trait Cmd: clap::Parser + Sized {
     type Output;
     fn run(self) -> eyre::Result<Self::Output>;
 }
@@ -70,7 +70,7 @@ pub fn manual_compile(
             // return the diagnostics error back to the user.
             eyre::bail!(output.to_string())
         }
-        return Ok(output)
+        return Ok(output);
     }
 
     let mut solc = project.solc.clone();

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -70,7 +70,7 @@ pub fn manual_compile(
             // return the diagnostics error back to the user.
             eyre::bail!(output.to_string())
         }
-        return Ok(output);
+        return Ok(output)
     }
 
     let mut solc = project.solc.clone();

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -2,11 +2,11 @@ use crate::{
     cmd::{build::BuildArgs, compile, manual_compile, Cmd},
     opts::forge::EvmOpts,
 };
+use clap::Parser;
 use ethers::abi::Abi;
 use forge::ContractRunner;
 use foundry_utils::IntoFunction;
 use std::{collections::BTreeMap, path::PathBuf};
-use structopt::StructOpt;
 use ui::{TUIExitReason, Tui, Ui};
 
 use ethers::solc::{
@@ -22,25 +22,25 @@ use ethers::{
     solc::artifacts::{CompactContractSome, ContractBytecodeSome},
 };
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct RunArgs {
-    #[structopt(help = "the path to the contract to run")]
+    #[clap(help = "the path to the contract to run")]
     pub path: PathBuf,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub evm_opts: EvmOpts,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     opts: BuildArgs,
 
-    #[structopt(
+    #[clap(
         long,
         short,
         help = "the contract you want to call and deploy, only necessary if there are more than 1 contract (Interfaces do not count) definitions on the script"
     )]
     pub target_contract: Option<String>,
 
-    #[structopt(
+    #[clap(
         long,
         short,
         help = "the function you want to call on the script contract, defaults to run()"

--- a/cli/src/cmd/snapshot.rs
+++ b/cli/src/cmd/snapshot.rs
@@ -114,12 +114,12 @@ impl SnapshotConfig {
     fn is_in_gas_range(&self, gas_used: u64) -> bool {
         if let Some(min) = self.min {
             if gas_used < min {
-                return false;
+                return false
             }
         }
         if let Some(max) = self.max {
             if gas_used > max {
-                return false;
+                return false
             }
         }
         true

--- a/cli/src/cmd/snapshot.rs
+++ b/cli/src/cmd/snapshot.rs
@@ -6,6 +6,7 @@ use crate::cmd::{
     Cmd,
 };
 use ansi_term::Colour;
+use clap::Parser;
 use eyre::Context;
 use forge::TestKindGas;
 use once_cell::sync::Lazy;
@@ -19,7 +20,6 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use structopt::StructOpt;
 
 /// A regex that matches a basic snapshot entry like
 /// `testDeposit() (gas: 58804)`
@@ -27,29 +27,29 @@ pub static RE_BASIC_SNAPSHOT_ENTRY: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?P<sig>(\w+)\s*\((.*?)\))\s*\(((gas:)?\s*(?P<gas>\d+)|(runs:\s*(?P<runs>\d+),\s*μ:\s*(?P<avg>\d+),\s*~:\s*(?P<med>\d+)))\)").unwrap()
 });
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct SnapshotArgs {
     /// All test arguments are supported
-    #[structopt(flatten)]
+    #[clap(flatten)]
     test: test::TestArgs,
     /// Additional configs for test results
-    #[structopt(flatten)]
+    #[clap(flatten)]
     config: SnapshotConfig,
-    #[structopt(
+    #[clap(
         help = "Compare against a snapshot and display changes from the snapshot. Takes an optional snapshot file, [default: .gas-snapshot]",
         conflicts_with = "snap",
         long
     )]
     diff: Option<Option<PathBuf>>,
-    #[structopt(
+    #[clap(
         help = "Run snapshot in 'check' mode and compares against an existing snapshot file, [default: .gas-snapshot]. Exits with 0 if snapshots match. Exits with 1 and prints a diff otherwise",
         conflicts_with = "diff",
         long
     )]
     check: Option<Option<PathBuf>>,
-    #[structopt(help = "How to format the output.", long)]
+    #[clap(help = "How to format the output.", long)]
     format: Option<Format>,
-    #[structopt(help = "Output file for the snapshot.", default_value = ".gas-snapshot", long)]
+    #[clap(help = "Output file for the snapshot.", default_value = ".gas-snapshot", long)]
     snap: PathBuf,
 }
 
@@ -98,15 +98,15 @@ impl FromStr for Format {
 }
 
 /// Additional filters that can be applied on the test results
-#[derive(Debug, Clone, StructOpt, Default)]
+#[derive(Debug, Clone, Parser, Default)]
 struct SnapshotConfig {
-    #[structopt(help = "sort results by ascending gas used.", long)]
+    #[clap(help = "sort results by ascending gas used.", long)]
     asc: bool,
-    #[structopt(help = "sort results by descending gas used.", conflicts_with = "asc", long)]
+    #[clap(help = "sort results by descending gas used.", conflicts_with = "asc", long)]
     desc: bool,
-    #[structopt(help = "Only include tests that used more gas that the given amount.", long)]
+    #[clap(help = "Only include tests that used more gas that the given amount.", long)]
     min: Option<u64>,
-    #[structopt(help = "Only include tests that used less gas that the given amount.", long)]
+    #[clap(help = "Only include tests that used less gas that the given amount.", long)]
     max: Option<u64>,
 }
 
@@ -114,12 +114,12 @@ impl SnapshotConfig {
     fn is_in_gas_range(&self, gas_used: u64) -> bool {
         if let Some(min) = self.min {
             if gas_used < min {
-                return false
+                return false;
             }
         }
         if let Some(max) = self.max {
             if gas_used > max {
-                return false
+                return false;
             }
         }
         true

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -9,42 +9,42 @@ use crate::{
     utils,
 };
 use ansi_term::Colour;
+use clap::{AppSettings, Parser};
 use ethers::solc::{ArtifactOutput, Project};
 use forge::{MultiContractRunnerBuilder, TestFilter};
 use std::collections::BTreeMap;
-use structopt::{clap::AppSettings, StructOpt};
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct Filter {
-    #[structopt(
-        long = "--match",
-        short = "-m",
+    #[clap(
+        long = "match",
+        short = 'm',
         help = "only run test methods matching regex (deprecated, see --match-test, --match-contract)"
     )]
     pattern: Option<regex::Regex>,
 
-    #[structopt(
+    #[clap(
         long = "--match-test",
         help = "only run test methods matching regex",
         conflicts_with = "pattern"
     )]
     test_pattern: Option<regex::Regex>,
 
-    #[structopt(
+    #[clap(
         long = "--no-match-test",
         help = "only run test methods not matching regex",
         conflicts_with = "pattern"
     )]
     test_pattern_inverse: Option<regex::Regex>,
 
-    #[structopt(
+    #[clap(
         long = "--match-contract",
         help = "only run test methods in contracts matching regex",
         conflicts_with = "pattern"
     )]
     contract_pattern: Option<regex::Regex>,
 
-    #[structopt(
+    #[clap(
         long = "--no-match-contract",
         help = "only run test methods in contracts not matching regex",
         conflicts_with = "pattern"
@@ -80,23 +80,23 @@ impl TestFilter for Filter {
     }
 }
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 // This is required to group Filter options in help output
-#[structopt(global_settings = &[AppSettings::DeriveDisplayOrder])]
+#[clap(global_setting = AppSettings::DeriveDisplayOrder)]
 pub struct TestArgs {
-    #[structopt(help = "print the test results in json format", long, short)]
+    #[clap(help = "print the test results in json format", long, short)]
     json: bool,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     evm_opts: EvmOpts,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     filter: Filter,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     opts: BuildArgs,
 
-    #[structopt(
+    #[clap(
         help = "if set to true, the process will exit with an exit code = 0, even if the tests fail",
         long,
         env = "FORGE_ALLOW_FAILURE"

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -24,28 +24,28 @@ pub struct Filter {
     pattern: Option<regex::Regex>,
 
     #[clap(
-        long = "--match-test",
+        long = "match-test",
         help = "only run test methods matching regex",
         conflicts_with = "pattern"
     )]
     test_pattern: Option<regex::Regex>,
 
     #[clap(
-        long = "--no-match-test",
+        long = "no-match-test",
         help = "only run test methods not matching regex",
         conflicts_with = "pattern"
     )]
     test_pattern_inverse: Option<regex::Regex>,
 
     #[clap(
-        long = "--match-contract",
+        long = "match-contract",
         help = "only run test methods in contracts matching regex",
         conflicts_with = "pattern"
     )]
     contract_pattern: Option<regex::Regex>,
 
     #[clap(
-        long = "--no-match-contract",
+        long = "no-match-contract",
         help = "only run test methods in contracts not matching regex",
         conflicts_with = "pattern"
     )]

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -7,13 +7,15 @@ use crate::cmd::Cmd;
 use ethers::solc::{remappings::Remapping, Project, ProjectPathsConfig};
 use opts::forge::{Dependency, FullContractInfo, Opts, Subcommands};
 use std::{process::Command, str::FromStr};
-use structopt::StructOpt;
+
+use clap::{IntoApp, Parser};
+use clap_complete::{generate, Generator, Shell};
 
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     utils::subscriber();
 
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
     match opts.sub {
         Subcommands::Test(cmd) => {
             let outcome = cmd.run()?;
@@ -121,7 +123,7 @@ fn main() -> eyre::Result<()> {
             println!("Done.");
         }
         Subcommands::Completions { shell } => {
-            Subcommands::clap().gen_completions_to("forge", shell, &mut std::io::stdout())
+            generate(shell, &mut Opts::into_app(), "forge", &mut std::io::stdout())
         }
         Subcommands::Clean { root } => {
             let root = root.unwrap_or_else(|| std::env::current_dir().unwrap());

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -9,7 +9,7 @@ use opts::forge::{Dependency, FullContractInfo, Opts, Subcommands};
 use std::{process::Command, str::FromStr};
 
 use clap::{IntoApp, Parser};
-use clap_complete::{generate, Generator, Shell};
+use clap_complete::generate;
 
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -6,6 +6,7 @@ use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256};
 use super::{EthereumOpts, Wallet};
 
 #[derive(Debug, Subcommand)]
+#[clap(name = "cast")]
 #[clap(about = "Perform Ethereum RPC calls from the comfort of your command line.")]
 pub enum Subcommands {
     #[clap(name = "--max-int")]
@@ -295,6 +296,11 @@ pub enum Subcommands {
     Wallet {
         #[clap(subcommand)]
         command: WalletSubcommands,
+    },
+    #[clap(about = "generate shell completions script")]
+    Completions {
+        #[clap(help = "the shell you are using")]
+        shell: clap_complete::Shell,
     },
 }
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -69,7 +69,7 @@ pub enum Subcommands {
         #[clap(long, env = "CAST_FULL_BLOCK")]
         full: bool,
         field: Option<String>,
-        #[clap(long = "--json", short = 'j')]
+        #[clap(long = "json", short = 'j')]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
@@ -121,7 +121,7 @@ pub enum Subcommands {
     Tx {
         hash: String,
         field: Option<String>,
-        #[clap(long = "--json", short = 'j')]
+        #[clap(long = "json", short = 'j')]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,31 +1,31 @@
 use std::str::FromStr;
 
+use clap::{Parser, Subcommand};
 use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256};
-use structopt::StructOpt;
 
 use super::{EthereumOpts, Wallet};
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Perform Ethereum RPC calls from the comfort of your command line.")]
+#[derive(Debug, Subcommand)]
+#[clap(about = "Perform Ethereum RPC calls from the comfort of your command line.")]
 pub enum Subcommands {
-    #[structopt(name = "--max-int")]
-    #[structopt(about = "maximum i256 value")]
+    #[clap(name = "--max-int")]
+    #[clap(about = "maximum i256 value")]
     MaxInt,
-    #[structopt(name = "--min-int")]
-    #[structopt(about = "minimum i256 value")]
+    #[clap(name = "--min-int")]
+    #[clap(about = "minimum i256 value")]
     MinInt,
-    #[structopt(name = "--max-uint")]
-    #[structopt(about = "maximum u256 value")]
+    #[clap(name = "--max-uint")]
+    #[clap(about = "maximum u256 value")]
     MaxUint,
-    #[structopt(aliases = &["--from-ascii"])]
-    #[structopt(name = "--from-utf8")]
-    #[structopt(about = "convert text data into hexdata")]
+    #[clap(aliases = &["--from-ascii"])]
+    #[clap(name = "--from-utf8")]
+    #[clap(about = "convert text data into hexdata")]
     FromUtf8 { text: Option<String> },
-    #[structopt(name = "--to-hex")]
-    #[structopt(about = "convert a decimal number into hex")]
+    #[clap(name = "--to-hex")]
+    #[clap(about = "convert a decimal number into hex")]
     ToHex { decimal: Option<String> },
-    #[structopt(name = "--to-hexdata")]
-    #[structopt(about = r#"[<hex>|</path>|<@tag>]
+    #[clap(name = "--to-hexdata")]
+    #[clap(about = r#"[<hex>|</path>|<@tag>]
     Output lowercase, 0x-prefixed hex, converting from the
     input, which can be:
       - mixed case hex with or without 0x prefix
@@ -34,65 +34,65 @@ pub enum Subcommands {
       - @tag, where $TAG is defined in environment variables
     "#)]
     ToHexdata { input: Option<String> },
-    #[structopt(aliases = &["--to-checksum"])] // Compatibility with dapptools' cast
-    #[structopt(name = "--to-checksum-address")]
-    #[structopt(about = "convert an address to a checksummed format (EIP-55)")]
+    #[clap(aliases = &["--to-checksum"])] // Compatibility with dapptools' cast
+    #[clap(name = "--to-checksum-address")]
+    #[clap(about = "convert an address to a checksummed format (EIP-55)")]
     ToCheckSumAddress { address: Option<Address> },
-    #[structopt(name = "--to-ascii")]
-    #[structopt(about = "convert hex data to text data")]
+    #[clap(name = "--to-ascii")]
+    #[clap(about = "convert hex data to text data")]
     ToAscii { hexdata: Option<String> },
-    #[structopt(name = "--to-bytes32")]
-    #[structopt(about = "left-pads a hex bytes string to 32 bytes)")]
+    #[clap(name = "--to-bytes32")]
+    #[clap(about = "left-pads a hex bytes string to 32 bytes)")]
     ToBytes32 { bytes: Option<String> },
-    #[structopt(name = "--to-dec")]
-    #[structopt(about = "convert hex value into decimal number")]
+    #[clap(name = "--to-dec")]
+    #[clap(about = "convert hex value into decimal number")]
     ToDec { hexvalue: Option<String> },
-    #[structopt(name = "--to-fix")]
-    #[structopt(about = "convert integers into fixed point with specified decimals")]
+    #[clap(name = "--to-fix")]
+    #[clap(about = "convert integers into fixed point with specified decimals")]
     ToFix { decimals: Option<u128>, value: Option<String> },
-    #[structopt(name = "--to-uint256")]
-    #[structopt(about = "convert a number into uint256 hex string with 0x prefix")]
+    #[clap(name = "--to-uint256")]
+    #[clap(about = "convert a number into uint256 hex string with 0x prefix")]
     ToUint256 { value: Option<String> },
-    #[structopt(name = "--to-wei")]
-    #[structopt(about = "convert an ETH amount into wei")]
+    #[clap(name = "--to-wei")]
+    #[clap(about = "convert an ETH amount into wei")]
     ToWei { value: Option<String>, unit: Option<String> },
-    #[structopt(name = "--from-wei")]
-    #[structopt(about = "convert wei into an ETH amount")]
+    #[clap(name = "--from-wei")]
+    #[clap(about = "convert wei into an ETH amount")]
     FromWei { value: Option<String>, unit: Option<String> },
-    #[structopt(name = "block")]
-    #[structopt(
+    #[clap(name = "block")]
+    #[clap(
         about = "Prints information about <block>. If <field> is given, print only the value of that field"
     )]
     Block {
-        #[structopt(help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        #[clap(help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
         block: BlockId,
-        #[structopt(long, env = "CAST_FULL_BLOCK")]
+        #[clap(long, env = "CAST_FULL_BLOCK")]
         full: bool,
         field: Option<String>,
-        #[structopt(long = "--json", short = "-j")]
+        #[clap(long = "--json", short = 'j')]
         to_json: bool,
-        #[structopt(long, env = "ETH_RPC_URL")]
+        #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "block-number")]
-    #[structopt(about = "Prints latest block number")]
+    #[clap(name = "block-number")]
+    #[clap(about = "Prints latest block number")]
     BlockNumber {
-        #[structopt(long, env = "ETH_RPC_URL")]
+        #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "call")]
-    #[structopt(about = "Perform a local call to <to> without publishing a transaction.")]
+    #[clap(name = "call")]
+    #[clap(about = "Perform a local call to <to> without publishing a transaction.")]
     Call {
-        #[structopt(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
         address: NameOrAddress,
         sig: String,
         args: Vec<String>,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         eth: EthereumOpts,
     },
-    #[structopt(about = "Pack a signature and an argument list into hexadecimal calldata.")]
+    #[clap(about = "Pack a signature and an argument list into hexadecimal calldata.")]
     Calldata {
-        #[structopt(
+        #[clap(
             help = r#"When called with <sig> of the form <name>(<types>...), then perform ABI encoding to produce the hexadecimal calldata.
         If the value given—containing at least one slash character—then treat it as a file name to read, and proceed as if the contents were passed as hexadecimal data.
         Given data, ensure it is hexadecimal calldata starting with 0x and normalize it to lowercase.
@@ -101,191 +101,179 @@ pub enum Subcommands {
         sig: String,
         args: Vec<String>,
     },
-    #[structopt(name = "chain")]
-    #[structopt(about = "Prints symbolic name of current blockchain by checking genesis hash")]
+    #[clap(name = "chain")]
+    #[clap(about = "Prints symbolic name of current blockchain by checking genesis hash")]
     Chain {
-        #[structopt(long, env = "ETH_RPC_URL")]
+        #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "chain-id")]
-    #[structopt(about = "returns ethereum chain id")]
+    #[clap(name = "chain-id")]
+    #[clap(about = "returns ethereum chain id")]
     ChainId {
-        #[structopt(long, env = "ETH_RPC_URL")]
+        #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "namehash")]
-    #[structopt(about = "returns ENS namehash of provided name")]
+    #[clap(name = "namehash")]
+    #[clap(about = "returns ENS namehash of provided name")]
     Namehash { name: String },
-    #[structopt(name = "tx")]
-    #[structopt(about = "Show information about the transaction <tx-hash>")]
+    #[clap(name = "tx")]
+    #[clap(about = "Show information about the transaction <tx-hash>")]
     Tx {
         hash: String,
         field: Option<String>,
-        #[structopt(long = "--json", short = "-j")]
+        #[clap(long = "--json", short = 'j')]
         to_json: bool,
-        #[structopt(long, env = "ETH_RPC_URL")]
+        #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "send")]
-    #[structopt(about = "Publish a transaction signed by <from> to call <to> with <data>")]
+    #[clap(name = "send")]
+    #[clap(about = "Publish a transaction signed by <from> to call <to> with <data>")]
     SendTx {
-        #[structopt(help = "the address you want to transact with", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "the address you want to transact with", parse(try_from_str = parse_name_or_address))]
         to: NameOrAddress,
-        #[structopt(help = "the function signature or name you want to call")]
+        #[clap(help = "the function signature or name you want to call")]
         sig: String,
-        #[structopt(help = "the list of arguments you want to call the function with")]
+        #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
-        #[structopt(long, env = "CAST_ASYNC")]
+        #[clap(long, env = "CAST_ASYNC")]
         cast_async: bool,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         eth: EthereumOpts,
     },
-    #[structopt(name = "estimate")]
-    #[structopt(about = "Estimate the gas cost of a transaction from <from> to <to> with <data>")]
+    #[clap(name = "estimate")]
+    #[clap(about = "Estimate the gas cost of a transaction from <from> to <to> with <data>")]
     Estimate {
-        #[structopt(help = "the address you want to transact with", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "the address you want to transact with", parse(try_from_str = parse_name_or_address))]
         to: NameOrAddress,
-        #[structopt(help = "the function signature or name you want to call")]
+        #[clap(help = "the function signature or name you want to call")]
         sig: String,
-        #[structopt(help = "the list of arguments you want to call the function with")]
+        #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         eth: EthereumOpts,
     },
-    #[structopt(name = "--calldata-decode")]
-    #[structopt(
-        about = "Decode ABI-encoded hex input data. Use `--abi-decode` to decode output data"
-    )]
+    #[clap(name = "--calldata-decode")]
+    #[clap(about = "Decode ABI-encoded hex input data. Use `--abi-decode` to decode output data")]
     CalldataDecode {
-        #[structopt(
+        #[clap(
             help = "the function signature you want to decode, in the format `<name>(<in-types>)(<out-types>)`"
         )]
         sig: String,
-        #[structopt(help = "the encoded calladata, in hex format")]
+        #[clap(help = "the encoded calladata, in hex format")]
         calldata: String,
     },
-    #[structopt(name = "--abi-decode")]
-    #[structopt(
+    #[clap(name = "--abi-decode")]
+    #[clap(
         about = "Decode ABI-encoded hex output data. Pass --input to decode as input, or use `--calldata-decode`"
     )]
     AbiDecode {
-        #[structopt(
+        #[clap(
             help = "the function signature you want to decode, in the format `<name>(<in-types>)(<out-types>)`"
         )]
         sig: String,
-        #[structopt(help = "the encoded calladata, in hex format")]
+        #[clap(help = "the encoded calladata, in hex format")]
         calldata: String,
-        #[structopt(long, short, help = "the encoded output, in hex format")]
+        #[clap(long, short, help = "the encoded output, in hex format")]
         input: bool,
     },
-    #[structopt(name = "abi-encode")]
-    #[structopt(
-        help = "ABI encodes the given arguments with the function signature, excluidng the selector"
+    #[clap(name = "abi-encode")]
+    #[clap(
+        override_help = "ABI encodes the given arguments with the function signature, excluidng the selector"
     )]
     AbiEncode {
-        #[structopt(help = "the function signature")]
+        #[clap(help = "the function signature")]
         sig: String,
-        #[structopt(help = "the list of function arguments")]
+        #[clap(help = "the list of function arguments")]
         args: Vec<String>,
     },
-    #[structopt(name = "4byte")]
-    #[structopt(about = "Fetches function signatures given the selector from 4byte.directory")]
+    #[clap(name = "4byte")]
+    #[clap(about = "Fetches function signatures given the selector from 4byte.directory")]
     FourByte {
-        #[structopt(help = "the function selector")]
+        #[clap(help = "the function selector")]
         selector: String,
     },
-    #[structopt(name = "4byte-decode")]
-    #[structopt(
-        about = "Decodes transaction calldata by fetching the signature using 4byte.directory"
-    )]
+    #[clap(name = "4byte-decode")]
+    #[clap(about = "Decodes transaction calldata by fetching the signature using 4byte.directory")]
     FourByteDecode {
-        #[structopt(help = "the ABI-encoded calldata")]
+        #[clap(help = "the ABI-encoded calldata")]
         calldata: String,
-        #[structopt(long, help = "the 4byte selector id to use, can also be earliest/latest")]
+        #[clap(long, help = "the 4byte selector id to use, can also be earliest/latest")]
         id: Option<String>,
     },
-    #[structopt(name = "age")]
-    #[structopt(about = "Prints the timestamp of a block")]
+    #[clap(name = "age")]
+    #[clap(about = "Prints the timestamp of a block")]
     Age {
-        #[structopt(global = true, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        #[clap(global = true, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
         block: Option<BlockId>,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "balance")]
-    #[structopt(about = "Print the balance of <account> in wei")]
+    #[clap(name = "balance")]
+    #[clap(about = "Print the balance of <account> in wei")]
     Balance {
-        #[structopt(long, short, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        #[clap(long, short, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
         block: Option<BlockId>,
-        #[structopt(help = "the account you want to query", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "the account you want to query", parse(try_from_str = parse_name_or_address))]
         who: NameOrAddress,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "basefee")]
-    #[structopt(about = "Print the basefee of a block")]
+    #[clap(name = "basefee")]
+    #[clap(about = "Print the basefee of a block")]
     BaseFee {
-        #[structopt(global = true, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        #[clap(global = true, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
         block: Option<BlockId>,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "code")]
-    #[structopt(about = "Prints the bytecode at <address>")]
+    #[clap(name = "code")]
+    #[clap(about = "Prints the bytecode at <address>")]
     Code {
-        #[structopt(long, short, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        #[clap(long, short, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
         block: Option<BlockId>,
-        #[structopt(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
         who: NameOrAddress,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "gas-price")]
-    #[structopt(about = "Prints current gas price of target chain")]
+    #[clap(name = "gas-price")]
+    #[clap(about = "Prints current gas price of target chain")]
     GasPrice {
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "keccak")]
-    #[structopt(about = "Keccak-256 hashes arbitrary data")]
+    #[clap(name = "keccak")]
+    #[clap(about = "Keccak-256 hashes arbitrary data")]
     Keccak { data: String },
-    #[structopt(name = "resolve-name")]
-    #[structopt(about = "Returns the address the provided ENS name resolves to")]
+    #[clap(name = "resolve-name")]
+    #[clap(about = "Returns the address the provided ENS name resolves to")]
     ResolveName {
-        #[structopt(help = "the account you want to resolve")]
+        #[clap(help = "the account you want to resolve")]
         who: Option<String>,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
-        #[structopt(
-            long,
-            short,
-            help = "do a forward resolution to ensure the ENS name is correct"
-        )]
+        #[clap(long, short, help = "do a forward resolution to ensure the ENS name is correct")]
         verify: bool,
     },
-    #[structopt(name = "lookup-address")]
-    #[structopt(about = "Returns the name the provided address resolves to")]
+    #[clap(name = "lookup-address")]
+    #[clap(about = "Returns the name the provided address resolves to")]
     LookupAddress {
-        #[structopt(help = "the account you want to resolve")]
+        #[clap(help = "the account you want to resolve")]
         who: Option<Address>,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
-        #[structopt(
-            long,
-            short,
-            help = "do a forward resolution to ensure the address is correct"
-        )]
+        #[clap(long, short, help = "do a forward resolution to ensure the address is correct")]
         verify: bool,
     },
-    #[structopt(name = "storage", about = "Show the raw value of a contract's storage slot")]
+    #[clap(name = "storage", about = "Show the raw value of a contract's storage slot")]
     Storage {
-        #[structopt(help = "the contract address", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "the contract address", parse(try_from_str = parse_name_or_address))]
         address: NameOrAddress,
-        #[structopt(help = "the storage slot number (hex or number)", parse(try_from_str = parse_slot))]
+        #[clap(help = "the storage slot number (hex or number)", parse(try_from_str = parse_slot))]
         slot: H256,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
-        #[structopt(
+        #[clap(
             long,
             short,
             help = "the block you want to query, can also be earliest/latest/pending",
@@ -293,30 +281,30 @@ pub enum Subcommands {
         )]
         block: Option<BlockId>,
     },
-    #[structopt(name = "nonce")]
-    #[structopt(about = "Prints the number of transactions sent from <address>")]
+    #[clap(name = "nonce")]
+    #[clap(about = "Prints the number of transactions sent from <address>")]
     Nonce {
-        #[structopt(long, short = "-B", help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        #[clap(long, short = 'B', help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
         block: Option<BlockId>,
-        #[structopt(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
         who: NameOrAddress,
-        #[structopt(short, long, env = "ETH_RPC_URL")]
+        #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
-    #[structopt(name = "wallet", about = "Set of wallet management utilities")]
+    #[clap(name = "wallet", about = "Set of wallet management utilities")]
     Wallet {
-        #[structopt(subcommand)]
+        #[clap(subcommand)]
         command: WalletSubcommands,
     },
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub enum WalletSubcommands {
-    #[structopt(name = "new", about = "Create and output a new random keypair")]
+    #[clap(name = "new", about = "Create and output a new random keypair")]
     New {
-        #[structopt(help = "If provided, then keypair will be written to encrypted json keystore")]
+        #[clap(help = "If provided, then keypair will be written to encrypted json keystore")]
         path: Option<String>,
-        #[structopt(
+        #[clap(
             long,
             short,
             help = "Triggers a hidden password prompt for the json keystore",
@@ -324,7 +312,7 @@ pub enum WalletSubcommands {
             requires = "path"
         )]
         password: bool,
-        #[structopt(
+        #[clap(
             long,
             help = "Password for json keystore in cleartext. This is UNSAFE to use and we recommend using the --password parameter",
             requires = "path",
@@ -332,32 +320,32 @@ pub enum WalletSubcommands {
         )]
         unsafe_password: Option<String>,
     },
-    #[structopt(name = "vanity", about = "Generate a vanity address")]
+    #[clap(name = "vanity", about = "Generate a vanity address")]
     Vanity {
-        #[structopt(long, help = "Prefix for vanity address", required_unless = "ends-with")]
+        #[clap(long, help = "Prefix for vanity address", required_unless_present = "ends-with")]
         starts_with: Option<String>,
-        #[structopt(long, help = "Suffix for vanity address")]
+        #[clap(long, help = "Suffix for vanity address")]
         ends_with: Option<String>,
     },
-    #[structopt(name = "address", about = "Convert a private key to an address")]
+    #[clap(name = "address", about = "Convert a private key to an address")]
     Address {
-        #[structopt(flatten)]
+        #[clap(flatten)]
         wallet: Wallet,
     },
-    #[structopt(name = "sign", about = "Sign the message with provided private key")]
+    #[clap(name = "sign", about = "Sign the message with provided private key")]
     Sign {
-        #[structopt(help = "message to sign")]
+        #[clap(help = "message to sign")]
         message: String,
-        #[structopt(flatten)]
+        #[clap(flatten)]
         wallet: Wallet,
     },
-    #[structopt(name = "verify", about = "Verify the signature on the message")]
+    #[clap(name = "verify", about = "Verify the signature on the message")]
     Verify {
-        #[structopt(help = "original message")]
+        #[clap(help = "original message")]
         message: String,
-        #[structopt(help = "signature to verify")]
+        #[clap(help = "signature to verify")]
         signature: String,
-        #[structopt(long, short, help = "pubkey of message signer")]
+        #[clap(long, short, help = "pubkey of message signer")]
         address: String,
     },
 }
@@ -388,8 +376,8 @@ fn parse_slot(s: &str) -> eyre::Result<H256> {
     })
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Opts {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub sub: Subcommands,
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -299,7 +299,7 @@ pub enum Subcommands {
     },
     #[clap(about = "generate shell completions script")]
     Completions {
-        #[clap(help = "the shell you are using")]
+        #[clap(help = "supported shells: bash, elvish, fish, powershell, zsh")]
         shell: clap_complete::Shell,
     },
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -1,127 +1,127 @@
-use structopt::StructOpt;
+use clap::{Parser, Subcommand};
 
 use ethers::{solc::EvmVersion, types::Address};
 use std::{path::PathBuf, str::FromStr};
 
 use crate::cmd::{build::BuildArgs, create::CreateArgs, run::RunArgs, snapshot, test};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Opts {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub sub: Subcommands,
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "forge")]
-#[structopt(about = "Build, test, fuzz, formally verify, debug & deploy solidity contracts.")]
+#[derive(Debug, Subcommand)]
+#[clap(name = "forge")]
+#[clap(about = "Build, test, fuzz, formally verify, debug & deploy solidity contracts.")]
 #[allow(clippy::large_enum_variant)]
 pub enum Subcommands {
-    #[structopt(about = "test your smart contracts")]
-    #[structopt(alias = "t")]
+    #[clap(about = "test your smart contracts")]
+    #[clap(alias = "t")]
     Test(test::TestArgs),
 
-    #[structopt(about = "build your smart contracts")]
-    #[structopt(alias = "b")]
+    #[clap(about = "build your smart contracts")]
+    #[clap(alias = "b")]
     Build(BuildArgs),
 
-    #[structopt(about = "run a single smart contract as a script")]
-    #[structopt(alias = "r")]
+    #[clap(about = "run a single smart contract as a script")]
+    #[clap(alias = "r")]
     Run(RunArgs),
 
-    #[structopt(alias = "u", about = "fetches all upstream lib changes")]
+    #[clap(alias = "u", about = "fetches all upstream lib changes")]
     Update {
-        #[structopt(
+        #[clap(
             help = "the submodule name of the library you want to update (will update all if none is provided)"
         )]
         lib: Option<PathBuf>,
     },
 
-    #[structopt(alias = "i", about = "installs one or more dependencies as git submodules")]
+    #[clap(alias = "i", about = "installs one or more dependencies as git submodules")]
     Install {
-        #[structopt(help = "the submodule name of the library you want to install")]
+        #[clap(help = "the submodule name of the library you want to install")]
         dependencies: Vec<Dependency>,
     },
 
-    #[structopt(alias = "r", about = "removes one or more dependencies from git submodules")]
+    #[clap(alias = "r", about = "removes one or more dependencies from git submodules")]
     Remove {
-        #[structopt(help = "the submodule name of the library you want to remove")]
+        #[clap(help = "the submodule name of the library you want to remove")]
         dependencies: Vec<Dependency>,
     },
 
-    #[structopt(about = "prints the automatically inferred remappings for this repository")]
+    #[clap(about = "prints the automatically inferred remappings for this repository")]
     Remappings {
-        #[structopt(
+        #[clap(
             help = "the project's root path, default being the current working directory",
             long
         )]
         root: Option<PathBuf>,
-        #[structopt(help = "the paths where your libraries are installed", long)]
+        #[clap(help = "the paths where your libraries are installed", long)]
         lib_paths: Vec<PathBuf>,
     },
 
-    #[structopt(
+    #[clap(
         about = "verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
     )]
     VerifyContract {
-        #[structopt(help = "contract source info `<path>:<contractname>`")]
+        #[clap(help = "contract source info `<path>:<contractname>`")]
         contract: FullContractInfo,
-        #[structopt(help = "the address of the contract to verify.")]
+        #[clap(help = "the address of the contract to verify.")]
         address: Address,
-        #[structopt(help = "constructor args calldata arguments.")]
+        #[clap(help = "constructor args calldata arguments.")]
         constructor_args: Vec<String>,
     },
 
-    #[structopt(alias = "c", about = "deploy a compiled contract")]
+    #[clap(alias = "c", about = "deploy a compiled contract")]
     Create(CreateArgs),
 
-    #[structopt(alias = "i", about = "initializes a new forge sample repository")]
+    #[clap(alias = "i", about = "initializes a new forge sample repository")]
     Init {
-        #[structopt(help = "the project's root path, default being the current working directory")]
+        #[clap(help = "the project's root path, default being the current working directory")]
         root: Option<PathBuf>,
-        #[structopt(help = "optional solidity template to start from", long, short)]
+        #[clap(help = "optional solidity template to start from", long, short)]
         template: Option<String>,
     },
 
-    #[structopt(about = "generate shell completions script")]
+    #[clap(about = "generate shell completions script")]
     Completions {
-        #[structopt(help = "the shell you are using")]
-        shell: structopt::clap::Shell,
+        #[clap(help = "the shell you are using")]
+        shell: clap_complete::Shell,
     },
 
-    #[structopt(about = "removes the build artifacts and cache directories")]
+    #[clap(about = "removes the build artifacts and cache directories")]
     Clean {
-        #[structopt(
+        #[clap(
             help = "the project's root path, default being the current working directory",
             long
         )]
         root: Option<PathBuf>,
     },
 
-    #[structopt(about = "creates a snapshot of each test's gas usage")]
+    #[clap(about = "creates a snapshot of each test's gas usage")]
     Snapshot(snapshot::SnapshotArgs),
 }
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct CompilerArgs {
-    #[structopt(help = "choose the evm version", long, default_value = "london")]
+    #[clap(help = "choose the evm version", long, default_value = "london")]
     pub evm_version: EvmVersion,
 
-    #[structopt(help = "activate the solidity optimizer", long)]
+    #[clap(help = "activate the solidity optimizer", long)]
     pub optimize: bool,
 
-    #[structopt(help = "optimizer parameter runs", long, default_value = "200")]
+    #[clap(help = "optimizer parameter runs", long, default_value = "200")]
     pub optimize_runs: u32,
 }
 
 use crate::cmd::build::{Env, EvmType};
 use ethers::types::U256;
 
-#[derive(Debug, Clone, StructOpt)]
+#[derive(Debug, Clone, Parser)]
 pub struct EvmOpts {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub env: Env,
 
-    #[structopt(
+    #[clap(
         long,
         short,
         help = "the EVM type you want to use (e.g. sputnik, evmodin)",
@@ -129,26 +129,22 @@ pub struct EvmOpts {
     )]
     pub evm_type: EvmType,
 
-    #[structopt(
-        help = "fetch state over a remote instead of starting from empty state",
-        long,
-        short
-    )]
-    #[structopt(alias = "rpc-url")]
+    #[clap(help = "fetch state over a remote instead of starting from empty state", long, short)]
+    #[clap(alias = "rpc-url")]
     pub fork_url: Option<String>,
 
-    #[structopt(help = "pins the block number for the state fork", long)]
-    #[structopt(env = "DAPP_FORK_BLOCK")]
+    #[clap(help = "pins the block number for the state fork", long)]
+    #[clap(env = "DAPP_FORK_BLOCK")]
     pub fork_block_number: Option<u64>,
 
-    #[structopt(
+    #[clap(
         help = "the initial balance of each deployed test contract",
         long,
         default_value = "0xffffffffffffffffffffffff"
     )]
     pub initial_balance: U256,
 
-    #[structopt(
+    #[clap(
         help = "the address which will be executing all tests",
         long,
         default_value = "0x0000000000000000000000000000000000000000",
@@ -156,10 +152,10 @@ pub struct EvmOpts {
     )]
     pub sender: Address,
 
-    #[structopt(help = "enables the FFI cheatcode", long)]
+    #[clap(help = "enables the FFI cheatcode", long)]
     pub ffi: bool,
 
-    #[structopt(
+    #[clap(
         help = r#"Verbosity mode of EVM output as number of occurences of the `v` flag (-v, -vv, -vvv, etc.)
     3: print test trace for failing tests
     4: always print test trace, print setup for failing tests
@@ -171,7 +167,7 @@ pub struct EvmOpts {
     )]
     pub verbosity: u8,
 
-    #[structopt(help = "enable debugger", long)]
+    #[clap(help = "enable debugger", long)]
     pub debug: bool,
 }
 

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -84,7 +84,7 @@ pub enum Subcommands {
 
     #[clap(about = "generate shell completions script")]
     Completions {
-        #[clap(help = "the shell you are using")]
+        #[clap(help = "bash, elvish, fish, powershell, zsh")]
         shell: clap_complete::Shell,
     },
 

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -3,6 +3,7 @@ pub mod forge;
 
 use std::{convert::TryFrom, str::FromStr};
 
+use clap::Parser;
 use ethers::{
     middleware::SignerMiddleware,
     providers::{Http, Provider},
@@ -13,27 +14,26 @@ use ethers::{
     types::{Address, Chain, U256},
 };
 use eyre::Result;
-use structopt::StructOpt;
 
 const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
 
-#[derive(StructOpt, Debug, Clone)]
+#[derive(Parser, Debug, Clone)]
 pub struct EthereumOpts {
-    #[structopt(env = "ETH_RPC_URL", long = "rpc-url", help = "The tracing / archival node's URL")]
+    #[clap(env = "ETH_RPC_URL", long = "rpc-url", help = "The tracing / archival node's URL")]
     pub rpc_url: Option<String>,
 
-    #[structopt(env = "ETH_FROM", short, long = "from", help = "The sender account")]
+    #[clap(env = "ETH_FROM", short, long = "from", help = "The sender account")]
     pub from: Option<Address>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub wallet: Wallet,
 
-    #[structopt(long, help = "Use the flashbots RPC URL (https://rpc.flashbots.net)")]
+    #[clap(long, help = "Use the flashbots RPC URL (https://rpc.flashbots.net)")]
     pub flashbots: bool,
 
-    #[structopt(long, env = "ETHERSCAN_API_KEY")]
+    #[clap(long, env = "ETHERSCAN_API_KEY")]
     pub etherscan_api_key: Option<String>,
-    #[structopt(long, env = "CHAIN", default_value = "mainnet")]
+    #[clap(long, env = "CHAIN", default_value = "mainnet")]
     pub chain: Chain,
 }
 
@@ -115,7 +115,7 @@ pub enum WalletType {
     Trezor(SignerMiddleware<Provider<Http>, Trezor>),
 }
 
-#[derive(StructOpt, Debug, Clone)]
+#[derive(Parser, Debug, Clone)]
 #[cfg_attr(not(doc), allow(missing_docs))]
 #[cfg_attr(
     doc,
@@ -130,34 +130,31 @@ The wallet options can either be:
 "#
 )]
 pub struct Wallet {
-    #[structopt(long, short, help = "Interactive prompt to insert your private key")]
+    #[clap(long, short, help = "Interactive prompt to insert your private key")]
     pub interactive: bool,
 
-    #[structopt(long = "private-key", help = "Your private key string")]
+    #[clap(long = "private-key", help = "Your private key string")]
     pub private_key: Option<String>,
 
-    #[structopt(long = "keystore", help = "Path to your keystore folder / file")]
+    #[clap(long = "keystore", help = "Path to your keystore folder / file")]
     pub keystore_path: Option<String>,
 
-    #[structopt(long = "password", help = "Your keystore password", requires = "keystore-path")]
+    #[clap(long = "password", help = "Your keystore password", requires = "keystore-path")]
     pub keystore_password: Option<String>,
 
-    #[structopt(long = "mnemonic-path", help = "Path to your mnemonic file")]
+    #[clap(long = "mnemonic-path", help = "Path to your mnemonic file")]
     pub mnemonic_path: Option<String>,
 
-    #[structopt(short, long = "ledger", help = "Use your Ledger hardware wallet")]
+    #[clap(short, long = "ledger", help = "Use your Ledger hardware wallet")]
     pub ledger: bool,
 
-    #[structopt(short, long = "trezor", help = "Use your Trezor hardware wallet")]
+    #[clap(short, long = "trezor", help = "Use your Trezor hardware wallet")]
     pub trezor: bool,
 
-    #[structopt(
-        long = "hd-path",
-        help = "Derivation path for your hardware wallet (trezor or ledger)"
-    )]
+    #[clap(long = "hd-path", help = "Derivation path for your hardware wallet (trezor or ledger)")]
     pub hd_path: Option<String>,
 
-    #[structopt(
+    #[clap(
         long = "mnemonic_index",
         help = "your index in the standard hd path",
         default_value = "0"


### PR DESCRIPTION
structopt is deprecated in favor of clap 3

todo:
- [x] https://github.com/roynalnaruto/svm-rs/pull/14
- [x] update docs
- [x] add shell completions to cast