### PR TITLE
fix: avoid redundant etherscan calls

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -207,7 +207,7 @@ pub async fn get_func_etherscan(
         }
     }
 
-    Err(eyre::eyre!("Function not found"))
+    Err(eyre::eyre!("Function not found in abi"))
 }
 
 /// Parses string input as Token against the expected ParamType

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -197,7 +197,8 @@ pub async fn get_func_etherscan(
         client.contract_abi(implementation).await?
     };
 
-    let funcs = abi.functions.get(function_name).unwrap();
+    let empty = vec![];
+    let funcs = abi.functions.get(function_name).unwrap_or(&empty);
 
     for func in funcs {
         let res = encode_args(func, &args);

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -188,15 +188,15 @@ pub async fn get_func_etherscan(
     etherscan_api_key: String,
 ) -> Result<Function> {
     let client = Client::new(chain, etherscan_api_key)?;
-
     let metadata = &client.contract_source_code(contract).await?.items[0];
-    let contract = if metadata.implementation.is_empty() {
-        contract
+
+    let abi = if metadata.implementation.is_empty() {
+        serde_json::from_str(&metadata.abi)?
     } else {
-        metadata.implementation.parse::<Address>()?
+        let implementation = metadata.implementation.parse::<Address>()?;
+        client.contract_abi(implementation).await?
     };
 
-    let abi = client.contract_abi(contract).await?;
     let funcs = abi.functions.get(function_name).unwrap();
 
     for func in funcs {


### PR DESCRIPTION
Follow up on #484 which adds proxy detection, but a the expense of making two etherscan API calls. I also made a slight improvement in the error handling. Before if the contract was not verified, you did not get a good error message.