### PR TITLE
chore: Minor cleanup in `brock/par_evm`

### DIFF
--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -79,25 +79,21 @@ impl Cmd for RunArgs {
         // this should never fail if compilation was successful
         let bytecode = bin.into_bytes().unwrap();
 
-        // 2. instantiate the EVM w forked backend if needed / pre-funded account(s)
+        // 1. instantiate the EVM w forked backend if needed / pre-funded account(s)
         let mut cfg = crate::utils::sputnik_cfg(self.opts.compiler.evm_version);
         let vicinity = self.evm_opts.vicinity()?;
         let evm = crate::utils::sputnik_helpers::evm(&evm_opts, &mut cfg, &vicinity)?;
 
-        // 3. deploy the contract
-        // let (addr, _, _, logs) = evm.deploy(self.evm_opts.sender, bytecode.clone(),
-        // 0u32.into())?;
-
-        // 4. set up the runner
+        // 2. set up the runner
         let runner =
             ContractRunner::new(self.evm_opts.clone(), &abi, bytecode, Some(self.evm_opts.sender));
 
-        // 5. run the test function & potentially the setup
+        // 3. run the test function & potentially the setup
         let needs_setup = abi.functions().any(|func| func.name == "setUp");
         let result = runner.run_test(&func, needs_setup, Some(&known_contracts))?;
 
         if self.evm_opts.debug {
-            // 6. Boot up debugger
+            // 4. Boot up debugger
             let source_code: BTreeMap<u32, String> = sources
                 .iter()
                 .map(|(id, path)| {
@@ -165,7 +161,7 @@ impl Cmd for RunArgs {
                 println!();
             }
         } else {
-            // 6. print the result nicely
+            // 5. print the result nicely
             if result.success {
                 println!("{}", Colour::Green.paint("Script ran successfully."));
             } else {

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -49,13 +49,13 @@ impl MultiContractRunnerBuilder {
         // artifacts
         let contracts = output.into_artifacts();
         let mut known_contracts: BTreeMap<String, (Abi, Vec<u8>)> = Default::default();
-        let mut deployed_contracts: BTreeMap<String, (Abi, ethers::prelude::Bytes)> =
+        let mut deployable_contracts: BTreeMap<String, (Abi, ethers::prelude::Bytes)> =
             Default::default();
 
         for (fname, contract) in contracts {
             let (maybe_abi, maybe_deploy_bytes, maybe_runtime_bytes) = contract.into_parts();
             if let (Some(abi), Some(bytecode)) = (maybe_abi, maybe_deploy_bytes) {
-                deployed_contracts.insert(fname.clone(), (abi.clone(), bytecode.clone()));
+                deployable_contracts.insert(fname.clone(), (abi.clone(), bytecode.clone()));
 
                 let split = fname.split(':').collect::<Vec<&str>>();
                 let contract_name = if split.len() > 1 { split[1] } else { split[0] };
@@ -66,7 +66,7 @@ impl MultiContractRunnerBuilder {
         }
 
         Ok(MultiContractRunner {
-            contracts: deployed_contracts,
+            contracts: deployable_contracts,
             known_contracts,
             identified_contracts: Default::default(),
             evm_opts,
@@ -97,8 +97,7 @@ impl MultiContractRunnerBuilder {
 /// A multi contract runner receives a set of contracts deployed in an EVM instance and proceeds
 /// to run all test functions in these contracts.
 pub struct MultiContractRunner {
-    /// Mapping of contract name to compiled bytecode, deployed address and logs emitted during
-    /// deployment
+    /// Mapping of contract name to Abi and creation bytecode
     pub contracts: BTreeMap<String, (Abi, ethers::prelude::Bytes)>,
     /// Compiled contracts by name that have an Abi and runtime bytecode
     pub known_contracts: BTreeMap<String, (Abi, Vec<u8>)>,


### PR DESCRIPTION
1. Renames `deployed_contracts` for clarity
2. Updates comments in some places