### PR TITLE
fix(cheatcode): dangling expectEmit should fail

### DIFF
--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -407,6 +407,11 @@ contract CheatCodes is DSTest {
         emitter.t();
     }
 
+    function testFailDanglingExpectEmit() public {
+        hevm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1337), 1337);
+    }
+
     // Test should fail if nothing is called
     // after expectRevert
     function testFailExpectRevert3() public {


### PR DESCRIPTION
Doesn't fix the issue yet, just demonstrates the problem:

Just like `expectRevert`, imho a dangling `expectEmit` should fail a test.