### PR TITLE
feat: detect proxies for `cast send` and `cast call`

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -187,7 +187,6 @@ pub async fn get_func_etherscan(
     chain: Chain,
     etherscan_api_key: String,
 ) -> Result<Function> {
-
     let client = Client::new(chain, etherscan_api_key)?;
 
     let metadata = &client.contract_source_code(contract).await?.items[0];
@@ -196,7 +195,7 @@ pub async fn get_func_etherscan(
     } else {
         metadata.implementation.parse::<Address>()?
     };
-    
+
     let abi = client.contract_abi(contract).await?;
     let funcs = abi.functions.get(function_name).unwrap();
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -178,6 +178,8 @@ pub fn get_func(sig: &str) -> Result<Function> {
     Ok(func.clone())
 }
 
+// Given a function name, address, and args, tries to parse it as a `Function` by fetching the
+// abi from etherscan. If the address is a proxy, fetches the ABI of the implementation contract.
 pub async fn get_func_etherscan(
     function_name: &str,
     contract: Address,
@@ -185,7 +187,16 @@ pub async fn get_func_etherscan(
     chain: Chain,
     etherscan_api_key: String,
 ) -> Result<Function> {
+
     let client = Client::new(chain, etherscan_api_key)?;
+
+    let metadata = &client.contract_source_code(contract).await?.items[0];
+    let contract = if metadata.implementation.is_empty() {
+        contract
+    } else {
+        metadata.implementation.parse::<Address>()?
+    };
+    
     let abi = client.contract_abi(contract).await?;
     let funcs = abi.functions.get(function_name).unwrap();
 


### PR DESCRIPTION
It turns out I didn't need to make any changes to ethers-rs, as `implementation` is exposed in the `Metadata` struct returned by `client.contract_source_code`.