### PR TITLE
feat: add publish to cast

### DIFF
--- a/cast/README.md
+++ b/cast/README.md
@@ -49,7 +49,7 @@
 - [ ] `mktx`
 - [x] `namehash`
 - [x] `nonce`
-- [ ] `publish`
+- [x] `publish`
 - [ ] `receipt`
 - [x] `resolve-name`
 - [ ] `run-tx`

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -160,12 +160,12 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn publish(&self, raw_tx: String) -> Result<PendingTransaction<'_, M::Provider>> {
-        let edit_raw_tx: String = match raw_tx.starts_with("0x") {
-            true => raw_tx.split_at(2).1.to_string(),
-            false => raw_tx,
+    pub async fn publish(&self, mut raw_tx: String) -> Result<PendingTransaction<'_, M::Provider>> {
+        raw_tx = match raw_tx.strip_prefix("0x") {
+            Some(s) => s.to_string(),
+            None => raw_tx,
         };
-        let tx = Bytes::from(hex::decode(edit_raw_tx)?);
+        let tx = Bytes::from(hex::decode(raw_tx)?);
         let res = self.provider.send_raw_transaction(tx).await?;
 
         Ok::<_, eyre::Error>(res)

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -146,6 +146,31 @@ where
         Ok::<_, eyre::Error>(res)
     }
 
+    /// Publishes a raw transaction to the network
+    ///
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let res = cast.publish("0x1234".to_string()).await?;
+    /// println!("{:?}", res);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn publish(&self, raw_tx: String) -> Result<PendingTransaction<'_, M::Provider>> {
+        let edit_raw_tx: String = match raw_tx.starts_with("0x") {
+            true => raw_tx.split_at(2).1.to_string(),
+            false => raw_tx,
+        };
+        let tx = Bytes::from(hex::decode(edit_raw_tx)?);
+        let res = self.provider.send_raw_transaction(tx).await?;
+
+        Ok::<_, eyre::Error>(res)
+    }
+
     /// Estimates the gas cost of a transaction
     ///
     /// ```no_run

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -229,6 +229,20 @@ async fn main() -> eyre::Result<()> {
                 .await?;
             }
         }
+        Subcommands::PublishTx { eth, raw_tx, cast_async } => {
+            let provider = Provider::try_from(eth.rpc_url()?)?;
+            let cast = Cast::new(&provider);
+            let pending_tx = cast.publish(raw_tx).await?;
+            let tx_hash = *pending_tx;
+
+            if cast_async {
+                println!("{:?}", pending_tx);
+            } else {
+                let receipt =
+                    pending_tx.await?.ok_or_else(|| eyre::eyre!("tx {} not found", tx_hash))?;
+                println!("Receipt: {:?}", receipt);
+            }
+        }
         Subcommands::Estimate { eth, to, sig, args } => {
             let provider = Provider::try_from(eth.rpc_url()?)?;
             let cast = Cast::new(&provider);

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -141,6 +141,16 @@ pub enum Subcommands {
         #[clap(flatten)]
         eth: EthereumOpts,
     },
+    #[clap(name = "publish")]
+    #[clap(about = "Publish a raw transaction to the network")]
+    PublishTx {
+        #[clap(help = "the raw transaction you want to publish")]
+        raw_tx: String,
+        #[clap(long, env = "CAST_ASYNC")]
+        cast_async: bool,
+        #[clap(flatten)]
+        eth: EthereumOpts,
+    },
     #[clap(name = "estimate")]
     #[clap(about = "Estimate the gas cost of a transaction from <from> to <to> with <data>")]
     Estimate {


### PR DESCRIPTION
Adds `publish` to cast letting users send raw transactions to the network.