### PR TITLE
Adds polygon-mainnet and polygon-mumbai

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -349,9 +349,7 @@ where
             "0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177" => "rinkeby",
             "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a" => "goerli",
             "0x14c2283285a88fe5fce9bf5c573ab03d6616695d717b12a127188bcacfc743c4" => "kotti",
-            "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b" => {
-                "polygon-mainnet"
-            }
+            "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b" => "polygon",
             "0x7b66506a9ebdbf30d32b43c5f15a3b1216269a1ec3a75aa3182b86176a2b1ca7" => {
                 "polygon-mumbai"
             }

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -349,6 +349,12 @@ where
             "0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177" => "rinkeby",
             "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a" => "goerli",
             "0x14c2283285a88fe5fce9bf5c573ab03d6616695d717b12a127188bcacfc743c4" => "kotti",
+            "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b" => {
+                "polygon-mainnet"
+            }
+            "0x7b66506a9ebdbf30d32b43c5f15a3b1216269a1ec3a75aa3182b86176a2b1ca7" => {
+                "polygon-mumbai"
+            }
             "0x6d3c66c5357ec91d5c43af47e234a939b22557cbb552dc45bebbceeed90fbe34" => "bsctest",
             "0x0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b" => "bsc",
             "0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b" => {


### PR DESCRIPTION
Adds polygon-mainnet and polygon-mumbai. 

**Genesis Hashes**
mainnet:
https://polygonscan.com/block/0

mumbai:
https://mumbai.polygonscan.com/block/0

**Test**
mainnet:
`ETH_RPC_URL=https://polygon-rpc.com cargo run --bin cast chain`

mumbai:
`ETH_RPC_URL=https://rpc-mumbai.matic.today cargo run --bin cast chain`


Used @joshieDo's [PR as reference](https://github.com/gakonst/foundry/pull/210#issue-1077601230)