### PR TITLE
Release workflow fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,15 +75,16 @@ jobs:
         id: artifacts
         env:
           PLATFORM_NAME: ${{ matrix.job.platform }}
+          TARGET: ${{ matrix.job.target }}
           ARCH: ${{ matrix.job.arch }}
         run: |
           if [ "$PLATFORM_NAME" != "win32" ]; then
-            tar -czvf "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/release forge cast
+            tar -czvf "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
             echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           else
-            cd ./target/release
+            cd ./target/${TARGET}/release
             7z a -tzip "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip" forge.exe cast.exe
-            mv "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../
+            mv "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../../
             echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip"
           fi
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
               await github.rest.git.deleteRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'refs/tags/nightly'
+                ref: 'tags/nightly'
               })
             } catch (err) {
               console.error(`Failed to delete nightly tag.`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.TAG_NAME }}
-          draft: ${{ env.IS_NIGHTLY }}
+          prerelease: ${{ env.IS_NIGHTLY }}
           body: ${{ steps.build_changelog.outputs.changelog }}
           files: ${{ steps.artifacts.outputs.file_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,13 +87,36 @@ jobs:
             echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip"
           fi
         shell: bash
- 
+
       - name: Build changelog
         id: build_changelog
         if: ${{ env.IS_NIGHTLY == false }}
         uses: mikepenz/release-changelog-builder-action@v2.4.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Move nightly tag
+        if: ${{ env.IS_NIGTHLY == true }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/nightly'
+              })
+            } catch (err) {
+              console.error(`Failed to delete nightly tag.`)
+              console.error(`This should only happen the first time.`)
+              console.error(err)
+            }
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/nightly',
+              sha: context.sha
+            })
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         default: nightly
 
 env:
-  TAG_NAME: ${{ (github.event_name == 'schedule' && 'nightly') || github.inputs.tag || github.ref_name }}
+  TAG_NAME: ${{ (github.event_name == 'schedule' && 'nightly') || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || github.ref_name }}
   IS_NIGHTLY: ${{ github.event_name != 'push' }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,22 +101,18 @@ jobs:
         with:
           script: |
             try {
-              await github.rest.git.deleteRef({
+              await github.rest.git.updateRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'tags/nightly'
+                ref: 'tags/nightly',
+                sha: context.sha,
+                force: true
               })
             } catch (err) {
-              console.error(`Failed to delete nightly tag.`)
+              console.error(`Failed to move nightly tag.`)
               console.error(`This should only happen the first time.`)
               console.error(err)
             }
-            await github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/nightly',
-              sha: context.sha
-            })
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ on:
 
 env:
   TAG_NAME: ${{ (github.event_name == 'schedule' && 'nightly') || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || github.ref_name }}
-  IS_NIGHTLY: ${{ github.event_name != 'push' }}
 
 jobs:
   release:
@@ -91,13 +90,13 @@ jobs:
 
       - name: Build changelog
         id: build_changelog
-        if: ${{ env.IS_NIGHTLY == false }}
+        if: ${{ env.TAG_NAME != 'nightly' }}
         uses: mikepenz/release-changelog-builder-action@v2.4.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Move nightly tag
-        if: ${{ env.IS_NIGTHLY == true }}
+        if: ${{ env.TAG_NAME == 'nightly' }}
         uses: actions/github-script@v5
         with:
           script: |
@@ -123,6 +122,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.TAG_NAME }}
-          prerelease: ${{ env.IS_NIGHTLY }}
+          prerelease: ${{ env.TAG_NAME == 'nightly' }}
           body: ${{ steps.build_changelog.outputs.changelog }}
           files: ${{ steps.artifacts.outputs.file_name }}


### PR DESCRIPTION
- Get the tag name properly from manual releases (it was `github.event.inputs` not `github.inputs`)
- The workflow doesn't automatically move the nightly tag, so we do that ourselves
- Draft releases are only for repo maintainers so we make a pre-release
- Binaries have moved to a new directory since we added `--target`