### PR TITLE
fix: move cargo forge & cast bins to foundry bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ Foundry consists of:
 
 ## Installation 
 
+First run the command below to get `foundryup`, the Foundry toolchain installer:
+
 ```
 curl https://raw.githubusercontent.com/gakonst/foundry/master/foundryup/install | bash
 ```
-in a new terminal session or after reloading your PATH:
+
+Then in a new terminal session or after reloading your PATH, run it to get the latest `forge` and `cast` binaries:
+
 ```
 foundryup
 ```
-
-Just get foundryup, the Foundry toolchain installer, and use it to install the latest `forge` and `cast` binaries.
 
 Advanced ways to use `foundryup` and other documentation can be found in the [foundryup package](./foundryup/README.md). Happy forging!
 

--- a/foundryup/install
+++ b/foundryup/install
@@ -86,7 +86,7 @@ else
     git pull
     cargo install --path ./cli --bins --locked --force
   else
-    # Repo path did not exist, grab the author from the repo, make a directory in .foundryup, cd to it, clone and install.
+    # Repo path did not exist, grab the author from the repo, make a directory in .foundry, cd to it, clone and install.
     IFS="/" read -ra AUTHOR <<< "$FOUNDRYUP_REPO"
     mkdir -p "$FOUNDRY_DIR/$AUTHOR"
     cd "$FOUNDRY_DIR/$AUTHOR"

--- a/foundryup/install
+++ b/foundryup/install
@@ -93,7 +93,11 @@ else
     git clone https://github.com/${FOUNDRYUP_REPO}
     cd $REPO_PATH
     git checkout ${FOUNDRYUP_BRANCH}
+
     cargo install --path ./cli --bins --locked --force
+    
+    mv ~/.cargo/bin/forge $FOUNDRY_BIN_DIR/forge
+    mv ~/.cargo/bin/cast $FOUNDRY_BIN_DIR/cast
   fi
 fi'
 

--- a/foundryup/install
+++ b/foundryup/install
@@ -94,10 +94,7 @@ else
     cd $REPO_PATH
     git checkout ${FOUNDRYUP_BRANCH}
 
-    cargo install --path ./cli --bins --locked --force
-    
-    mv ~/.cargo/bin/forge $FOUNDRY_BIN_DIR/forge
-    mv ~/.cargo/bin/cast $FOUNDRY_BIN_DIR/cast
+    cargo install --path ./cli --bins --locked --force --root $FOUNDRY_BIN_DIR
   fi
 fi'
 


### PR DESCRIPTION
if we have two different sets of binaries on the system both sourced in PATH (.cargo/bin .foundry/bin) one will always take precedent over the other. since the foundryup command itself uses both cargo and manually adding to foundry bin, we need to fix this (https://github.com/gakonst/foundry/pull/480)

the lazy fix is just to move the bins put in cargo bin into the foundry bin dir after running cargo install, which i have impl'd here