### PR TITLE
feat/cast: adds --to-unit

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -807,11 +807,13 @@ impl SimpleCast {
         let value = U256::from(LenientTokenizer::tokenize_uint(&value)?);
 
         Ok(match &unit[..] {
-            "ether" => ethers_core::utils::format_units(value, 18)?.trim_end_matches(".000000000000000000").to_string(),
-            "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9)?.trim_end_matches(".000000000").to_string(),
-            "wei" => {
-                ethers_core::utils::format_units(value, 0)?.trim_end_matches(".0").to_string()
-            }
+            "ether" => ethers_core::utils::format_units(value, 18)?
+                .trim_end_matches(".000000000000000000")
+                .to_string(),
+            "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9)?
+                .trim_end_matches(".000000000")
+                .to_string(),
+            "wei" => ethers_core::utils::format_units(value, 0)?.trim_end_matches(".0").to_string(),
             _ => return Err(eyre::eyre!("invalid unit")),
         })
     }

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -795,8 +795,8 @@ impl SimpleCast {
     /// use cast::SimpleCast as Cast;
     ///
     /// fn main() -> eyre::Result<()> {
-    ///     assert_eq!(Cast::to_unit("1 wei".to_string(), "".to_string())?, "1");
-    ///     assert_eq!(Cast::to_unit("1".to_string(), "".to_string())?, "1");
+    ///     assert_eq!(Cast::to_unit("1 wei".to_string(), "wei".to_string())?, "1");
+    ///     assert_eq!(Cast::to_unit("1".to_string(), "wei".to_string())?, "1");
     ///     assert_eq!(Cast::to_unit("1ether".to_string(), "wei".to_string())?, "1000000000000000000");
     ///     assert_eq!(Cast::to_unit("100 gwei".to_string(), "gwei".to_string())?, "100");
     ///

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -807,10 +807,10 @@ impl SimpleCast {
         let value = U256::from(LenientTokenizer::tokenize_uint(&value)?);
 
         Ok(match &unit[..] {
-            "ether" => ethers_core::utils::format_units(value, 18)?,
-            "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9u32)?,
+            "ether" => ethers_core::utils::format_units(value, 18)?.trim_end_matches(".000000000000000000").to_string(),
+            "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9)?.trim_end_matches(".000000000").to_string(),
             "wei" => {
-                ethers_core::utils::format_units(value, 0u32)?.trim_end_matches(".0").to_string()
+                ethers_core::utils::format_units(value, 0)?.trim_end_matches(".0").to_string()
             }
             _ => return Err(eyre::eyre!("invalid unit")),
         })

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -3,7 +3,10 @@
 //! TODO
 use chrono::NaiveDateTime;
 use ethers_core::{
-    abi::{Abi, AbiParser, Token},
+    abi::{
+        token::{LenientTokenizer, Tokenizer},
+        Abi, AbiParser, Token,
+    },
     types::{Chain, *},
     utils::{self, keccak256},
 };
@@ -784,6 +787,33 @@ impl SimpleCast {
         let num_u256 = U256::from_str_radix(value, 10)?;
         let num_hex = format!("{:x}", num_u256);
         Ok(format!("0x{}{}", "0".repeat(64 - num_hex.len()), num_hex))
+    }
+
+    /// Converts an eth amount into a specified unit
+    ///
+    /// ```
+    /// use cast::SimpleCast as Cast;
+    ///
+    /// fn main() -> eyre::Result<()> {
+    ///     assert_eq!(Cast::to_unit("1 wei".to_string(), "".to_string())?, "1");
+    ///     assert_eq!(Cast::to_unit("1".to_string(), "".to_string())?, "1");
+    ///     assert_eq!(Cast::to_unit("1ether".to_string(), "wei".to_string())?, "1000000000000000000");
+    ///     assert_eq!(Cast::to_unit("100 gwei".to_string(), "gwei".to_string())?, "100");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn to_unit(value: String, unit: String) -> Result<String> {
+        let value = U256::from(LenientTokenizer::tokenize_uint(&value)?);
+
+        Ok(match &unit[..] {
+            "ether" => ethers_core::utils::format_units(value, 18)?,
+            "gwei" | "nano" | "nanoether" => ethers_core::utils::format_units(value, 9u32)?,
+            "wei" => {
+                ethers_core::utils::format_units(value, 0u32)?.trim_end_matches(".0").to_string()
+            }
+            _ => return Err(eyre::eyre!("invalid unit")),
+        })
     }
 
     /// Converts an eth amount into wei

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -107,6 +107,10 @@ async fn main() -> eyre::Result<()> {
             let val = unwrap_or_stdin(value)?;
             println!("{}", SimpleCast::to_uint256(&val)?);
         }
+        Subcommands::ToUnit { value, unit } => {
+            let val = unwrap_or_stdin(value)?;
+            println!("{}", SimpleCast::to_unit(val, unit.unwrap_or_else(|| String::from("wei")))?);
+        }
         Subcommands::ToWei { value, unit } => {
             let val = unwrap_or_stdin(value)?;
             println!(

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -54,11 +54,22 @@ pub enum Subcommands {
     #[clap(name = "--to-uint256")]
     #[clap(about = "convert a number into uint256 hex string with 0x prefix")]
     ToUint256 { value: Option<String> },
+    #[clap(name = "--to-unit")]
+    #[clap(
+        about = r#"convert an ETH amount into a specified unit: ether, gwei or wei (default: wei). 
+    Usage Example: 
+      - 1ether wei     | converts 1 ether to wei
+      - "1 ether" wei  | converts 1 ether to wei
+      - 1 gwei         | converts 1 wei to gwei
+      - 1gwei ether    | converts 1 gwei to ether
+    "#
+    )]
+    ToUnit { value: Option<String>, unit: Option<String> },
     #[clap(name = "--to-wei")]
-    #[clap(about = "convert an ETH amount into wei")]
+    #[clap(about = "convert an ETH amount into wei. Consider using --to-unit.")]
     ToWei { value: Option<String>, unit: Option<String> },
     #[clap(name = "--from-wei")]
-    #[clap(about = "convert wei into an ETH amount")]
+    #[clap(about = "convert wei into an ETH amount. Consider using --to-unit.")]
     FromWei { value: Option<String>, unit: Option<String> },
     #[clap(name = "block")]
     #[clap(

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -57,9 +57,10 @@ pub enum Subcommands {
     #[clap(name = "--to-unit")]
     #[clap(
         about = r#"convert an ETH amount into a specified unit: ether, gwei or wei (default: wei). 
-    Usage Example: 
+    Usage: 
       - 1ether wei     | converts 1 ether to wei
       - "1 ether" wei  | converts 1 ether to wei
+      - 1ether         | converts 1 ether to wei
       - 1 gwei         | converts 1 wei to gwei
       - 1gwei ether    | converts 1 gwei to ether
     "#


### PR DESCRIPTION
It uses `LenientTokenizer` from `ethabi` to convert in-between units (`ether`, `gwei`, `nano`, `nanoether` and `wei`).

Imo, should be recommended for using instead of `--to-wei` and `--from-wei`, where the parsing is done through `f64`, which might have some precision issues: https://github.com/rust-ethereum/ethabi/pull/255#discussion_r786490582

I'm trimming the decimal part, if there are only decimal 0s. I think it makes sense for when converting to `wei`, but the rest is debatable I guess.

```
cast---to-unit
convert an ETH amount into a specified unit: ether, gwei or wei (default: wei).
    Usage Example:
      - 1ether wei     | converts 1 ether to wei
      - "1 ether" wei  | converts 1 ether to wei
      - 1ether         | converts 1 ether to wei
      - 1 gwei         | converts 1 wei to gwei
      - 1gwei ether    | converts 1 gwei to ether


USAGE:
    cast --to-unit [ARGS]

ARGS:
    <VALUE>
    <UNIT>

OPTIONS:
    -h, --help    Print help information
```