### PR TITLE
fix(cast): --to-wei with decimals

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -693,7 +693,7 @@ impl SimpleCast {
     /// use cast::SimpleCast as Cast;
     ///
     /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_wei(1.into(), "".to_string())?, "1");
+    ///     assert_eq!(Cast::to_wei(1.into(), "".to_string())?, "1000000000000000000");
     ///     assert_eq!(Cast::to_wei(100.into(), "gwei".to_string())?, "100000000000");
     ///     assert_eq!(Cast::to_wei(100.into(), "eth".to_string())?, "100000000000000000000");
     ///     assert_eq!(Cast::to_wei(1000.into(), "ether".to_string())?, "1000000000000000000000");
@@ -719,9 +719,9 @@ impl SimpleCast {
     /// fn main() -> eyre::Result<()> {
     ///     assert_eq!(Cast::from_wei(1.into(), "gwei".to_string())?, "0.000000001");
     ///     assert_eq!(Cast::from_wei(12340000005u64.into(), "gwei".to_string())?, "12.340000005");
-    ///     assert_eq!(Cast::from_wei(10.into(), "ether".to_string())?, "0.00000000000000001");
-    ///     assert_eq!(Cast::from_wei(100.into(), "eth".to_string())?, "0.0000000000000001");
-    ///     assert_eq!(Cast::from_wei(17.into(), "".to_string())?, "17");
+    ///     assert_eq!(Cast::from_wei(10.into(), "ether".to_string())?, "0.000000000000000010");
+    ///     assert_eq!(Cast::from_wei(100.into(), "eth".to_string())?, "0.000000000000000100");
+    ///     assert_eq!(Cast::from_wei(17.into(), "".to_string())?, "0.000000000000000017");
     ///
     ///     Ok(())
     /// }
@@ -730,7 +730,7 @@ impl SimpleCast {
         Ok(match &unit[..] {
             "gwei" => ethers_core::utils::format_units(value, 9),
             "eth" | "ether" => ethers_core::utils::format_units(value, 18),
-            _ => ethers_core::utils::format_units(value, 9),
+            _ => ethers_core::utils::format_units(value, 18),
         }?)
     }
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -707,7 +707,8 @@ impl SimpleCast {
             "gwei" => ethers_core::utils::parse_units(value, 9),
             "eth" | "ether" => ethers_core::utils::parse_units(value, 18),
             _ => ethers_core::utils::parse_units(value, 18),
-        }?.to_string())
+        }?
+        .to_string())
     }
 
     /// Converts wei into an eth amount

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -701,13 +701,13 @@ impl SimpleCast {
     ///     Ok(())
     /// }
     /// ```
-    pub fn to_wei(value: U256, unit: String) -> Result<String> {
+    pub fn to_wei(value: f64, unit: String) -> Result<String> {
         let value = value.to_string();
         Ok(match &unit[..] {
-            "gwei" => format!("{:0<1$}", value, 9 + value.len()),
-            "eth" | "ether" => format!("{:0<1$}", value, 18 + value.len()),
-            _ => value,
-        })
+            "gwei" => ethers_core::utils::parse_units(value, 9),
+            "eth" | "ether" => ethers_core::utils::parse_units(value, 18),
+            _ => ethers_core::utils::parse_units(value, 18),
+        }?.to_string())
     }
 
     /// Converts wei into an eth amount
@@ -727,22 +727,10 @@ impl SimpleCast {
     /// ```
     pub fn from_wei(value: U256, unit: String) -> Result<String> {
         Ok(match &unit[..] {
-            "gwei" => {
-                let gwei = U256::pow(10.into(), 9.into());
-                let left = value / gwei;
-                let right = value - left * gwei;
-                let res = format!("{}.{:0>9}", left, right.to_string());
-                res.trim_end_matches('0').to_string()
-            }
-            "eth" | "ether" => {
-                let wei = U256::pow(10.into(), 18.into());
-                let left = value / wei;
-                let right = value - left * wei;
-                let res = format!("{}.{:0>18}", left, right.to_string());
-                res.trim_end_matches('0').to_string()
-            }
-            _ => value.to_string(),
-        })
+            "gwei" => ethers_core::utils::format_units(value, 9),
+            "eth" | "ether" => ethers_core::utils::format_units(value, 18),
+            _ => ethers_core::utils::format_units(value, 9),
+        }?)
     }
 
     /// Converts an Ethereum address to its checksum format

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -110,7 +110,7 @@ async fn main() -> eyre::Result<()> {
             println!(
                 "{}",
                 SimpleCast::to_wei(
-                    U256::from_dec_str(&val)?,
+                    val.parse::<f64>()?,
                     unit.unwrap_or_else(|| String::from("eth"))
                 )?
             );


### PR DESCRIPTION
`cast --to-wei` was using `U256` as the type for the input, causing it to fail when you included a decimal point. I fixed that and also refactored `to_wei` and `from_wei` to use `ethers::utils::parse_uints` and `ethers::utils::format_units` which helps clean things up a bit.