### PR TITLE
Fix integration testdata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ integration-tests-testdata: $(INTEGRATION_TESTS_REPOS)
 $(INTEGRATION_TESTS_REPOS):
 	@FOLDER=$(shell dirname "$0")/integration-tests/testdata/$(lastword $(subst /, ,$@));\
 	if [ ! -d $$FOLDER ] ; then git clone --depth 1 --recursive https://github.com/$@ $$FOLDER;\
-	else cd $$FOLDER; git pull --recurse-submodules; fi
+	else cd $$FOLDER; git pull && git submodule update --recursive; fi
 
 testdata: integration-tests-testdata
 


### PR DESCRIPTION
Using `git pull --recurse-submodules` updates the submodules to the latest remote commit of the submodule, which is not what we want. Our integration tests are failing because we are updating the `solmate` dependency in Rari's vaults repository which removed a contract that they are still using.

We should instead:

- `git pull` to check for new commits in the testdata
- `git submodule update --recursive` to update the submodules accordingly if they were changed in the testdata repository