### PR TITLE
Follow redirect when installing foundryup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Foundry consists of:
 First run the command below to get `foundryup`, the Foundry toolchain installer:
 
 ```
-curl https://foundry.paradigm.xyz | bash
+curl -L https://foundry.paradigm.xyz | bash
 ```
 
 Then in a new terminal session or after reloading your PATH, run it to get the latest `forge` and `cast` binaries:


### PR DESCRIPTION
It seems that there is a redirect involved when calling `foundry.paradigm.xyz` that needs to be followed so the curl can work properly.

```
curl https://foundry.paradigm.xyz -vvv
*   Trying 2606:4700::6811:1258:443...
* Connected to foundry.paradigm.xyz (2606:4700::6811:1258) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: Jun 27 00:00:00 2021 GMT
*  expire date: Jun 26 23:59:59 2022 GMT
*  subjectAltName: host "foundry.paradigm.xyz" matched cert's "*.paradigm.xyz"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55dac6845560)
> GET / HTTP/2
> Host: foundry.paradigm.xyz
> user-agent: curl/7.74.0
> accept: */*
> 
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Connection state changed (MAX_CONCURRENT_STREAMS == 256)!
< HTTP/2 301 
```