### PR TITLE
feat(forge): custom error decode

### DIFF
--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -17,6 +17,7 @@ use ethers::{
     solc::artifacts::{CompactContractSome, ContractBytecodeSome},
 };
 use evm_adapters::{
+    call_tracing::ExecutionInfo,
     evm_opts::{BackendKind, EvmOpts},
     sputnik::{cheatcodes::debugger::DebugArena, helpers::vm},
 };
@@ -160,22 +161,22 @@ impl Cmd for RunArgs {
             {
                 if !result.success && evm_opts.verbosity == 3 || evm_opts.verbosity > 3 {
                     let mut ident = identified_contracts.clone();
+                    let mut exec_info = ExecutionInfo::new(&known_contracts, &mut ident);
+                    let vm = vm();
                     if evm_opts.verbosity > 4 || !result.success {
                         // print setup calls as well
                         traces.iter().for_each(|trace| {
-                            trace.pretty_print(0, &known_contracts, &mut ident, &vm(), "");
+                            trace.pretty_print(0, &mut exec_info, &vm, "");
                         });
                     } else if !traces.is_empty() {
                         traces.last().expect("no last but not empty").pretty_print(
                             0,
-                            &known_contracts,
-                            &mut ident,
-                            &vm(),
+                            &mut exec_info,
+                            &vm,
                             "",
                         );
                     }
                 }
-
                 println!();
             }
         } else {

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -95,6 +95,7 @@ impl Cmd for RunArgs {
                     &abi,
                     bytecode,
                     Some(evm_opts.sender),
+                    None,
                 );
                 runner.run_test(&func, needs_setup, Some(&known_contracts))?
             }
@@ -106,6 +107,7 @@ impl Cmd for RunArgs {
                     &abi,
                     bytecode,
                     Some(evm_opts.sender),
+                    None,
                 );
                 runner.run_test(&func, needs_setup, Some(&known_contracts))?
             }
@@ -161,7 +163,10 @@ impl Cmd for RunArgs {
             {
                 if !result.success && evm_opts.verbosity == 3 || evm_opts.verbosity > 3 {
                     let mut ident = identified_contracts.clone();
-                    let mut exec_info = ExecutionInfo::new(&known_contracts, &mut ident);
+                    let (funcs, events, errors) =
+                        foundry_utils::flatten_known_contracts(&known_contracts);
+                    let mut exec_info =
+                        ExecutionInfo::new(&known_contracts, &mut ident, &funcs, &events, &errors);
                     let vm = vm();
                     if evm_opts.verbosity > 4 || !result.success {
                         // print setup calls as well

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -209,6 +209,7 @@ fn test<A: ArtifactOutput + 'static>(
 
     let results = runner.test(&filter)?;
 
+    let (funcs, events, errors) = runner.execution_info;
     if json {
         let res = serde_json::to_string(&results)?;
         println!("{}", res);
@@ -270,8 +271,13 @@ fn test<A: ArtifactOutput + 'static>(
                             }
 
                             let mut ident = identified_contracts.clone();
-                            let mut exec_info =
-                                ExecutionInfo::new(&runner.known_contracts, &mut ident);
+                            let mut exec_info = ExecutionInfo::new(
+                                &runner.known_contracts,
+                                &mut ident,
+                                &funcs,
+                                &events,
+                                &errors,
+                            );
                             let vm = vm();
                             if verbosity > 4 || !result.success {
                                 add_newline = true;

--- a/evm-adapters/src/call_tracing.rs
+++ b/evm-adapters/src/call_tracing.rs
@@ -452,7 +452,7 @@ impl CallTrace {
                                 #[cfg(feature = "sputnik")]
                                 if self.addr == *CHEATCODE_ADDRESS && func.name == "expectRevert" {
                                     // try to decode better than just `bytes` for `expectRevert`
-                                    if let Ok(decoded) = foundry_utils::decode_revert(&self.data) {
+                                    if let Ok(decoded) = foundry_utils::decode_revert(&self.data, Some(abi)) {
                                         strings = decoded;
                                     }
                                 }
@@ -479,7 +479,7 @@ impl CallTrace {
                                 )
                             } else if !self.output.is_empty() && !self.success {
                                 if let Ok(decoded_error) =
-                                    foundry_utils::decode_revert(&self.output[..])
+                                    foundry_utils::decode_revert(&self.output[..], Some(abi))
                                 {
                                     return Output::Token(vec![ethers::abi::Token::String(
                                         decoded_error,
@@ -508,7 +508,7 @@ impl CallTrace {
                 );
 
                 if !self.success {
-                    if let Ok(decoded_error) = foundry_utils::decode_revert(&self.output[..]) {
+                    if let Ok(decoded_error) = foundry_utils::decode_revert(&self.output[..], Some(abi)) {
                         return Output::Token(vec![ethers::abi::Token::String(decoded_error)])
                     }
                 }
@@ -540,7 +540,7 @@ impl CallTrace {
         );
 
         if !self.success {
-            if let Ok(decoded_error) = foundry_utils::decode_revert(&self.output[..]) {
+            if let Ok(decoded_error) = foundry_utils::decode_revert(&self.output[..], abi) {
                 return Output::Token(vec![ethers::abi::Token::String(decoded_error)])
             }
         }

--- a/evm-adapters/src/call_tracing.rs
+++ b/evm-adapters/src/call_tracing.rs
@@ -1,6 +1,6 @@
 use ethers::{
-    abi::{Abi, FunctionExt, RawLog},
-    types::{H160, U256},
+    abi::{Abi, Event, Function, RawLog},
+    types::{H160, H256, U256},
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -10,7 +10,10 @@ use ansi_term::Colour;
 use foundry_utils::format_token;
 
 #[cfg(feature = "sputnik")]
-use crate::sputnik::cheatcodes::{cheatcode_handler::CHEATCODE_ADDRESS, HEVM_ABI};
+use crate::sputnik::cheatcodes::{
+    cheatcode_handler::{CHEATCODE_ADDRESS, CONSOLE_ADDRESS},
+    CONSOLE_ABI, HEVMCONSOLE_ABI, HEVM_ABI,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// An arena of `CallTraceNode`s
@@ -157,6 +160,72 @@ impl CallTraceArena {
         });
     }
 
+    /// Flattens a group of contracts into maps of all events and functions
+    pub fn flatten_funcs_and_events(
+        contracts: &BTreeMap<String, (Abi, Vec<u8>)>,
+    ) -> (BTreeMap<[u8; 4], Function>, BTreeMap<H256, Event>, Abi) {
+        let mut flattened_funcs: BTreeMap<[u8; 4], Function> = contracts
+            .iter()
+            .flat_map(|(_name, (abi, _code))| abi.functions().cloned().collect::<Vec<Function>>())
+            .collect::<Vec<Function>>()
+            .into_iter()
+            .map(|func| (func.short_signature(), func))
+            .collect();
+
+        let mut flattened_events: BTreeMap<H256, Event> = contracts
+            .iter()
+            .flat_map(|(_name, (abi, _code))| abi.events().cloned().collect::<Vec<Event>>())
+            .collect::<Vec<Event>>()
+            .into_iter()
+            .map(|event| (event.signature(), event))
+            .collect();
+
+        // We need this for better revert decoding, and want it in abi form
+        let mut errors_abi = Abi::default();
+        contracts.iter().for_each(|(_name, (abi, _code))| {
+            abi.errors().for_each(|error| {
+                let entry =
+                    errors_abi.errors.entry(error.name.clone()).or_insert_with(Default::default);
+                entry.push(error.clone());
+            });
+        });
+
+        // add forge specific functions
+        #[cfg(feature = "sputnik")]
+        {
+            flattened_funcs.extend(
+                HEVM_ABI
+                    .functions()
+                    .cloned()
+                    .map(|func| (func.short_signature(), func))
+                    .collect::<BTreeMap<[u8; 4], Function>>(),
+            );
+            flattened_events.extend(
+                HEVM_ABI
+                    .events()
+                    .cloned()
+                    .map(|event| (event.signature(), event))
+                    .collect::<BTreeMap<H256, Event>>(),
+            );
+            flattened_events.extend(
+                HEVMCONSOLE_ABI
+                    .events()
+                    .cloned()
+                    .map(|event| (event.signature(), event))
+                    .collect::<BTreeMap<H256, Event>>(),
+            );
+            flattened_events.extend(
+                CONSOLE_ABI
+                    .events()
+                    .cloned()
+                    .map(|event| (event.signature(), event))
+                    .collect::<BTreeMap<H256, Event>>(),
+            );
+        }
+
+        (flattened_funcs, flattened_events, errors_abi)
+    }
+
     /// Pretty print a CallTraceArena
     ///
     /// `idx` is the call arena index to start at. Generally this will be 0, but if you want to
@@ -184,8 +253,14 @@ impl CallTraceArena {
     ) {
         let trace = &self.arena[idx].trace;
 
+        let (funcs, events, errors) = Self::flatten_funcs_and_events(contracts);
+
         #[cfg(feature = "sputnik")]
-        identified_contracts.insert(*CHEATCODE_ADDRESS, ("VM".to_string(), HEVM_ABI.clone()));
+        {
+            identified_contracts.insert(*CHEATCODE_ADDRESS, ("VM".to_string(), HEVM_ABI.clone()));
+            identified_contracts
+                .insert(*CONSOLE_ADDRESS, ("console".to_string(), CONSOLE_ABI.clone()));
+        }
 
         #[cfg(feature = "sputnik")]
         // color the trace function call & output by success
@@ -220,7 +295,7 @@ impl CallTraceArena {
                     println!("{}{} {}@{}", left, Colour::Yellow.paint("→ new"), name, trace.addr);
                     self.print_children_and_logs(
                         idx,
-                        Some(abi),
+                        events,
                         contracts,
                         identified_contracts,
                         evm,
@@ -239,24 +314,9 @@ impl CallTraceArena {
             } else if trace.created {
                 // we couldn't identify, print the children and logs without the abi
                 println!("{}{} <Unknown>@{}", left, Colour::Yellow.paint("→ new"), trace.addr);
-                self.print_children_and_logs(idx, None, contracts, identified_contracts, evm, left);
-                println!(
-                    "{}  └─ {} {} bytes of code",
-                    left.replace("├─", "│").replace("└─", "  "),
-                    color.paint("←"),
-                    trace.output.len()
-                );
-            } else {
-                let output = trace.print_func_call(None, None, color, left);
-                self.print_children_and_logs(idx, None, contracts, identified_contracts, evm, left);
-                output.print(color, left);
-            }
-        } else if let Some((name, abi)) = res {
-            if trace.created {
-                println!("{}{} {}@{}", left, Colour::Yellow.paint("→ new"), name, trace.addr);
                 self.print_children_and_logs(
                     idx,
-                    Some(&abi),
+                    events,
                     contracts,
                     identified_contracts,
                     evm,
@@ -269,10 +329,39 @@ impl CallTraceArena {
                     trace.output.len()
                 );
             } else {
-                let output = trace.print_func_call(Some(&abi), Some(&name), color, left);
+                let output = trace.print_func_call(&funcs, Some(&errors), None, color, left);
                 self.print_children_and_logs(
                     idx,
-                    Some(&abi),
+                    events,
+                    contracts,
+                    identified_contracts,
+                    evm,
+                    left,
+                );
+                output.print(color, left);
+            }
+        } else if let Some((name, _abi)) = res {
+            if trace.created {
+                println!("{}{} {}@{}", left, Colour::Yellow.paint("→ new"), name, trace.addr);
+                self.print_children_and_logs(
+                    idx,
+                    events,
+                    contracts,
+                    identified_contracts,
+                    evm,
+                    left,
+                );
+                println!(
+                    "{}  └─ {} {} bytes of code",
+                    left.replace("├─", "│").replace("└─", "  "),
+                    color.paint("←"),
+                    trace.output.len()
+                );
+            } else {
+                let output = trace.print_func_call(&funcs, Some(&errors), Some(&name), color, left);
+                self.print_children_and_logs(
+                    idx,
+                    events,
                     contracts,
                     identified_contracts,
                     evm,
@@ -287,7 +376,7 @@ impl CallTraceArena {
     pub fn print_children_and_logs<'a, S: Clone, E: crate::Evm<S>>(
         &self,
         node_idx: usize,
-        abi: Option<&Abi>,
+        events: BTreeMap<H256, Event>,
         contracts: &BTreeMap<String, (Abi, Vec<u8>)>,
         identified_contracts: &mut BTreeMap<H160, (String, Abi)>,
         evm: &'a E,
@@ -298,7 +387,7 @@ impl CallTraceArena {
         // logs and calls in the correct order
         self.arena[node_idx].ordering.iter().for_each(|ordering| match ordering {
             LogCallOrder::Log(index) => {
-                self.arena[node_idx].print_log(*index, abi, left);
+                self.arena[node_idx].print_log(*index, &events, left);
             }
             LogCallOrder::Call(index) => {
                 self.pretty_print(
@@ -333,30 +422,26 @@ pub struct CallTraceNode {
 
 impl CallTraceNode {
     /// Prints a log at a particular index, optionally decoding if abi is provided
-    pub fn print_log(&self, index: usize, abi: Option<&Abi>, left: &str) {
+    pub fn print_log(&self, index: usize, events: &BTreeMap<H256, Event>, left: &str) {
         let log = &self.logs[index];
         let right = "  ├─ ";
-        if let Some(abi) = abi {
-            for (event_name, overloaded_events) in abi.events.iter() {
-                for event in overloaded_events.iter() {
-                    if event.signature() == log.topics[0] {
-                        let params = event.parse_log(log.clone()).expect("Bad event").params;
-                        let strings = params
-                            .into_iter()
-                            .map(|param| format!("{}: {}", param.name, format_token(&param.value)))
-                            .collect::<Vec<String>>()
-                            .join(", ");
-                        println!(
-                            "{}emit {}({})",
-                            left.replace("├─", "│") + right,
-                            Colour::Cyan.paint(event_name),
-                            strings
-                        );
-                        return
-                    }
-                }
-            }
+
+        if let Some(event) = events.get(&log.topics[0]) {
+            let params = event.parse_log(log.clone()).expect("Bad event").params;
+            let strings = params
+                .into_iter()
+                .map(|param| format!("{}: {}", param.name, format_token(&param.value)))
+                .collect::<Vec<String>>()
+                .join(", ");
+            println!(
+                "{}emit {}({})",
+                left.replace("├─", "│") + right,
+                Colour::Cyan.paint(event.name.clone()),
+                strings
+            );
+            return
         }
+
         // we didnt decode the log, print it as an unknown log
         for (i, topic) in log.topics.iter().enumerate() {
             let right = if i == log.topics.len() - 1 && log.data.is_empty() {
@@ -430,90 +515,83 @@ impl CallTrace {
     /// Prints function call, returning the decoded or raw output
     pub fn print_func_call(
         &self,
-        abi: Option<&Abi>,
+        funcs: &BTreeMap<[u8; 4], Function>,
+        abi_for_errors: Option<&Abi>,
         name: Option<&String>,
         color: Colour,
         left: &str,
     ) -> Output {
-        if let (Some(abi), Some(name)) = (abi, name) {
-            // Is data longer than 4, meaning we can attempt to decode it
-            if self.data.len() >= 4 {
-                for (func_name, overloaded_funcs) in abi.functions.iter() {
-                    for func in overloaded_funcs.iter() {
-                        if func.selector() == self.data[0..4] {
-                            let mut strings = "".to_string();
-                            if !self.data[4..].is_empty() {
-                                let params = func
-                                    .decode_input(&self.data[4..])
-                                    .expect("Bad func data decode");
-                                strings =
-                                    params.iter().map(format_token).collect::<Vec<_>>().join(", ");
+        // Is data longer than 4, meaning we can attempt to decode it
+        if self.data.len() >= 4 {
+            if let Some(func) = funcs.get(&self.data[0..4]) {
+                let mut strings = "".to_string();
+                if !self.data[4..].is_empty() {
+                    let params = func.decode_input(&self.data[4..]).expect("Bad func data decode");
+                    strings = params.iter().map(format_token).collect::<Vec<_>>().join(", ");
 
-                                #[cfg(feature = "sputnik")]
-                                if self.addr == *CHEATCODE_ADDRESS && func.name == "expectRevert" {
-                                    // try to decode better than just `bytes` for `expectRevert`
-                                    if let Ok(decoded) = foundry_utils::decode_revert(&self.data, Some(abi)) {
-                                        strings = decoded;
-                                    }
-                                }
-                            }
-
-                            println!(
-                                "{}[{}] {}::{}{}({})",
-                                left,
-                                self.cost,
-                                color.paint(name),
-                                color.paint(func_name),
-                                if self.value > 0.into() {
-                                    format!("{{value: {}}}", self.value)
-                                } else {
-                                    "".to_string()
-                                },
-                                strings,
-                            );
-
-                            if !self.output.is_empty() && self.success {
-                                return Output::Token(
-                                    func.decode_output(&self.output[..])
-                                        .expect("Bad func output decode"),
-                                )
-                            } else if !self.output.is_empty() && !self.success {
-                                if let Ok(decoded_error) =
-                                    foundry_utils::decode_revert(&self.output[..], Some(abi))
-                                {
-                                    return Output::Token(vec![ethers::abi::Token::String(
-                                        decoded_error,
-                                    )])
-                                } else {
-                                    return Output::Raw(self.output.clone())
-                                }
-                            } else {
-                                return Output::Raw(vec![])
-                            }
+                    #[cfg(feature = "sputnik")]
+                    if self.addr == *CHEATCODE_ADDRESS && func.name == "expectRevert" {
+                        // try to decode better than just `bytes` for `expectRevert`
+                        if let Ok(decoded) =
+                            foundry_utils::decode_revert(&self.data, abi_for_errors)
+                        {
+                            strings = decoded;
                         }
                     }
                 }
-            } else {
-                // fallback function
+
                 println!(
-                    "{}[{}] {}::fallback{}()",
+                    "{}[{}] {}::{}{}({})",
                     left,
                     self.cost,
-                    color.paint(name),
+                    color.paint(name.unwrap_or(&self.addr.to_string())),
+                    color.paint(func.name.clone()),
                     if self.value > 0.into() {
                         format!("{{value: {}}}", self.value)
                     } else {
                         "".to_string()
-                    }
+                    },
+                    strings,
                 );
 
-                if !self.success {
-                    if let Ok(decoded_error) = foundry_utils::decode_revert(&self.output[..], Some(abi)) {
+                if !self.output.is_empty() && self.success {
+                    return Output::Token(
+                        func.decode_output(&self.output[..]).expect("Bad func output decode"),
+                    )
+                } else if !self.output.is_empty() && !self.success {
+                    if let Ok(decoded_error) =
+                        foundry_utils::decode_revert(&self.output[..], abi_for_errors)
+                    {
                         return Output::Token(vec![ethers::abi::Token::String(decoded_error)])
+                    } else {
+                        return Output::Raw(self.output.clone())
                     }
+                } else {
+                    return Output::Raw(vec![])
                 }
-                return Output::Raw(self.output[..].to_vec())
             }
+        } else {
+            // fallback function
+            println!(
+                "{}[{}] {}::fallback{}()",
+                left,
+                self.cost,
+                color.paint(name.unwrap_or(&self.addr.to_string())),
+                if self.value > 0.into() {
+                    format!("{{value: {}}}", self.value)
+                } else {
+                    "".to_string()
+                }
+            );
+
+            if !self.success {
+                if let Ok(decoded_error) =
+                    foundry_utils::decode_revert(&self.output[..], abi_for_errors)
+                {
+                    return Output::Token(vec![ethers::abi::Token::String(decoded_error)])
+                }
+            }
+            return Output::Raw(self.output[..].to_vec())
         }
 
         // We couldn't decode the function call, so print it as an abstract call
@@ -540,7 +618,9 @@ impl CallTrace {
         );
 
         if !self.success {
-            if let Ok(decoded_error) = foundry_utils::decode_revert(&self.output[..], abi) {
+            if let Ok(decoded_error) =
+                foundry_utils::decode_revert(&self.output[..], abi_for_errors)
+            {
                 return Output::Token(vec![ethers::abi::Token::String(decoded_error)])
             }
         }

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -174,8 +174,14 @@ pub trait Evm<State> {
     /// see whether the `failed` state var is set. This is to allow compatibility
     /// with dapptools-style DSTest smart contracts to preserve emitting of logs
     fn failed(&mut self, address: Address) -> Result<bool> {
-        let (failed, _, _, _) =
-            self.call::<bool, _, _>(Address::zero(), address, "failed()(bool)", (), 0.into(), None)?;
+        let (failed, _, _, _) = self.call::<bool, _, _>(
+            Address::zero(),
+            address,
+            "failed()(bool)",
+            (),
+            0.into(),
+            None,
+        )?;
         Ok(failed)
     }
 
@@ -243,11 +249,25 @@ mod test_helpers {
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let (_, status1, _, _) = evm
-            .call::<(), _, _>(Address::zero(), addr, "greet(string)", "hi".to_owned(), 0.into(), compiled.abi)
+            .call::<(), _, _>(
+                Address::zero(),
+                addr,
+                "greet(string)",
+                "hi".to_owned(),
+                0.into(),
+                compiled.abi,
+            )
             .unwrap();
 
         let (retdata, status2, _, _) = evm
-            .call::<String, _, _>(Address::zero(), addr, "greeting()(string)", (), 0.into(), compiled.abi)
+            .call::<String, _, _>(
+                Address::zero(),
+                addr,
+                "greeting()(string)",
+                (),
+                0.into(),
+                compiled.abi,
+            )
             .unwrap();
         assert_eq!(retdata, "hi");
 
@@ -264,8 +284,9 @@ mod test_helpers {
         // call the setup function to deploy the contracts inside the test
         let status1 = evm.setup(addr).unwrap().0;
 
-        let (_, status2, _, _) =
-            evm.call::<(), _, _>(Address::zero(), addr, "testGreeting()", (), 0.into(), compiled.abi).unwrap();
+        let (_, status2, _, _) = evm
+            .call::<(), _, _>(Address::zero(), addr, "testGreeting()", (), 0.into(), compiled.abi)
+            .unwrap();
 
         vec![status1, status2].iter().for_each(|reason| {
             let res = evm.check_success(addr, reason, false);

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -22,7 +22,7 @@ pub mod call_tracing;
 pub mod evm_opts;
 
 use ethers::{
-    abi::{Detokenize, Tokenize},
+    abi::{Abi, Detokenize, Tokenize},
     contract::{decode_function_data, encode_function_data},
     core::types::{Address, Bytes, U256},
 };
@@ -104,11 +104,12 @@ pub trait Evm<State> {
         func: F,
         args: T, // derive arbitrary for Tokenize?
         value: U256,
+        abi: Option<&Abi>,
     ) -> std::result::Result<(D, Self::ReturnReason, u64, Vec<String>), EvmError> {
         let func = func.into();
         let (retdata, status, gas, logs) = self.call_unchecked(from, to, &func, args, value)?;
         if Self::is_fail(&status) {
-            let reason = foundry_utils::decode_revert(retdata.as_ref()).unwrap_or_default();
+            let reason = foundry_utils::decode_revert(retdata.as_ref(), abi).unwrap_or_default();
             Err(EvmError::Execution { reason, gas_used: gas, logs })
         } else {
             let retdata = decode_function_data(&func, retdata, false)?;
@@ -165,7 +166,7 @@ pub trait Evm<State> {
         let span = tracing::trace_span!("setup", ?address);
         let _enter = span.enter();
         let (_, status, _, logs) =
-            self.call::<(), _, _>(Address::zero(), address, "setUp()", (), 0.into())?;
+            self.call::<(), _, _>(Address::zero(), address, "setUp()", (), 0.into(), None)?;
         Ok((status, logs))
     }
 
@@ -174,7 +175,7 @@ pub trait Evm<State> {
     /// with dapptools-style DSTest smart contracts to preserve emitting of logs
     fn failed(&mut self, address: Address) -> Result<bool> {
         let (failed, _, _, _) =
-            self.call::<bool, _, _>(Address::zero(), address, "failed()(bool)", (), 0.into())?;
+            self.call::<bool, _, _>(Address::zero(), address, "failed()(bool)", (), 0.into(), None)?;
         Ok(failed)
     }
 
@@ -242,11 +243,11 @@ mod test_helpers {
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let (_, status1, _, _) = evm
-            .call::<(), _, _>(Address::zero(), addr, "greet(string)", "hi".to_owned(), 0.into())
+            .call::<(), _, _>(Address::zero(), addr, "greet(string)", "hi".to_owned(), 0.into(), compiled.abi)
             .unwrap();
 
         let (retdata, status2, _, _) = evm
-            .call::<String, _, _>(Address::zero(), addr, "greeting()(string)", (), 0.into())
+            .call::<String, _, _>(Address::zero(), addr, "greeting()(string)", (), 0.into(), compiled.abi)
             .unwrap();
         assert_eq!(retdata, "hi");
 
@@ -264,7 +265,7 @@ mod test_helpers {
         let status1 = evm.setup(addr).unwrap().0;
 
         let (_, status2, _, _) =
-            evm.call::<(), _, _>(Address::zero(), addr, "testGreeting()", (), 0.into()).unwrap();
+            evm.call::<(), _, _>(Address::zero(), addr, "testGreeting()", (), 0.into(), compiled.abi).unwrap();
 
         vec![status1, status2].iter().for_each(|reason| {
             let res = evm.check_success(addr, reason, false);

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -759,11 +759,6 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     return e
                 }
             }
-            HEVMCalls::ExpectRevert2(inner) => {
-                if let Err(e) = self.expect_revert(inner.0.as_bytes().to_vec()) {
-                    return e
-                }
-            }
             HEVMCalls::Deal(inner) => {
                 self.add_debug(CheatOp::DEAL);
                 let who = inner.0;

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1784,6 +1784,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
 #[cfg(test)]
 mod tests {
     use crate::{
+        call_tracing::ExecutionInfo,
         fuzz::FuzzedExecutor,
         sputnik::helpers::{vm, vm_no_limit, vm_tracing},
         test_helpers::COMPILED,
@@ -2042,7 +2043,9 @@ mod tests {
             ),
         );
         let mut identified = Default::default();
-        evm.traces()[1].pretty_print(0, &mapping, &mut identified, &evm, "");
+        let (funcs, events, errors) = foundry_utils::flatten_known_contracts(&mapping);
+        let mut exec_info = ExecutionInfo::new(&mapping, &mut identified, &funcs, &events, &errors);
+        evm.traces()[1].pretty_print(0, &mut exec_info, &evm, "");
     }
 
     #[test]
@@ -2101,6 +2104,8 @@ mod tests {
             ),
         );
         let mut identified = Default::default();
-        evm.traces()[1].pretty_print(0, &mapping, &mut identified, &evm, "");
+        let (funcs, events, errors) = foundry_utils::flatten_known_contracts(&mapping);
+        let mut exec_info = ExecutionInfo::new(&mapping, &mut identified, &funcs, &events, &errors);
+        evm.traces()[1].pretty_print(0, &mut exec_info, &evm, "");
     }
 }

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1800,8 +1800,9 @@ mod tests {
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // after the evm call is done, we call `logs` and print it all to the user
-        let (_, _, _, logs) =
-            evm.call::<(), _, _>(Address::zero(), addr, "test_log()", (), 0.into(), compiled.abi).unwrap();
+        let (_, _, _, logs) = evm
+            .call::<(), _, _>(Address::zero(), addr, "test_log()", (), 0.into(), compiled.abi)
+            .unwrap();
         let expected = [
             "Hi",
             "0x1234",
@@ -1843,8 +1844,9 @@ mod tests {
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // after the evm call is done, we call `logs` and print it all to the user
-        let (_, _, _, logs) =
-            evm.call::<(), _, _>(Address::zero(), addr, "test_log()", (), 0.into(), compiled.abi).unwrap();
+        let (_, _, _, logs) = evm
+            .call::<(), _, _>(Address::zero(), addr, "test_log()", (), 0.into(), compiled.abi)
+            .unwrap();
         let expected = [
             "0x1111111111111111111111111111111111111111",
             "Hi",
@@ -1858,8 +1860,9 @@ mod tests {
         .collect::<Vec<_>>();
         assert_eq!(logs, expected);
 
-        let (_, _, _, logs) =
-            evm.call::<(), _, _>(Address::zero(), addr, "test_log()", (), 0.into(), compiled.abi).unwrap();
+        let (_, _, _, logs) = evm
+            .call::<(), _, _>(Address::zero(), addr, "test_log()", (), 0.into(), compiled.abi)
+            .unwrap();
         assert_eq!(logs, expected);
     }
 
@@ -1872,8 +1875,9 @@ mod tests {
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         // after the evm call is done, we call `logs` and print it all to the user
-        let (_, _, _, logs) =
-            evm.call::<(), _, _>(Address::zero(), addr, "test_log_types()", (), 0.into(), compiled.abi).unwrap();
+        let (_, _, _, logs) = evm
+            .call::<(), _, _>(Address::zero(), addr, "test_log_types()", (), 0.into(), compiled.abi)
+            .unwrap();
         let expected = ["String", "1337", "-20", "1245", "true"]
             .iter()
             .map(ToString::to_string)
@@ -1891,7 +1895,14 @@ mod tests {
 
         // after the evm call is done, we call `logs` and print it all to the user
         let (_, _, _, logs) = evm
-            .call::<(), _, _>(Address::zero(), addr, "test_log_elsewhere()", (), 0.into(), compiled.abi)
+            .call::<(), _, _>(
+                Address::zero(),
+                addr,
+                "test_log_elsewhere()",
+                (),
+                0.into(),
+                compiled.abi,
+            )
             .unwrap();
         let expected = ["0x1111111111111111111111111111111111111111", "Hi"]
             .iter()
@@ -1914,10 +1925,24 @@ mod tests {
 
         // ensure the storage slot is set at 10 anyway
         let (storage_contract, _, _, _) = evm
-            .call::<Address, _, _>(Address::zero(), addr, "store()(address)", (), 0.into(), compiled.abi)
+            .call::<Address, _, _>(
+                Address::zero(),
+                addr,
+                "store()(address)",
+                (),
+                0.into(),
+                compiled.abi,
+            )
             .unwrap();
         let (slot, _, _, _) = evm
-            .call::<U256, _, _>(Address::zero(), storage_contract, "slot0()(uint256)", (), 0.into(), compiled.abi)
+            .call::<U256, _, _>(
+                Address::zero(),
+                storage_contract,
+                "slot0()(uint256)",
+                (),
+                0.into(),
+                compiled.abi,
+            )
             .unwrap();
         assert_eq!(slot, 10.into());
 
@@ -1952,8 +1977,9 @@ mod tests {
         let (addr, _, _, _) =
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
-        let err =
-            evm.call::<(), _, _>(Address::zero(), addr, "testFFI()", (), 0.into(), compiled.abi).unwrap_err();
+        let err = evm
+            .call::<(), _, _>(Address::zero(), addr, "testFFI()", (), 0.into(), compiled.abi)
+            .unwrap_err();
         let reason = match err {
             crate::EvmError::Execution { reason, .. } => reason,
             _ => panic!("unexpected error"),
@@ -1983,7 +2009,7 @@ mod tests {
                 "recurseCall(uint256,uint256)",
                 (U256::from(2u32), U256::from(0u32)),
                 0u32.into(),
-                compiled.abi
+                compiled.abi,
             )
             .unwrap();
 
@@ -2042,7 +2068,7 @@ mod tests {
                 "recurseCreate(uint256,uint256)",
                 (U256::from(3u32), U256::from(0u32)),
                 0u32.into(),
-                compiled.abi
+                compiled.abi,
             )
             .unwrap();
 

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -64,6 +64,8 @@ ethers::contract::abigen!(
             deal(address,uint256)
             etch(address,bytes)
             expectRevert(bytes)
+            expectRevert(bytes4)
+            expectRevert(string)
             record()
             accesses(address)(bytes32[],bytes32[])
             expectEmit(bool,bool,bool,bool)

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -65,7 +65,6 @@ ethers::contract::abigen!(
             etch(address,bytes)
             expectRevert(bytes)
             expectRevert(bytes4)
-            expectRevert(string)
             record()
             accesses(address)(bytes32[],bytes32[])
             expectEmit(bool,bool,bool,bool)

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -98,9 +98,11 @@ ethers::contract::abigen!(
             event log_named_string       (string key, string val)
             ]"#,
 );
+pub use hevmconsole_mod::HEVMCONSOLE_ABI;
 
 // Bindings for hardhat console
 ethers::contract::abigen!(Console, "./testdata/console.json",);
+pub use console_mod::CONSOLE_ABI;
 
 /// If the input starts with a known `hardhat/console.log` `uint` selector, then this will replace
 /// it with the selector `abigen!` bindings expect.

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -402,7 +402,7 @@ mod tests {
         assert_eq!(status, ExitReason::Succeed(ExitSucceed::Stopped));
 
         let err = evm
-            .call::<(), _, _>(Address::zero(), addr, "testFailGreeting()", (), 0.into())
+            .call::<(), _, _>(Address::zero(), addr, "testFailGreeting()", (), 0.into(), compiled.abi)
             .unwrap_err();
         let (reason, gas_used) = match err {
             crate::EvmError::Execution { reason, gas_used, .. } => (reason, gas_used),

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -402,7 +402,14 @@ mod tests {
         assert_eq!(status, ExitReason::Succeed(ExitSucceed::Stopped));
 
         let err = evm
-            .call::<(), _, _>(Address::zero(), addr, "testFailGreeting()", (), 0.into(), compiled.abi)
+            .call::<(), _, _>(
+                Address::zero(),
+                addr,
+                "testFailGreeting()",
+                (),
+                0.into(),
+                compiled.abi,
+            )
             .unwrap_err();
         let (reason, gas_used) = match err {
             crate::EvmError::Execution { reason, gas_used, .. } => (reason, gas_used),

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -234,8 +234,16 @@ mod tests {
         let (addr, _, _, _) =
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
-        let (res, _, _, _) =
-            evm.call::<U256, _, _>(Address::zero(), addr, "time()(uint256)", (), 0.into(), compiled.abi).unwrap();
+        let (res, _, _, _) = evm
+            .call::<U256, _, _>(
+                Address::zero(),
+                addr,
+                "time()(uint256)",
+                (),
+                0.into(),
+                compiled.abi,
+            )
+            .unwrap();
 
         // https://etherscan.io/block/13292465
         assert_eq!(res.as_u64(), 1632539668);

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -235,7 +235,7 @@ mod tests {
             evm.deploy(Address::zero(), compiled.bytecode().unwrap().clone(), 0.into()).unwrap();
 
         let (res, _, _, _) =
-            evm.call::<U256, _, _>(Address::zero(), addr, "time()(uint256)", (), 0.into()).unwrap();
+            evm.call::<U256, _, _>(Address::zero(), addr, "time()(uint256)", (), 0.into(), compiled.abi).unwrap();
 
         // https://etherscan.io/block/13292465
         assert_eq!(res.as_u64(), 1632539668);

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -38,6 +38,8 @@ interface Hevm {
     function etch(address, bytes calldata) external;
     // Expects an error on next call
     function expectRevert(bytes calldata) external;
+    function expectRevert(bytes4) external;
+    function expectRevert(string calldata) external;
     // Record all storage reads and writes
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
@@ -294,13 +296,13 @@ contract CheatCodes is DSTest {
 
     function testExpectRevert() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert("Value too large");
+        hevm.expectRevert(string("Value too large"));
         target.stringErr(101);
         target.stringErr(99);
     }
 
     function testExpectRevertConstructor() public {
-        hevm.expectRevert("Value too large Constructor");
+        hevm.expectRevert(string("Value too large Constructor"));
         ExpectRevertConstructor target = new ExpectRevertConstructor(101);
         ExpectRevertConstructor target2 = new ExpectRevertConstructor(99);
     }
@@ -321,20 +323,20 @@ contract CheatCodes is DSTest {
 
     function testCalleeExpectRevert() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert("Value too largeCallee");
+        hevm.expectRevert(string("Value too largeCallee"));
         target.stringErrCall(101);
         target.stringErrCall(99);
     }
 
     function testFailExpectRevert() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert("Value too large");
+        hevm.expectRevert(string("Value too large"));
         target.stringErr2(101);
     }
 
     function testFailExpectRevert2() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert("Value too large");
+        hevm.expectRevert(string("Value too large"));
         target.stringErr(99);
     }
 
@@ -410,7 +412,7 @@ contract CheatCodes is DSTest {
     // Test should fail if nothing is called
     // after expectRevert
     function testFailExpectRevert3() public {
-        hevm.expectRevert("revert");
+        hevm.expectRevert(string("revert"));
     }
 
     function testMockArbitraryCall() public {

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -39,7 +39,6 @@ interface Hevm {
     // Expects an error on next call
     function expectRevert(bytes calldata) external;
     function expectRevert(bytes4) external;
-    function expectRevert(string calldata) external;
     // Record all storage reads and writes
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
@@ -296,13 +295,13 @@ contract CheatCodes is DSTest {
 
     function testExpectRevert() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert(string("Value too large"));
+        hevm.expectRevert("Value too large");
         target.stringErr(101);
         target.stringErr(99);
     }
 
     function testExpectRevertConstructor() public {
-        hevm.expectRevert(string("Value too large Constructor"));
+        hevm.expectRevert("Value too large Constructor");
         ExpectRevertConstructor target = new ExpectRevertConstructor(101);
         ExpectRevertConstructor target2 = new ExpectRevertConstructor(99);
     }
@@ -323,20 +322,20 @@ contract CheatCodes is DSTest {
 
     function testCalleeExpectRevert() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert(string("Value too largeCallee"));
+        hevm.expectRevert("Value too largeCallee");
         target.stringErrCall(101);
         target.stringErrCall(99);
     }
 
     function testFailExpectRevert() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert(string("Value too large"));
+        hevm.expectRevert("Value too large");
         target.stringErr2(101);
     }
 
     function testFailExpectRevert2() public {
         ExpectRevert target = new ExpectRevert();
-        hevm.expectRevert(string("Value too large"));
+        hevm.expectRevert("Value too large");
         target.stringErr(99);
     }
 
@@ -412,7 +411,7 @@ contract CheatCodes is DSTest {
     // Test should fail if nothing is called
     // after expectRevert
     function testFailExpectRevert3() public {
-        hevm.expectRevert(string("revert"));
+        hevm.expectRevert("revert");
     }
 
     function testMockArbitraryCall() public {

--- a/forge/README.md
+++ b/forge/README.md
@@ -145,7 +145,7 @@ which implements the following methods:
 - `function stopPrank()`: Stop calling smart contracts with the address set at `startPrank`
 
 - `function expectRevert(<overloaded> expectedError)`:
-  Tells the evm to expect that the next call reverts with specified error bytes. Valid input types: `bytes`, `bytes4`, and `string`
+  Tells the evm to expect that the next call reverts with specified error bytes. Valid input types: `bytes`, and `bytes4`. Implicitly, strings get converted to bytes except when shorter than 4, in which case you will need to cast explicitly to `bytes`.
   
 - `function expectEmit(bool,bool,bool,bool) external`: Expects the next emitted event. Params check topic 1, topic 2, topic 3 and data are the same.
 
@@ -249,7 +249,6 @@ interface Hevm {
     // Expects an error on next call
     function expectRevert(bytes calldata) external;
     function expectRevert(bytes4) external;
-    function expectRevert(string calldata) external;
     // Record all storage reads and writes
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address

--- a/forge/README.md
+++ b/forge/README.md
@@ -144,8 +144,8 @@ which implements the following methods:
 
 - `function stopPrank()`: Stop calling smart contracts with the address set at `startPrank`
 
-- `function expectRevert(bytes calldata expectedError)`:
-  Tells the evm to expect that the next call reverts with specified error bytes.
+- `function expectRevert(<overloaded> expectedError)`:
+  Tells the evm to expect that the next call reverts with specified error bytes. Valid input types: `bytes`, `bytes4`, and `string`
   
 - `function expectEmit(bool,bool,bool,bool) external`: Expects the next emitted event. Params check topic 1, topic 2, topic 3 and data are the same.
 
@@ -215,26 +215,32 @@ contract ExpectEmit {
 
 A full interface for all cheatcodes is here:
 ```solidity
-interface Vm {
+interface Hevm {
     // Set block.timestamp (newTimestamp)
     function warp(uint256) external;
     // Set block.height (newHeight)
     function roll(uint256) external;
+    // Set block.basefee (newBasefee)
+    function fee(uint256) external;
     // Loads a storage slot from an address (who, slot)
     function load(address,bytes32) external returns (bytes32);
     // Stores a value to an address' storage slot, (who, slot, value)
     function store(address,bytes32,bytes32) external;
-    // Signs data, (privateKey, digest) => (r, v, s)
+    // Signs data, (privateKey, digest) => (v, r, s)
     function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
     // Gets address for a given private key, (privateKey) => (address)
     function addr(uint256) external returns (address);
     // Performs a foreign function call via terminal, (stringInputs) => (result)
     function ffi(string[] calldata) external returns (bytes memory);
-    // Performs the next smart contract call with specified `msg.sender`, (newSender)
+    // Sets the *next* call's msg.sender to be the input address
     function prank(address) external;
-    // Performs all the following smart contract calls with specified `msg.sender`, (newSender)
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
     function startPrank(address) external;
-    // Stop smart contract calls using the specified address with prankStart()
+    // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
+    function prank(address,address) external;
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
+    function startPrank(address,address) external;
+    // Resets subsequent calls' msg.sender to be `address(this)`
     function stopPrank() external;
     // Sets an address' balance, (who, newBalance)
     function deal(address, uint256) external;
@@ -242,8 +248,16 @@ interface Vm {
     function etch(address, bytes calldata) external;
     // Expects an error on next call
     function expectRevert(bytes calldata) external;
-    // Expects the next emitted event. Params check topic 1, topic 2, topic 3 and data are the same.
-    function expectEmit(bool, bool, bool, bool) external;
+    function expectRevert(bytes4) external;
+    function expectRevert(string calldata) external;
+    // Record all storage reads and writes
+    function record() external;
+    // Gets all accessed reads and write slot from a recording session, for a given address
+    function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
+    // Call this function, then emit an event, then call a function. Internally after the call, we check if
+    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
+    function expectEmit(bool,bool,bool,bool) external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity
@@ -254,6 +268,8 @@ interface Vm {
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
     function expectCall(address,bytes calldata) external;
+
+    function getCode(string calldata) external returns (bytes memory);
 }
 ```
 ### `console.log`

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -1,5 +1,8 @@
 use crate::{runner::TestResult, ContractRunner, TestFilter};
-use evm_adapters::evm_opts::{BackendKind, EvmOpts};
+use evm_adapters::{
+    evm_opts::{BackendKind, EvmOpts},
+    sputnik::cheatcodes::{CONSOLE_ABI, HEVMCONSOLE_ABI, HEVM_ABI},
+};
 use sputnik::{backend::Backend, Config};
 
 use ethers::solc::Artifact;
@@ -78,6 +81,11 @@ impl MultiContractRunnerBuilder {
                 }
             }
         }
+
+        // add forge+sputnik specific contracts
+        known_contracts.insert("VM".to_string(), (HEVM_ABI.clone(), Vec::new()));
+        known_contracts.insert("VM_CONSOLE".to_string(), (HEVMCONSOLE_ABI.clone(), Vec::new()));
+        known_contracts.insert("CONSOLE".to_string(), (CONSOLE_ABI.clone(), Vec::new()));
 
         Ok(MultiContractRunner {
             contracts: deployable_contracts,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -267,6 +267,12 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
 
         let (address, mut evm, init_logs) = self.new_sputnik_evm()?;
 
+        let errors_abi = if let Some(contracts) = known_contracts {
+            foundry_utils::flatten_funcs_and_events(contracts).2
+        } else {
+            self.contract.clone()
+        };
+
         let mut logs = init_logs;
 
         let mut traces: Option<Vec<CallTraceArena>> = None;
@@ -319,7 +325,7 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
             func.clone(),
             (),
             0.into(),
-            Some(self.contract),
+            Some(&errors_abi),
         ) {
             Ok((_, status, gas_used, execution_logs)) => {
                 logs.extend(execution_logs);

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -314,7 +314,7 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
         }
 
         let (status, reason, gas_used, logs) =
-            match evm.call::<(), _, _>(self.sender, address, func.clone(), (), 0.into()) {
+            match evm.call::<(), _, _>(self.sender, address, func.clone(), (), 0.into(), Some(self.contract)) {
                 Ok((_, status, gas_used, execution_logs)) => {
                     logs.extend(execution_logs);
                     (status, None, gas_used, logs)
@@ -421,7 +421,7 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
 
         // instantiate the fuzzed evm in line
         let evm = FuzzedExecutor::new(&mut evm, runner, self.sender);
-        let FuzzTestResult { cases, test_error } = evm.fuzz(func, address, should_fail);
+        let FuzzTestResult { cases, test_error } = evm.fuzz(func, address, should_fail, Some(self.contract));
 
         let evm = evm.into_inner();
         if let Some(ref error) = test_error {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -148,7 +148,7 @@ pub fn decode_revert(error: &[u8], maybe_abi: Option<&Abi>) -> Result<String> {
                                 if let Ok(decoded) = abi_error.decode(&error[4..]) {
                                     let inputs = decoded
                                         .iter()
-                                        .map(|token| format_token(token))
+                                        .map(format_token)
                                         .collect::<Vec<String>>()
                                         .join(", ");
                                     return Ok(format!("{}({})", abi_error.name, inputs))

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -80,10 +80,11 @@ pub fn flatten_known_contracts(
 
     let flattened_events: BTreeMap<H256, Event> = contracts
         .iter()
-        .flat_map(|(_name, (abi, _code))| abi.events().collect::<Vec<&Event>>())
-        .collect::<Vec<&Event>>()
-        .into_iter()
-        .map(|event| (event.signature(), event.clone()))
+        .flat_map(|(_name, (abi, _code))| {
+            abi.events()
+                .map(|event| (event.signature(), event.clone()))
+                .collect::<BTreeMap<H256, Event>>()
+        })
         .collect();
 
     // We need this for better revert decoding, and want it in abi form

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -143,10 +143,15 @@ pub fn decode_revert(error: &[u8], maybe_abi: Option<&Abi>) -> Result<String> {
                     if let Some(abi) = maybe_abi {
                         for abi_error in abi.errors() {
                             if abi_error.signature()[0..4] == error[0..4] {
-                                // if we dont decode, dont return an error, try to decode as a string later
+                                // if we dont decode, dont return an error, try to decode as a
+                                // string later
                                 if let Ok(decoded) = abi_error.decode(&error[4..]) {
-                                    let inputs = decoded.iter().map(|token| { format_token(token) }).collect::<Vec<String>>().join(", ");
-                                    return Ok(format!("{}({})", abi_error.name, inputs));
+                                    let inputs = decoded
+                                        .iter()
+                                        .map(|token| format_token(token))
+                                        .collect::<Vec<String>>()
+                                        .join(", ");
+                                    return Ok(format!("{}({})", abi_error.name, inputs))
                                 }
                             }
                         }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -69,7 +69,7 @@ pub fn remove_extra_costs(gas: U256, calldata: &[u8]) -> U256 {
 pub fn flatten_funcs_and_events(
     contracts: &BTreeMap<String, (Abi, Vec<u8>)>,
 ) -> (BTreeMap<[u8; 4], Function>, BTreeMap<H256, Event>, Abi) {
-    let mut flattened_funcs: BTreeMap<[u8; 4], Function> = contracts
+    let flattened_funcs: BTreeMap<[u8; 4], Function> = contracts
         .iter()
         .flat_map(|(_name, (abi, _code))| abi.functions().cloned().collect::<Vec<Function>>())
         .collect::<Vec<Function>>()
@@ -77,7 +77,7 @@ pub fn flatten_funcs_and_events(
         .map(|func| (func.short_signature(), func))
         .collect();
 
-    let mut flattened_events: BTreeMap<H256, Event> = contracts
+    let flattened_events: BTreeMap<H256, Event> = contracts
         .iter()
         .flat_map(|(_name, (abi, _code))| abi.events().cloned().collect::<Vec<Event>>())
         .collect::<Vec<Event>>()
@@ -94,39 +94,6 @@ pub fn flatten_funcs_and_events(
             entry.push(error.clone());
         });
     });
-
-    // add forge specific functions
-    #[cfg(feature = "sputnik")]
-    {
-        flattened_funcs.extend(
-            HEVM_ABI
-                .functions()
-                .cloned()
-                .map(|func| (func.short_signature(), func))
-                .collect::<BTreeMap<[u8; 4], Function>>(),
-        );
-        flattened_events.extend(
-            HEVM_ABI
-                .events()
-                .cloned()
-                .map(|event| (event.signature(), event))
-                .collect::<BTreeMap<H256, Event>>(),
-        );
-        flattened_events.extend(
-            HEVMCONSOLE_ABI
-                .events()
-                .cloned()
-                .map(|event| (event.signature(), event))
-                .collect::<BTreeMap<H256, Event>>(),
-        );
-        flattened_events.extend(
-            CONSOLE_ABI
-                .events()
-                .cloned()
-                .map(|event| (event.signature(), event))
-                .collect::<BTreeMap<H256, Event>>(),
-        );
-    }
     (flattened_funcs, flattened_events, errors_abi)
 }
 


### PR DESCRIPTION
Primarily, this introduces improvements:
1. Decodes custom errors in call traces as well as fail messages
2. adds overloading of `expectRevert`
3. functions, events, and errors are flattened across all compiled abis to allow for decoding of calls, events, and errors regardless if a particular contract is identified.

Closes #409, Closes #479