### PR TITLE
Nightly releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,16 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
-          # We can't compile for M1 yet
-          # See https://github.com/rust-bitcoin/rust-secp256k1/issues/283
-          # - os: macos-latest
-          #   platform: darwin
-          #   target: x86_64-apple-darwin
-          #   arch: amd64
           - os: macos-latest
             platform: darwin
-            target: aarch64-apple-darwin
-            arch: arm64
+            target: x86_64-apple-darwin
+            arch: amd64
+          # We can't compile for M1 yet
+          # See https://github.com/rust-bitcoin/rust-secp256k1/issues/283
+          #- os: macos-latest
+          #  platform: darwin
+          #  target: aarch64-apple-darwin
+          #  arch: arm64
           - os: windows-latest
             platform: win32
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,86 +1,100 @@
 name: Release version
+
 on:
   push:
     tags:
       - 'v*.*.*'
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  TAG_NAME: ${{ github.event_name == 'schedule' && 'nightly' || github.ref_name }}
+  IS_NIGHTLY: ${{ github.event_name == 'schedule' }}
+
 jobs:
-  # this job builds the `forge` and `cast` binaries for the specified platforms
-  # in the matrix. The MacOS binaries do not support M1 yet: https://github.com/actions/runner/issues/805
-  build-artifacts:
-    runs-on:  ${{ matrix.os }}
+  release:
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        job:
+          # The OS is used for the runner
+          # The platform is a generic platform name
+          # The target is used by Cargo
+          # The arch is either 386 or amd64
+          - os: ubuntu-latest
+            platform: linux
+            target: x86_64-unknown-linux-gnu
+            arch: amd64
+          # The macOS binaries do not support M1 yet: https://github.com/actions/runner/issues/805
+          - os: macos-latest
+            platform: darwin
+            target: x86_64-apple-darwin
+            arch: amd64
+          - os: windows-latest
+            platform: win32
+            target: x86_64-pc-windows-msvc
+            arch: amd64
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
-      - name: cargo build
+
+      - name: Build binaries
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --release --bins
 
-      - name: Upload production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-            name: target-${{ matrix.os }}
-            path: |
-              ./target/release/forge
-              ./target/release/cast
+      - name: Strip binaries (non-Windows)
+        if: matrix.job.platform != 'win32'
+        run: |
+          cd target/release
+          strip cast
+          strip forge
 
-  # creates a GH release with the built binaries and CHANGELOG entry
-  create-release:
-    runs-on: ubuntu-latest
-    needs:  build-artifacts
-    steps:
-     - name: Checkout
-       uses: actions/checkout@v2
-       with:
-        fetch-depth: 1000
-
-     - name: Set output
-       id: vars
-       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-
-     - name: Restore artifacts
-       uses: actions/download-artifact@v2
-
-     - name: Build Changelog
-       id: github_release
-       uses: mikepenz/release-changelog-builder-action@v2.4.2
-       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
-     - name: Create Release
-       id: create-release
-       uses: softprops/action-gh-release@v0.1.13
-       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-       with:
-         tag_name:  ${{ steps.vars.outputs.tag }}
-         release_name: ${{ github.ref }}
-         body: ${{steps.build_changelog.outputs.changelog}}
-         files: |
-           ./target-macos-latest
-           ./target-ubuntu-latest
-
-  # after the GH release is done, proceed to open a PR on homebrew-core
-  publish-homebrew:
-    runs-on: ubuntu-latest
-    needs:  build-artifacts
-    steps:
-      - name: Create homebrew-core PR
-        uses: mislav/bump-homebrew-formula-action@v1.12
-        with:
-          formula-name: foundry
+      - name: Archive binaries
+        id: artifacts
         env:
-          COMMITTER_TOKEN: ${{ secrets.GH_TOKEN }}
+          PLATFORM_NAME: ${{ matrix.job.platform }}
+          ARCH: ${{ matrix.job.arch }}
+        run: |
+          if [ "$PLATFORM_NAME" != "win32" ]; then
+            tar -czvf "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/release forge cast
+            echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+          else
+            cd ./target/release
+            7z a -tzip "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip" forge.exe cast.exe
+            mv "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../
+            echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip"
+          fi
+        shell: bash
+ 
+      - name: Build changelog
+        id: build_changelog
+        if: ${{ env.IS_NIGHTLY == false }}
+        uses: mikepenz/release-changelog-builder-action@v2.4.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.TAG_NAME }}
+          draft: ${{ env.IS_NIGHTLY }}
+          body: ${{ steps.build_changelog.outputs.changelog }}
+          files: ${{ steps.artifacts.outputs.file_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   TAG_NAME: ${{ (github.event_name == 'schedule' && 'nightly') || github.inputs.tag || github.ref_name }}
-  IS_NIGHTLY: ${{ env.TAG_NAME == 'nightly' }}
+  IS_NIGHTLY: ${{ github.event_name != 'push' }}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,9 @@ jobs:
 
       - name: Build binaries
         uses: actions-rs/cargo@v1
-        env:
-          TARGET: ${{ matrix.job.target }}
         with:
           command: build
-          args: --release --bins --target $TARGET
+          args: --release --bins --target ${{ matrix.job.target }}
 
       - name: Strip binaries (non-Windows)
         if: matrix.job.platform != 'win32'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ env.IS_NIGHTLY == false }}
         uses: mikepenz/release-changelog-builder-action@v2.4.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,16 @@ on:
       - 'v*.*.*'
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name to release or nightly for nightly releases'
+        required: true
+        default: nightly
 
 env:
-  TAG_NAME: ${{ github.event_name == 'schedule' && 'nightly' || github.ref_name }}
-  IS_NIGHTLY: ${{ github.event_name == 'schedule' }}
+  TAG_NAME: ${{ (github.event_name == 'schedule' && 'nightly') || github.inputs.tag || github.ref_name }}
+  IS_NIGHTLY: ${{ env.TAG_NAME == 'nightly' }}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,12 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
-          - os: macos-latest
-            platform: darwin
-            target: x86_64-apple-darwin
-            arch: amd64
+          # We can't compile for M1 yet
+          # See https://github.com/rust-bitcoin/rust-secp256k1/issues/283
+          # - os: macos-latest
+          #   platform: darwin
+          #   target: x86_64-apple-darwin
+          #   arch: amd64
           - os: macos-latest
             platform: darwin
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,14 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
-          # The macOS binaries do not support M1 yet: https://github.com/actions/runner/issues/805
           - os: macos-latest
             platform: darwin
             target: x86_64-apple-darwin
             arch: amd64
+          - os: macos-latest
+            platform: darwin
+            target: aarch64-apple-darwin
+            arch: arm64
           - os: windows-latest
             platform: win32
             target: x86_64-pc-windows-msvc
@@ -51,6 +54,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: ${{ matrix.job.target }}
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -59,9 +63,11 @@ jobs:
 
       - name: Build binaries
         uses: actions-rs/cargo@v1
+        env:
+          TARGET: ${{ matrix.job.target }}
         with:
           command: build
-          args: --release --bins
+          args: --release --bins --target $TARGET
 
       - name: Strip binaries (non-Windows)
         if: matrix.job.platform != 'win32'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,17 +64,12 @@ jobs:
           cache-on-failure: true
 
       - name: Build binaries
+        env:
+          RUSTFLAGS: -C link-args=-s
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --bins --target ${{ matrix.job.target }}
-
-      - name: Strip binaries (non-Windows)
-        if: matrix.job.platform != 'win32'
-        run: |
-          cd target/release
-          strip cast
-          strip forge
 
       - name: Archive binaries
         id: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,8 @@ jobs:
 
       - name: Create release
         uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ env.TAG_NAME }}
-          name: ${{ env.TAG_NAME }}
           draft: ${{ env.IS_NIGHTLY }}
           body: ${{ steps.build_changelog.outputs.changelog }}
           files: ${{ steps.artifacts.outputs.file_name }}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,3 +77,8 @@ doc = false
 name = "forge"
 path = "src/forge.rs"
 doc = false
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
Adds nightly releases and cleans up the release workflow.

Nightly releases are put under a draft version and the workflow is automatically run every day at midnight GitHub-time.

The release has archive files for macOS, Linux and Windows. Each archive contains both the `forge` and `cast` binaries and nothing else.

The archive files have predictable names that work well with scripts that pull specific versions off of GitHub releases (such as [https://github.com/onbjerg/foundry-action](foundry-action)).

An example release can be seen here: https://github.com/onbjerg/foundry/releases/v0.0.1

As an aside, when we do start releasing stable versions we should probably consider adding a changelog and using that for the release descriptions.