### PR TITLE
feat(forge): Pranks can now set tx.origin

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/backend.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/backend.rs
@@ -25,7 +25,7 @@ impl<B: Backend> Backend for CheatcodeBackend<B> {
     }
 
     fn origin(&self) -> H160 {
-        self.backend.origin()
+        self.cheats.origin.unwrap_or_else(|| self.backend.origin())
     }
 
     fn block_hash(&self, number: U256) -> H256 {

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -32,6 +32,7 @@ use std::{convert::Infallible, str::FromStr};
 
 use crate::sputnik::cheatcodes::{
     debugger::{CheatOp, DebugArena, DebugNode, DebugStep, OpCode},
+    memory_stackstate_owned::Prank,
     patch_hardhat_console_log_selector,
 };
 use once_cell::sync::Lazy;
@@ -622,10 +623,10 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     Token::FixedBytes(s_bytes.to_vec()),
                 ])]);
             }
-            HEVMCalls::Prank(inner) => {
+            HEVMCalls::Prank0(inner) => {
                 self.add_debug(CheatOp::PRANK);
                 let caller = inner.0;
-                if let Some((original_pranker, caller, depth)) = self.state().msg_sender {
+                if let Some(Prank { prank_caller, depth, .. }) = self.state().prank {
                     let start_prank_depth = if let Some(depth) = self.state().metadata().depth() {
                         depth + 1
                     } else {
@@ -634,13 +635,22 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     // we allow someone to do a 1 time prank even when startPrank is set if
                     // and only if we ensure that the startPrank *cannot* be applied to the
                     // following call
-                    if start_prank_depth == depth && caller == original_pranker {
+                    if start_prank_depth == depth && caller == prank_caller {
                         return evm_error("You have an active `startPrank` at this frame depth already. Use either `prank` or `startPrank`, not both");
                     }
                 }
-                self.state_mut().next_msg_sender = Some(caller);
+                self.state_mut().next_prank = Some(Prank {
+                    prank_caller: msg_sender,
+                    new_caller: caller,
+                    new_origin: None,
+                    depth: if let Some(depth) = self.state().metadata().depth() {
+                        depth + 1
+                    } else {
+                        0
+                    },
+                });
             }
-            HEVMCalls::StartPrank(inner) => {
+            HEVMCalls::StartPrank0(inner) => {
                 self.add_debug(CheatOp::STARTPRANK);
                 // startPrank works by using frame depth to determine whether to overwrite
                 // msg.sender if we set a prank caller at a particular depth, it
@@ -651,23 +661,68 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 // so that we dont apply it to any other addresses when depth ==
                 // prank_depth
                 let caller = inner.0;
-                if self.state().next_msg_sender.is_some() {
+                if self.state().next_prank.is_some() {
                     return evm_error("You have an active `prank` call already. Use either `prank` or `startPrank`, not both");
                 } else {
-                    self.state_mut().msg_sender = Some((
-                        msg_sender,
-                        caller,
-                        if let Some(depth) = self.state().metadata().depth() {
+                    self.state_mut().prank = Some(Prank {
+                        prank_caller: msg_sender,
+                        new_caller: caller,
+                        new_origin: None,
+                        depth: if let Some(depth) = self.state().metadata().depth() {
                             depth + 1
                         } else {
                             0
                         },
-                    ));
+                    });
+                }
+            }
+            HEVMCalls::Prank1(inner) => {
+                self.add_debug(CheatOp::PRANK);
+                let caller = inner.0;
+                let origin = inner.1;
+                if let Some(Prank { depth, prank_caller, .. }) = self.state().prank {
+                    let start_prank_depth = if let Some(depth) = self.state().metadata().depth() {
+                        depth + 1
+                    } else {
+                        0
+                    };
+                    if start_prank_depth == depth && caller == prank_caller {
+                        return evm_error("You have an active `startPrank` at this frame depth already. Use either `prank` or `startPrank`, not both");
+                    }
+                }
+                self.state_mut().next_prank = Some(Prank {
+                    prank_caller: msg_sender,
+                    new_caller: caller,
+                    new_origin: Some(origin),
+                    depth: if let Some(depth) = self.state().metadata().depth() {
+                        depth + 1
+                    } else {
+                        0
+                    },
+                });
+            }
+            HEVMCalls::StartPrank1(inner) => {
+                self.add_debug(CheatOp::STARTPRANK);
+                let caller = inner.0;
+                let origin = inner.1;
+                if self.state().next_prank.is_some() {
+                    return evm_error("You have an active `prank` call already. Use either `prank` or `startPrank`, not both");
+                } else {
+                    self.state_mut().prank = Some(Prank {
+                        prank_caller: msg_sender,
+                        new_caller: caller,
+                        new_origin: Some(origin),
+                        depth: if let Some(depth) = self.state().metadata().depth() {
+                            depth + 1
+                        } else {
+                            0
+                        },
+                    });
                 }
             }
             HEVMCalls::StopPrank(_) => {
                 self.add_debug(CheatOp::STOPPRANK);
-                self.state_mut().msg_sender = None;
+                self.state_mut().prank = None;
             }
             HEVMCalls::ExpectRevert(inner) => {
                 self.add_debug(CheatOp::EXPECTREVERT);
@@ -1374,6 +1429,9 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
         } else if code_address == *CONSOLE_ADDRESS {
             self.console_log(input)
         } else {
+            // record prior origin
+            let prev_origin = self.state().backend.cheats.origin;
+
             // modify execution context depending on the cheatcode
             let expected_revert = self.state_mut().expected_revert.take();
             let mut new_context = context;
@@ -1382,28 +1440,32 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 if let Some(depth) = self.state().metadata().depth() { depth + 1 } else { 0 };
 
             // handle `startPrank` - see apply_cheatcodes for more info
-            if let Some((original_msg_sender, permanent_caller, depth)) = self.state().msg_sender {
-                if curr_depth == depth && new_context.caller == original_msg_sender {
-                    new_context.caller = permanent_caller;
+            if let Some(Prank { prank_caller, new_caller, new_origin, depth }) = self.state().prank
+            {
+                // if depth and msg.sender match, perform the prank
+                if curr_depth == depth && new_context.caller == prank_caller {
+                    new_context.caller = new_caller;
 
                     if let Some(t) = &new_transfer {
-                        new_transfer = Some(Transfer {
-                            source: permanent_caller,
-                            target: t.target,
-                            value: t.value,
-                        });
+                        new_transfer =
+                            Some(Transfer { source: new_caller, target: t.target, value: t.value });
                     }
+
+                    // set the origin if the user used the overloaded func
+                    self.state_mut().backend.cheats.origin = new_origin;
                 }
             }
 
             // handle normal `prank`
-            if let Some(caller) = self.state_mut().next_msg_sender.take() {
-                new_context.caller = caller;
+            if let Some(Prank { new_caller, new_origin, .. }) = self.state_mut().next_prank.take() {
+                new_context.caller = new_caller;
 
                 if let Some(t) = &new_transfer {
                     new_transfer =
-                        Some(Transfer { source: caller, target: t.target, value: t.value });
+                        Some(Transfer { source: new_caller, target: t.target, value: t.value });
                 }
+
+                self.state_mut().backend.cheats.origin = new_origin;
             }
 
             // handle expected calls
@@ -1443,6 +1505,9 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 true,
                 new_context,
             );
+
+            // if we set the origin, now we should reset to previous
+            self.state_mut().backend.cheats.origin = prev_origin;
 
             // handle expected emits
             if !self.state_mut().expected_emits.is_empty() &&
@@ -1619,35 +1684,45 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
         target_gas: Option<u64>,
     ) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Self::CreateInterrupt> {
         // modify execution context depending on the cheatcode
+
+        let prev_origin = self.state().backend.cheats.origin;
         let expected_revert = self.state_mut().expected_revert.take();
-        let mut new_caller = caller;
+        let mut new_tx_caller = caller;
         let mut new_scheme = scheme;
         let curr_depth =
             if let Some(depth) = self.state().metadata().depth() { depth + 1 } else { 0 };
 
         // handle `startPrank` - see apply_cheatcodes for more info
-        if let Some((original_msg_sender, permanent_caller, depth)) = self.state().msg_sender {
-            if curr_depth == depth && new_caller == original_msg_sender {
-                new_caller = permanent_caller;
+        if let Some(Prank { prank_caller, new_caller, new_origin, depth }) = self.state().prank {
+            if curr_depth == depth && new_tx_caller == prank_caller {
+                new_tx_caller = new_caller;
+
+                self.state_mut().backend.cheats.origin = new_origin
             }
         }
 
         // handle normal `prank`
-        if let Some(caller) = self.state_mut().next_msg_sender.take() {
-            new_caller = caller;
+        if let Some(Prank { new_caller, new_origin, .. }) = self.state_mut().next_prank.take() {
+            new_tx_caller = new_caller;
+
+            self.state_mut().backend.cheats.origin = new_origin
         }
 
-        if caller != new_caller {
+        if caller != new_tx_caller {
             new_scheme = match scheme {
-                CreateScheme::Legacy { .. } => CreateScheme::Legacy { caller: new_caller },
+                CreateScheme::Legacy { .. } => CreateScheme::Legacy { caller: new_tx_caller },
                 CreateScheme::Create2 { code_hash, salt, .. } => {
-                    CreateScheme::Create2 { caller: new_caller, code_hash, salt }
+                    CreateScheme::Create2 { caller: new_tx_caller, code_hash, salt }
                 }
                 _ => scheme,
             };
         }
 
-        let res = self.create_inner(new_caller, new_scheme, value, init_code, target_gas, true);
+        let res = self.create_inner(new_tx_caller, new_scheme, value, init_code, target_gas, true);
+
+        // if we set the origin, now we should reset to prior origin
+        self.state_mut().backend.cheats.origin = prev_origin;
+
         if !self.state_mut().expected_emits.is_empty() &&
             !self
                 .state()

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -28,6 +28,18 @@ pub struct ExpectedEmit {
     pub found: bool,
 }
 
+#[derive(Clone, Default, Debug)]
+pub struct Prank {
+    /// Address of the contract that called prank
+    pub prank_caller: H160,
+    /// Address to set msg.sender to
+    pub new_caller: H160,
+    /// New origin to use
+    pub new_origin: Option<H160>,
+    /// Call depth at which the prank was called
+    pub depth: usize,
+}
+
 /// This struct implementation is copied from [upstream](https://github.com/rust-blockchain/evm/blob/5ecf36ce393380a89c6f1b09ef79f686fe043624/src/executor/stack/state.rs#L412) and modified to own the Backend type.
 ///
 /// We had to copy it so that we can modify the Stack's internal backend, because
@@ -47,10 +59,10 @@ pub struct MemoryStackStateOwned<'config, B> {
     pub traces: Vec<CallTraceArena>,
     /// Expected revert storage of bytes
     pub expected_revert: Option<Vec<u8>>,
-    /// Msg.sender of next call
-    pub next_msg_sender: Option<H160>,
-    /// Tuple of (address that called startPrank, new address to use, depth)
-    pub msg_sender: Option<(H160, H160, usize)>,
+    /// Next call's prank
+    pub next_prank: Option<Prank>,
+    /// StartPrank information
+    pub prank: Option<Prank>,
     /// List of accesses done during a call
     pub accesses: Option<RecordAccess>,
     /// All logs accumulated (regardless of revert status)
@@ -121,8 +133,8 @@ impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
             trace_index: 1,
             traces: vec![Default::default()],
             expected_revert: None,
-            next_msg_sender: None,
-            msg_sender: None,
+            next_prank: None,
+            prank: None,
             accesses: None,
             all_logs: Default::default(),
             expected_emits: Default::default(),

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -27,6 +27,8 @@ pub struct Cheatcodes {
     pub block_base_fee_per_gas: Option<U256>,
     /// The overridden storage slots
     pub accounts: HashMap<Address, MemoryAccount>,
+    /// The overriden tx.origin
+    pub origin: Option<Address>,
 }
 
 /// Extension trait over [`Backend`] which provides additional methods for interacting with the
@@ -56,6 +58,8 @@ ethers::contract::abigen!(
             sign(uint256,bytes32)(uint8,bytes32,bytes32)
             prank(address)
             startPrank(address)
+            prank(address,address)
+            startPrank(address,address)
             stopPrank()
             deal(address,uint256)
             etch(address,bytes)

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -26,6 +26,10 @@ interface Hevm {
     function prank(address) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
     function startPrank(address) external;
+    // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
+    function prank(address,address) external;
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
+    function startPrank(address,address) external;
     // Resets subsequent calls' msg.sender to be `address(this)`
     function stopPrank() external;
     // Sets an address' balance, (who, newBalance)
@@ -238,6 +242,43 @@ contract CheatCodes is DSTest {
         complexPrank.uncompletedPrank();
         prank.bar(address(this));
         complexPrank.completePrank(prank);
+    }
+
+    function testPrankDual() public {
+        Prank prank = new Prank();
+        address new_sender = address(1337);
+        address sender = msg.sender;
+        hevm.prank(new_sender, new_sender);
+        prank.baz(new_sender, new_sender);
+        prank.baz(address(this), tx.origin);
+    }
+
+    function testPrankConstructorDual() public {
+        address new_sender = address(1337);
+        hevm.prank(new_sender, new_sender);
+        PrankConstructorDual prank2 = new PrankConstructorDual(address(1337), address(1337));
+        PrankConstructorDual prank3 = new PrankConstructorDual(address(this), tx.origin);
+    }
+
+    function testPrankStartDual() public {
+        Prank prank = new Prank();
+        address new_sender = address(1337);
+        address sender = msg.sender;
+        hevm.startPrank(new_sender, new_sender);
+        prank.baz(new_sender, new_sender);
+        prank.baz(new_sender, new_sender);
+        hevm.stopPrank();
+        prank.baz(address(this), tx.origin);
+    }
+
+    function testPrankStartComplexDual() public {
+        // A -> B, B starts pranking, doesnt call stopPrank, A calls C calls D
+        // C -> D would be pranked
+        ComplexPrank complexPrank = new ComplexPrank();
+        Prank prank = new Prank();
+        complexPrank.uncompletedPrankDual();
+        prank.baz(address(this), tx.origin);
+        complexPrank.completePrankDual(prank);
     }
 
     function testEtch() public {
@@ -613,6 +654,13 @@ contract Prank {
         inner.bar(address(this));
     }
 
+    function baz(address expectedMsgSender, address expectedOrigin) public {
+        require(msg.sender == expectedMsgSender, "bad prank");
+        require(tx.origin == expectedOrigin, "bad prank origin");
+        InnerPrank inner = new InnerPrank();
+        inner.baz(address(this), expectedOrigin);
+    }
+
     function payableBar(address expectedMsgSender) payable public {
         bar(expectedMsgSender);
     }
@@ -630,9 +678,28 @@ contract PrankConstructor {
     }
 }
 
+contract PrankConstructorDual {
+    constructor(address expectedMsgSender, address expectedOrigin) {
+        require(msg.sender == expectedMsgSender, "bad prank");
+        require(tx.origin == expectedOrigin, "bad prank origin");
+    }
+
+    function baz(address expectedMsgSender, address expectedOrigin) public {
+        require(msg.sender == expectedMsgSender, "bad prank");
+        require(tx.origin == expectedOrigin, "bad prank origin");
+        InnerPrank inner = new InnerPrank();
+        inner.baz(address(this), expectedOrigin);
+    }
+}
+
 contract InnerPrank {
     function bar(address expectedMsgSender) public {
         require(msg.sender == expectedMsgSender, "bad prank");
+    }
+
+    function baz(address expectedMsgSender, address expectedOrigin) public {
+        require(msg.sender == expectedMsgSender, "bad prank");
+        require(tx.origin == expectedOrigin, "bad prank origin");
     }
 }
 
@@ -643,10 +710,20 @@ contract ComplexPrank {
         hevm.startPrank(address(1337));
     }
 
+    function uncompletedPrankDual() public {
+        hevm.startPrank(address(1337), address(1337));
+    }
+
     function completePrank(Prank prank) public {
         prank.bar(address(1337));
         hevm.stopPrank();
         prank.bar(address(this));
+    }
+
+    function completePrankDual(Prank prank) public {
+        prank.baz(address(1337), address(1337));
+        hevm.stopPrank();
+        prank.baz(address(this), tx.origin);
     }
 }
 

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -272,6 +272,9 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
         let mut traces: Option<Vec<CallTraceArena>> = None;
         let mut identified_contracts: Option<BTreeMap<Address, (String, Abi)>> = None;
 
+        // clear out the deployment trace
+        evm.reset_traces();
+
         // call the setup function in each test to reset the test's state.
         if setup {
             tracing::trace!("setting up");
@@ -372,6 +375,9 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
 
         let mut traces: Option<Vec<CallTraceArena>> = None;
         let mut identified_contracts: Option<BTreeMap<Address, (String, Abi)>> = None;
+
+        // clear out the deployment trace
+        evm.reset_traces();
 
         // call the setup function in each test to reset the test's state.
         if setup {


### PR DESCRIPTION
Per title, adds ability to pass two address to prank cheatcodes to enable setting of origin as well.

Also fixes a tracing bug that would display the deployment trace that regressed after parallel evm was merged