### PR TITLE
Build releases for Apple M1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,10 @@ jobs:
             platform: darwin
             target: x86_64-apple-darwin
             arch: amd64
-          # We can't compile for M1 yet
-          # See https://github.com/rust-bitcoin/rust-secp256k1/issues/283
-          #- os: macos-latest
-          #  platform: darwin
-          #  target: aarch64-apple-darwin
-          #  arch: arm64
+          - os: macos-latest
+            platform: darwin
+            target: aarch64-apple-darwin
+            arch: arm64
           - os: windows-latest
             platform: win32
             target: x86_64-pc-windows-msvc
@@ -61,6 +59,12 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
+
+      - name: Apple M1 setup
+        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
       - name: Build binaries
         env:


### PR DESCRIPTION
I'm not entirely sure why it works, but I looked around for other repos that were targetting Apple M1 and it seems like this is the fix. Maybe it's something about being more explicit about the SDK used to cross-compile when we're compiling bindings?

Regardless... behold: https://github.com/onbjerg/foundry/runs/4828392401

(Also can someone with an M1 chip please test I do not own one myself so I don't know if the binary is useable)

Closes #466 