### PR TITLE
chore(deps): bump ethabi master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "16.0.0"
-source = "git+https://github.com/rust-ethereum/ethabi?branch=master#7f4bb3d6164775928485b2bad2f6e130a96f438e"
+source = "git+https://github.com/rust-ethereum/ethabi?branch=master#199e307462ea6ad17c3ff48dcba8aa42b23cb2c3"
 dependencies = [
  "ethereum-types",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1362,7 +1362,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1456,7 +1456,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#19671e51deefec4c8f384270dd9141290a4f65b9"
+source = "git+https://github.com/gakonst/ethers-rs#b619a5522f4aa814f56599d7be8463bca12c23fa"
 dependencies = [
  "colored",
  "dunce",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "solang-parser"
 version = "0.1.1"
-source = "git+https://github.com/hyperledger-labs/solang#190f7205dd2ec50f8d930741785a79e6ddf0148b"
+source = "git+https://github.com/hyperledger-labs/solang#50585197f0cc391e776bba0fe15ed125c8a2f16c"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -52,7 +52,7 @@ pub async fn run(
             name: "constructor".to_string(),
             inputs: constructor.inputs,
             outputs: vec![],
-            constant: false,
+            constant: None,
             state_mutability: Default::default(),
         };
 

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -132,7 +132,7 @@ pub trait Evm<State> {
     ) -> Result<(Bytes, Self::ReturnReason, u64, Vec<String>)> {
         let calldata = encode_function_data(func, args)?;
         #[allow(deprecated)]
-        let is_static = func.constant ||
+        let is_static = func.constant.unwrap_or_default() ||
             matches!(
                 func.state_mutability,
                 ethers::abi::StateMutability::View | ethers::abi::StateMutability::Pure


### PR DESCRIPTION
blocked by https://github.com/gakonst/ethers-rs/pull/787
needs `cargo update -p ethers` 