### PR TITLE
fix `forge test` -- `Address::zero()` incompatibility

### DIFF
--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -290,14 +290,14 @@ pub struct Env {
     #[clap(
         help = "the tx.origin value during EVM execution",
         long,
-        default_value_t = Address::zero()
+        default_value = "0x0000000000000000000000000000000000000000"
     )]
     pub tx_origin: Address,
 
     #[clap(
         help = "the block.coinbase value during EVM execution",
         long,
-        default_value_t = Address::zero()
+        default_value = "0x0000000000000000000000000000000000000000"
     )]
     pub block_coinbase: Address,
     #[clap(


### PR DESCRIPTION
i should have caught this but it slipped by. there's an issue with Address::zero() being used as a default in clap. 

```
❯ forge test
error: Invalid value for '--tx-origin <TX_ORIGIN>': Invalid character '…' at position 4
```