### PR TITLE
Keep 3 days of nightlies

### DIFF
--- a/.github/scripts/move-tag.js
+++ b/.github/scripts/move-tag.js
@@ -1,0 +1,15 @@
+module.exports = async ({github, context}, tagName) => {
+  try {
+    await github.rest.git.updateRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `tags/${tagName}`,
+      sha: context.sha,
+      force: true
+    })
+  } catch (err) {
+    console.error(`Failed to move nightly tag.`)
+    console.error(`This should only happen the first time.`)
+    console.error(err)
+  }
+}

--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -1,0 +1,31 @@
+module.exports = async ({github, context}) => {
+  console.log('Pruning old prereleases')
+
+  const { data: releases } = await github.rest.repos.listReleases({
+    owner: context.repo.owner,
+    repo: context.repo.repo
+  })
+  let nightlies = releases.filter(
+    (release) => release.tag_name.includes('nightly')
+  )
+
+  // Keep newest 3 nightlies
+  nightlies = nightlies.slice(3)
+
+  for (const nightly of nightlies) {
+    console.log(`Deleting nightly: ${nightly.tag_name}`)
+    await github.rest.repos.deleteRelease({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      release_id: nightly.id
+    })
+    console.log(`Deleting nightly tag: ${nightly.tag_name}`)
+    await github.rest.git.deleteRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `tags/${nightly.tag_name}`
+    })
+  }
+
+  console.log('Done.')
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,61 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag name to release or nightly for nightly releases'
-        required: true
-        default: nightly
 
 env:
-  TAG_NAME: ${{ (github.event_name == 'schedule' && 'nightly') || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || github.ref_name }}
+  IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
 jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag_name: ${{ steps.release_info.outputs.tag_name }}
+      release_name: ${{ steps.release_info.outputs.release_name }}
+      changelog: ${{ steps.build_changelog.outputs.changelog }}
+
+    steps:
+      - name: Move nightly tag
+        if: ${{ env.IS_NIGHTLY }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            try {
+              await github.rest.git.updateRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/nightly',
+                sha: context.sha,
+                force: true
+              })
+            } catch (err) {
+              console.error(`Failed to move nightly tag.`)
+              console.error(`This should only happen the first time.`)
+              console.error(err)
+            }
+
+      - name: Compute release name and tag
+        id: release_info
+        run: |
+          if [[ $IS_NIGHTLY ]]; then
+            echo "::set-output name=tag_name::nightly-${GITHUB_SHA}"
+            echo "::set-output name=release_name::Nightly ($(date '+%Y-%m-%d'))"
+          else
+            echo "::set-output name=tag_name::${GITHUB_REF_NAME}"
+            echo "::set-output name=release_name::${GITHUB_REF_NAME}"
+          fi
+
+      - name: Build changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
+    needs: prepare
     strategy:
       matrix:
         job:
@@ -113,32 +155,6 @@ jobs:
           echo "::set-output name=foundry_man::foundry_man_${TAG_NAME}.tar.gz"
         shell: bash
 
-      - name: Build changelog
-        id: build_changelog
-        if: ${{ env.TAG_NAME != 'nightly' }}
-        uses: mikepenz/release-changelog-builder-action@v2.4.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Move nightly tag
-        if: ${{ env.TAG_NAME == 'nightly' }}
-        uses: actions/github-script@v5
-        with:
-          script: |
-            try {
-              await github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/nightly',
-                sha: context.sha,
-                force: true
-              })
-            } catch (err) {
-              console.error(`Failed to move nightly tag.`)
-              console.error(`This should only happen the first time.`)
-              console.error(err)
-            }
-
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
@@ -148,3 +164,52 @@ jobs:
           files:  |
             ${{ steps.artifacts.outputs.file_name }}
             ${{ steps.man.outputs.foundry_man }}
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ needs.prepare.outputs.release_name }}
+          tag_name: ${{ needs.prepare.outputs.tag_name }}
+          prerelease: ${{ env.IS_NIGHTLY }}
+          body: ${{ needs.prepare.outputs.changelog }}
+          files: |
+            ${{ steps.artifacts.outputs.file_name }}
+            ${{ steps.man.outputs.foundry_man }}
+  cleanup:
+    name: Release cleanup
+    runs-on: ubuntu-latest
+    needs: release
+
+    steps:
+      - name: Delete old nightlies
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+            let nightlies = releases.filter(
+              (release) => release.tag_name.includes('nightly')
+            )
+
+            // Keep newest 3 nightlies
+            nightlies = nightlies.slice(3)
+
+            for (const nightly of nightlies) {
+              console.log(`Deleting nightly: ${nightly.tag_name}`)
+              await github.rest.repos.deleteRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: nightly.id
+              })
+              console.log(`Deleting nightly tag: ${nightly.tag_name}`)
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${nightly.tag_name}`
+              })
+            }
+
+            console.log('Done.')
+>>>>>>> cb72d6c (Keep 3 days of nightlies)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,20 +122,21 @@ jobs:
           PLATFORM_NAME: ${{ matrix.job.platform }}
           TARGET: ${{ matrix.job.target }}
           ARCH: ${{ matrix.job.arch }}
+          VERSION_NAME: ${{ (env.IS_NIGHTLY && 'nightly') || needs.prepare.outputs.tag_name }}
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
-            tar -czvf "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-            echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+            tar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+            echo "::set-output name=file_name::foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           elif [ "$PLATFORM_NAME" == "darwin" ]; then
             # We need to use gtar here otherwise the archive is corrupt.
             # See: https://github.com/actions/virtual-environments/issues/2619
-            gtar -czvf "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
-            echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+            gtar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+            echo "::set-output name=file_name::foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           else
             cd ./target/${TARGET}/release
-            7z a -tzip "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip" forge.exe cast.exe
-            mv "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../../
-            echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.zip"
+            7z a -tzip "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" forge.exe cast.exe
+            mv "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../../
+            echo "::set-output name=file_name::foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip"
           fi
         shell: bash
 
@@ -212,4 +213,3 @@ jobs:
             }
 
             console.log('Done.')
->>>>>>> cb72d6c (Keep 3 days of nightlies)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,8 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            try {
-              await github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/nightly',
-                sha: context.sha,
-                force: true
-              })
-            } catch (err) {
-              console.error(`Failed to move nightly tag.`)
-              console.error(`This should only happen the first time.`)
-              console.error(err)
-            }
+            const moveTag = require('./.github/scripts/move-tag.js')
+            await moveTag({ github, context }, 'nightly')
 
       - name: Compute release name and tag
         id: release_info
@@ -176,30 +165,5 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const { data: releases } = await github.rest.repos.listReleases({
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            })
-            let nightlies = releases.filter(
-              (release) => release.tag_name.includes('nightly')
-            )
-
-            // Keep newest 3 nightlies
-            nightlies = nightlies.slice(3)
-
-            for (const nightly of nightlies) {
-              console.log(`Deleting nightly: ${nightly.tag_name}`)
-              await github.rest.repos.deleteRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: nightly.id
-              })
-              console.log(`Deleting nightly tag: ${nightly.tag_name}`)
-              await github.rest.git.deleteRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `tags/${nightly.tag_name}`
-              })
-            }
-
-            console.log('Done.')
+            const prunePrereleases = require('./.github/scripts/prune-prereleases.js')
+            await prunePrereleases({github, context})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,16 +159,6 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ env.TAG_NAME }}
-          prerelease: ${{ env.TAG_NAME == 'nightly' }}
-          body: ${{ steps.build_changelog.outputs.changelog }}
-          files:  |
-            ${{ steps.artifacts.outputs.file_name }}
-            ${{ steps.man.outputs.foundry_man }}
-
-      - name: Create release
-        uses: softprops/action-gh-release@v1
-        with:
           name: ${{ needs.prepare.outputs.release_name }}
           tag_name: ${{ needs.prepare.outputs.tag_name }}
           prerelease: ${{ env.IS_NIGHTLY }}

--- a/foundryup/README.md
+++ b/foundryup/README.md
@@ -5,7 +5,7 @@ Update or revert to a specific Foundry branch with ease.
 ## Installing
 
 ```sh
-curl https://raw.githubusercontent.com/gakonst/foundry/master/foundryup/install | bash
+curl -L https://foundry.paradigm.xyz | bash
 ```
 
 ## Usage

--- a/foundryup/install
+++ b/foundryup/install
@@ -30,6 +30,22 @@ FOUNDRYUP_REPO=${FOUNDRYUP_REPO-gakonst/foundry}
 
 if [[ "$FOUNDRYUP_REPO" == "gakonst/foundry" && -z "$FOUNDRYUP_BRANCH" ]]; then 
   FOUNDRYUP_VERSION=${FOUNDRYUP_VERSION-nightly}
+  FOUNDRYUP_TAG=$FOUNDRYUP_VERSION
+
+  # Normalize versions (handle channels, versions without v prefix
+  if [[ "$FOUNDRYUP_VERSION" == "nightly" ]]; then
+    # Locate real nightly tag
+    SHA=$(curl -sSf https://api.github.com/repos/${FOUNDRYUP_REPO}/git/refs/tags/nightly \
+      | grep -Eo '\''"sha"[^,]*'\'' \
+      | grep -Eo '\''[^:]*$'\'' \
+      | tr -d '\''"'\'' \
+      | tr -d '\'' '\'')
+    FOUNDRYUP_TAG="nightly-${SHA}"
+  elif [[ "$FOUNDRYUP_VERSION" == [[:digit:]]* ]]; then
+    # Add v prefix
+    FOUNDRYUP_VERSION="v${FOUNDRYUP_VERSION}"
+    FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
+  fi
 
   PLATFORM="$(uname -s)"
   case $PLATFORM in
@@ -60,7 +76,7 @@ if [[ "$FOUNDRYUP_REPO" == "gakonst/foundry" && -z "$FOUNDRYUP_BRANCH" ]]; then
   fi
   
   # Compute the URL of the release tarball in the Foundry repository.
-  RELEASE_URL="https://github.com/${FOUNDRYUP_REPO}/releases/download/${FOUNDRYUP_VERSION}/"
+  RELEASE_URL="https://github.com/${FOUNDRYUP_REPO}/releases/download/${FOUNDRYUP_TAG}/"
   BIN_TARBALL_URL="${RELEASE_URL}foundry_${FOUNDRYUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.tar.gz"
   MAN_TARBALL_URL="${RELEASE_URL}foundry_man_${FOUNDRYUP_VERSION}.tar.gz"
 
@@ -68,6 +84,7 @@ if [[ "$FOUNDRYUP_REPO" == "gakonst/foundry" && -z "$FOUNDRYUP_BRANCH" ]]; then
   curl -L $BIN_TARBALL_URL | tar -xvzC $FOUNDRY_BIN_DIR
   # Download the man tarball and unpack it into the .foundry man directory.
   curl -L $MAN_TARBALL_URL | tar -xvzC $FOUNDRY_MAN_DIR
+  echo foundryup: done!
 else 
   FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH-master}
   
@@ -104,6 +121,7 @@ else
     help2man -N $FOUNDRY_BIN_DIR/forge > $FOUNDRY_MAN_DIR/forge.1
     help2man -N $FOUNDRY_BIN_DIR/cast > $FOUNDRY_MAN_DIR/cast.1
   fi
+  echo foundryup: done!
 fi'
 
 BINARY="$FOUNDRY_BIN_DIR/foundryup"


### PR DESCRIPTION
Cleans up the release workflow a bit and keeps 3 nightlies.

Nightlies are now tagged with `nightly-$SHA` as well as `nightly`. To find the latest nightly, you would look up the `nightly` tag and find the release at `nightly-$SHA` where `$SHA` is the commit that `nightly` is pointing to.

The workflow only deletes releases that have `nightly` in the tag of the release, which allows us to release other pre-release versions (betas etc.)

This also adjusts `foundryup` accordingly and there is a PR for `foundry-toolchain` too: https://github.com/onbjerg/foundry-toolchain/pull/2. **This is a breaking change for `foundryup`.**

Closes #472