### PR TITLE
feat(forge): add linked libraries env var

### DIFF
--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -77,6 +77,7 @@ pub struct BuildArgs {
 
     #[clap(help = "add linked libraries", long)]
     pub libraries: Vec<String>,
+    #[clap(env = "DAPP_LIBRARIES")]
 }
 
 impl Cmd for BuildArgs {

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -75,9 +75,8 @@ pub struct BuildArgs {
     )]
     pub hardhat: bool,
 
-    #[clap(help = "add linked libraries", long)]
+    #[clap(help = "add linked libraries", long, env = "DAPP_LIBRARIES")]
     pub libraries: Vec<String>,
-    #[clap(env = "DAPP_LIBRARIES")]
 }
 
 impl Cmd for BuildArgs {


### PR DESCRIPTION
- Add linked libraries env var

Test PASS:
- `forgeup naszam/foundry add-lib-env-var`
- https://github.com/makerdao/spells-mainnet/pull/213
- `make test-forge block=13779177`

```haskell
Running 13 tests for DssSpellTest.json:DssSpellTest
[PASS] testCastCost() (gas: 2864655)
[PASS] testFailTooEarly() (gas: 3580)
[PASS] testFailTooLate() (gas: 3591)
[PASS] testFailWrongDay() (gas: 3614)
[PASS] testFail_notScheduled() (gas: 7225)
[PASS] testOnTime() (gas: 2863066)
[PASS] testSpellIsCast_GENERAL() (gas: 11711549)
[PASS] testVestTransfer() (gas: 4238332)
[PASS] test_auth() (gas: 18446673704903691396)
[PASS] test_auth_in_sources() (gas: 18446673704895359673)
[PASS] test_bytecode_matches() (gas: 2783386)
[PASS] test_nextCastTime() (gas: 340057)
[PASS] test_use_eta() (gas: 338962)
```