### PR TITLE
fix(forge): No bail on setup

### DIFF
--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -161,7 +161,7 @@ pub struct FuzzedCases {
 }
 
 impl FuzzedCases {
-    fn new(mut cases: Vec<FuzzCase>) -> Self {
+    pub fn new(mut cases: Vec<FuzzCase>) -> Self {
         cases.sort_by_key(|c| c.gas);
         Self { cases }
     }

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -222,9 +222,14 @@ mod tests {
 
         // 8 contracts being built
         assert_eq!(results.keys().len(), 8);
-        for (_, contract_tests) in results {
-            assert_ne!(contract_tests.keys().len(), 0);
-            assert!(contract_tests.iter().all(|(_, result)| result.success));
+        for (key, contract_tests) in results {
+            // for a bad setup, we dont want a successful test
+            if key == "SetupTest.json:SetupTest" {
+                assert!(contract_tests.iter().all(|(_, result)| !result.success));
+            } else {
+                assert_ne!(contract_tests.keys().len(), 0);
+                assert!(contract_tests.iter().all(|(_, result)| result.success));
+            }
         }
 
         // can also filter

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -220,8 +220,8 @@ mod tests {
         let mut runner = runner(evm);
         let results = runner.test(&Filter::new(".*", ".*")).unwrap();
 
-        // 6 contracts being built
-        assert_eq!(results.keys().len(), 7);
+        // 8 contracts being built
+        assert_eq!(results.keys().len(), 8);
         for (_, contract_tests) in results {
             assert_ne!(contract_tests.keys().len(), 0);
             assert!(contract_tests.iter().all(|(_, result)| result.success));

--- a/forge/testdata/BadSetup.sol
+++ b/forge/testdata/BadSetup.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.1;
+
+contract DsTestMini {
+    bool public failed;
+
+    function fail() private {
+        failed = true;
+    }
+
+    function assertEq(uint a, uint b) internal {
+        if (a != b) {
+            fail();
+        }
+    }
+}
+
+contract SetupTest is DsTestMini {
+    function setUp() public {
+        T t = new T(10);
+    }
+
+    function testSetupBad() public {
+    }
+
+    function testSetupBad2() public {
+    }
+}
+
+
+contract T {
+    constructor(uint256 a) {
+        uint256 b = a - 100;
+    }
+}


### PR DESCRIPTION
Instead of bailing when a `setUp` fails, we just return a failed test. This allows people to debug the setup via `-vvv` and generally just know why the setup failed.


Closes #433 