### PR TITLE
chore: fix typos

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -188,7 +188,7 @@ OPTIONS:
         --ffi
             enables the FFI cheatcode
     -v, --verbosity
-            Verbosity mode of EVM output as number of occurences of the `v` flag (-v, -vv, -vvv, etc.)
+            Verbosity mode of EVM output as number of occurrences of the `v` flag (-v, -vv, -vvv, etc.)
                 3: print test trace for failing tests
                 4: always print test trace, print setup for failing tests
                 5: always print test trace and setup
@@ -263,7 +263,7 @@ You can optionally specify a regular expression, to only run matching functions:
 ```bash
 $ forge test -m Cannot
 $HOME/oss/foundry/target/release/forge test -m Cannot
-no files changed, compilation skippped.
+no files changed, compilation skipped.
 Running 1 test for "Greet.json":Greet
 [PASS] testCannotGm (gas: 6819)
 
@@ -277,7 +277,7 @@ the `--json` flag
 
 ```bash
 $ forge test --json
-no files changed, compilation skippped.
+no files changed, compilation skipped.
 {"\"Gm.json\":Gm":{"testNonOwnerCannotGm":{"success":true,"reason":null,"gas_used":3782,"counterexample":null,"logs":[]},"testOwnerCannotGmOnBadBlocks":{"success":true,"reason":null,"gas_used":7771,"counterexample":null,"logs":[]},"testOwnerCanGmOnGoodBlocks":{"success":true,"reason":null,"gas_used":31696,"counterexample":null,"logs":[]}},"\"Greet.json\":Greet":{"testWorksForAllGreetings":{"success":true,"reason":null,"gas_used":null,"counterexample":null,"logs":[]},"testCannotGm":{"success":true,"reason":null,"gas_used":6819,"counterexample":null,"logs":[]},"testCanSetGreeting":{"success":true,"reason":null,"gas_used":31070,"counterexample":null,"logs":[]}}}
 ```
 

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -48,7 +48,7 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
     if output.has_compiler_errors() {
         eyre::bail!(output.to_string())
     } else if output.is_unchanged() {
-        println!("no files changed, compilation skippped.");
+        println!("no files changed, compilation skipped.");
     } else {
         println!("success.");
     }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -156,7 +156,7 @@ pub struct EvmOpts {
     pub ffi: bool,
 
     #[clap(
-        help = r#"Verbosity mode of EVM output as number of occurences of the `v` flag (-v, -vv, -vvv, etc.)
+        help = r#"Verbosity mode of EVM output as number of occurrences of the `v` flag (-v, -vv, -vvv, etc.)
     3: print test trace for failing tests
     4: always print test trace, print setup for failing tests
     5: always print test trace and setup

--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// After instantiation, calling `fuzz` will proceed to hammer the deployed smart contract with
 /// inputs, until it finds a counterexample. The provided `TestRunner` contains all the
-/// configuration which can be overriden via [environment variables](https://docs.rs/proptest/1.0.0/proptest/test_runner/struct.Config.html)
+/// configuration which can be overridden via [environment variables](https://docs.rs/proptest/1.0.0/proptest/test_runner/struct.Config.html)
 #[derive(Debug)]
 pub struct FuzzedExecutor<'a, E, S> {
     evm: RefCell<&'a mut E>,

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -38,10 +38,10 @@ pub static FAUCET_ACCOUNT: Lazy<Address> =
 pub enum EvmError {
     #[error("Execution reverted: {reason}, (gas: {gas_used})")]
     // TODO: Add proper log printing.
-    /// Error which occured during execution of an EVM transaction
+    /// Error which occurred during execution of an EVM transaction
     Execution { reason: String, gas_used: u64, logs: Vec<String> },
     #[error(transparent)]
-    /// Error which occured during ABI encoding / decoding of data
+    /// Error which occurred during ABI encoding / decoding of data
     AbiError(#[from] ethers::contract::AbiError),
     #[error(transparent)]
     /// Any other generic error
@@ -168,7 +168,7 @@ pub trait Evm<State> {
 
     /// Runs the `failed()` function call to inspect the test contract's state and
     /// see whether the `failed` state var is set. This is to allow compatibility
-    /// with dapptools-style DSTest smart contracts to preserve emiting of logs
+    /// with dapptools-style DSTest smart contracts to preserve emitting of logs
     fn failed(&mut self, address: Address) -> Result<bool> {
         let (failed, _, _, _) =
             self.call::<bool, _, _>(Address::zero(), address, "failed()(bool)", (), 0.into())?;

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -621,7 +621,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             HEVMCalls::Prank(inner) => {
                 self.add_debug(CheatOp::PRANK);
                 let caller = inner.0;
-                if let Some((orginal_pranker, caller, depth)) = self.state().msg_sender {
+                if let Some((original_pranker, caller, depth)) = self.state().msg_sender {
                     let start_prank_depth = if let Some(depth) = self.state().metadata().depth() {
                         depth + 1
                     } else {
@@ -630,7 +630,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     // we allow someone to do a 1 time prank even when startPrank is set if
                     // and only if we ensure that the startPrank *cannot* be applied to the
                     // following call
-                    if start_prank_depth == depth && caller == orginal_pranker {
+                    if start_prank_depth == depth && caller == original_pranker {
                         return evm_error("You have an active `startPrank` at this frame depth already. Use either `prank` or `startPrank`, not both");
                     }
                 }
@@ -760,7 +760,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         Capture::Exit((ExitReason::Succeed(ExitSucceed::Stopped), res))
     }
 
-    // NB: This function is copy-pasted from uptream's `execute`, adjusted so that we call the
+    // NB: This function is copy-pasted from upstream's `execute`, adjusted so that we call the
     // Runtime with our own handler
     pub fn execute(&mut self, runtime: &mut Runtime) -> ExitReason {
         match runtime.run(self) {
@@ -834,7 +834,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 Opcode::STATICCALL => {
                     // this would create an interrupt, have `debug_run` construct a new vec
                     // to commit the current vector of steps into the debugarena
-                    // this maintains the call heirarchy correctly
+                    // this maintains the call hierarchy correctly
                     true
                 }
                 _ => false,
@@ -998,7 +998,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         }
     }
 
-    // NB: This function is copy-pasted from uptream's call_inner
+    // NB: This function is copy-pasted from upstream's call_inner
     #[allow(clippy::too_many_arguments)]
     fn call_inner(
         &mut self,
@@ -1162,7 +1162,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
         }
     }
 
-    // NB: This function is copy-pasted from uptream's create_inner
+    // NB: This function is copy-pasted from upstream's create_inner
     fn create_inner(
         &mut self,
         caller: H160,

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -19,13 +19,13 @@ use sputnik::backend::{Backend, MemoryAccount, MemoryBackend};
 /// Cheatcodes can be used to control the EVM context during setup or runtime,
 /// which can be useful for simulations or specialized unit tests
 pub struct Cheatcodes {
-    /// The overriden block number
+    /// The overridden block number
     pub block_number: Option<U256>,
-    /// The overriden timestamp
+    /// The overridden timestamp
     pub block_timestamp: Option<U256>,
-    /// The overriden basefee
+    /// The overridden basefee
     pub block_base_fee_per_gas: Option<U256>,
-    /// The overriden storage slots
+    /// The overridden storage slots
     pub accounts: HashMap<Address, MemoryAccount>,
 }
 

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -39,7 +39,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet>
     Executor<MemoryStackState<'a, 'a, B>, StackExecutor<'a, 'b, MemoryStackState<'a, 'a, B>, P>>
 {
     /// Given a gas limit, vm version, initial chain configuration and initial state
-    // TOOD: See if we can make lifetimes better here
+    // TODO: See if we can make lifetimes better here
     pub fn new(gas_limit: u64, config: &'a Config, backend: &'a B, precompiles: &'b P) -> Self {
         // setup gasometer
         let metadata = StackSubstateMetadata::new(gas_limit, config);

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -40,7 +40,7 @@ interface Hevm {
     function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
-    // logs were emited in the expected order with the expected topics and data (as specified by the booleans)
+    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
     function expectEmit(bool,bool,bool,bool) external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -47,7 +47,7 @@ impl MultiContractRunnerBuilder {
             // return the diagnostics error back to the user.
             eyre::bail!(output.to_string())
         } else if output.is_unchanged() {
-            println!("no files changed, compilation skippped.");
+            println!("no files changed, compilation skipped.");
         } else {
             println!("success.");
         }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -522,7 +522,7 @@ impl Tui {
         let abs_min_start = 0;
         // Adjust for weird scrolling for max top line
         let abs_max_start = (opcode_list.len() as i32 - 1) - height + scroll_offset;
-        // actual minumum start line
+        // actual minimum start line
         let mut min_start =
             max(current_step as i32 - height + extra_top_lines, abs_min_start) as usize;
 


### PR DESCRIPTION
`skippped` in the terminal output bugged me so here's a very important PR! 😛

(thanks to [typos](https://github.com/crate-ci/typos) crate for finding the other typos here)