### PR TITLE
Forge: skip `abstract` contracts

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -231,10 +231,16 @@ mod tests {
         let only_gm = runner.test(&Filter::new("testGm.*", ".*")).unwrap();
         assert_eq!(only_gm.len(), 1);
 
-        dbg!(only_gm.keys().collect::<Vec<_>>());
-
         assert_eq!(only_gm["GmTest.json:GmTest"].len(), 1);
         assert!(only_gm["GmTest.json:GmTest"]["testGm()"].success);
+    }
+
+    fn test_abstract_contract<S: Clone, E: Evm<S>>(evm: E) {
+        let mut runner = runner(evm);
+        let results = runner.test(&Filter::new(".*", ".*")).unwrap();
+        assert!(results.get("Tests.json:Tests").is_none());
+        assert!(results.get("ATests.json:ATests").is_some());
+        assert!(results.get("BTests.json:BTests").is_some());
     }
 
     mod sputnik {
@@ -279,6 +285,11 @@ mod tests {
         #[test]
         fn test_sputnik_multi_runner() {
             test_multi_runner(vm());
+        }
+
+        #[test]
+        fn test_sputnik_abstract_contract() {
+            test_abstract_contract(vm());
         }
     }
 

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -65,6 +65,11 @@ impl MultiContractRunnerBuilder {
         for (fname, contract) in contracts {
             let (maybe_abi, maybe_deploy_bytes, maybe_runtime_bytes) = contract.into_parts();
             if let (Some(abi), Some(bytecode)) = (maybe_abi, maybe_deploy_bytes) {
+                // skip deployment of abstract contracts
+                if bytecode.as_ref().is_empty() {
+                    continue
+                }
+
                 if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true) &&
                     abi.functions().any(|func| func.name.starts_with("test"))
                 {

--- a/forge/testdata/Abstract.sol
+++ b/forge/testdata/Abstract.sol
@@ -1,0 +1,26 @@
+pragma solidity 0.8.10;
+
+interface IContract { function foo() external; }
+
+// your 2 implementations
+contract A is IContract { function foo() public {  } }
+contract B is IContract { function foo() public {  } }
+
+// the shared test suite
+abstract contract Tests {
+          IContract myContract;
+          // this function is part of any contract that inherits `Tests`
+          function testFoo() public { myContract.foo(); }
+}
+
+contract ATests is Tests {
+         function setUp() public {
+                  myContract = IContract(address(new A()));
+         }
+}
+
+contract BTests is Tests {
+         function setUp() public {
+                  myContract = IContract(address(new B()));
+         }
+}


### PR DESCRIPTION
Since Abstract contracts have no bytecode, they should not be deployed at all.

Fixes https://github.com/gakonst/foundry/issues/407