### PR TITLE
Fix double space when no mutability is specified

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -515,14 +515,15 @@ pub fn abi_to_solidity(contract_abi: &Abi, mut contract_name: &str) -> Result<St
                 _ => "",
             };
 
-            if outputs.is_empty() {
-                format!("function {}({}) {} external;", function.name, inputs, mutability)
-            } else {
-                format!(
-                    "function {}({}) {} external returns ({});",
-                    function.name, inputs, mutability, outputs
-                )
+            let mut func = format!("function {}({})", function.name, inputs);
+            if !mutability.is_empty() {
+                func = format!("{} {}", func, mutability);
             }
+            func = format!("{} external", func);
+            if !outputs.is_empty() {
+                func = format!("{} returns ({})", func, outputs);
+            }
+            format!("{};", func)
         })
         .collect::<Vec<_>>()
         .join("\n    ");


### PR DESCRIPTION
There was a double space before `external` when using `cast interface` if we could not determine the mutability of the function. Alternative to this PR we could assume a default mutability, but I'm unsure if that is different depending on the Solidity version used?

Closes #471 