### PR TITLE
feat(cli): install man pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,24 @@ jobs:
           fi
         shell: bash
 
+      - name: Build man page
+        id: man
+        if: ${{ matrix.job.platform == 'linux' }}
+        env:
+          PLATFORM_NAME: ${{ matrix.job.platform }}
+          TARGET: ${{ matrix.job.target }}
+        run: |
+          sudo apt-get -y install help2man
+          help2man --version-string=0.1 -N ./target/${TARGET}/release/forge > forge.1
+          help2man --version-string=0.1 -N ./target/${TARGET}/release/cast > cast.1
+          gzip forge.1
+          gzip cast.1
+          mv forge.1.gz forge.1
+          mv cast.1.gz cast.1
+          tar -czvf "foundry_man_${TAG_NAME}.tar.gz" forge.1 cast.1
+          echo "::set-output name=foundry_man::foundry_man_${TAG_NAME}.tar.gz"
+        shell: bash
+
       - name: Build changelog
         id: build_changelog
         if: ${{ env.TAG_NAME != 'nightly' }}
@@ -124,4 +142,6 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           prerelease: ${{ env.TAG_NAME == 'nightly' }}
           body: ${{ steps.build_changelog.outputs.changelog }}
-          files: ${{ steps.artifacts.outputs.file_name }}
+          files:  |
+            ${{ steps.artifacts.outputs.file_name }}
+            ${{ steps.man.outputs.foundry_man }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,8 @@ jobs:
           TARGET: ${{ matrix.job.target }}
         run: |
           sudo apt-get -y install help2man
-          help2man --version-string=0.1 -N ./target/${TARGET}/release/forge > forge.1
-          help2man --version-string=0.1 -N ./target/${TARGET}/release/cast > cast.1
+          help2man -N ./target/${TARGET}/release/forge > forge.1
+          help2man -N ./target/${TARGET}/release/cast > cast.1
           gzip forge.1
           gzip cast.1
           mv forge.1.gz forge.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,7 @@ jobs:
           help2man -N ./target/${TARGET}/release/cast > cast.1
           gzip forge.1
           gzip cast.1
-          mv forge.1.gz forge.1
-          mv cast.1.gz cast.1
-          tar -czvf "foundry_man_${TAG_NAME}.tar.gz" forge.1 cast.1
+          tar -czvf "foundry_man_${TAG_NAME}.tar.gz" forge.1.gz cast.1.gz
           echo "::set-output name=foundry_man::foundry_man_${TAG_NAME}.tar.gz"
         shell: bash
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -6,7 +6,6 @@ use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256};
 use super::{ClapChain, EthereumOpts, Wallet};
 
 #[derive(Debug, Subcommand)]
-#[clap(name = "cast")]
 #[clap(about = "Perform Ethereum RPC calls from the comfort of your command line.")]
 pub enum Subcommands {
     #[clap(name = "--max-int")]
@@ -431,6 +430,8 @@ fn parse_slot(s: &str) -> eyre::Result<H256> {
 }
 
 #[derive(Debug, Parser)]
+#[clap(name = "cast")]
+#[clap(version)]
 pub struct Opts {
     #[clap(subcommand)]
     pub sub: Subcommands,

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -9,13 +9,14 @@ use crate::cmd::{
 };
 
 #[derive(Debug, Parser)]
+#[clap(name = "forge")]
+#[clap(version)]
 pub struct Opts {
     #[clap(subcommand)]
     pub sub: Subcommands,
 }
 
 #[derive(Debug, Subcommand)]
-#[clap(name = "forge")]
 #[clap(about = "Build, test, fuzz, formally verify, debug & deploy solidity contracts.")]
 #[allow(clippy::large_enum_variant)]
 pub enum Subcommands {

--- a/foundryup/install
+++ b/foundryup/install
@@ -5,12 +5,14 @@ echo Installing foundryup...
 
 FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
+FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
 FOUNDRYUP='#!/usr/bin/env bash
 set -e
 
 FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.foundry"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
+FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
 while [[ $1 ]]; do
   case $1 in
@@ -63,10 +65,14 @@ if [[ "$FOUNDRYUP_REPO" == "gakonst/foundry" && -z "$FOUNDRYUP_BRANCH" ]]; then
   fi
   
   # Compute the URL of the release tarball in the Foundry repository.
-  TARBALL_URL="https://github.com/${FOUNDRYUP_REPO}/releases/download/${FOUNDRYUP_VERSION}/foundry_${FOUNDRYUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.tar.gz"
+  RELEASE_URL="https://github.com/${FOUNDRYUP_REPO}/releases/download/${FOUNDRYUP_VERSION}/"
+  BIN_TARBALL_URL="${RELEASE_URL}foundry_${FOUNDRYUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.tar.gz"
+  MAN_TARBALL_URL="${RELEASE_URL}foundry_man_${FOUNDRYUP_VERSION}.tar.gz"
 
-  # Download the release tarball and unpack it into the .foundry bin directory.
-  curl -L $TARBALL_URL | tar -xvzC $FOUNDRY_BIN_DIR
+  # Download the binaries tarball and unpack it into the .foundry bin directory.
+  curl -L $BIN_TARBALL_URL | tar -xvzC $FOUNDRY_BIN_DIR
+  # Download the man tarball and unpack it into the .foundry man directory.
+  curl -L $MAN_TARBALL_URL | tar -xvzC $FOUNDRY_MAN_DIR
 else 
   FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH-master}
   
@@ -97,6 +103,22 @@ else
   # Build the repo and install it locally to the .foundry bin directory.
   # --root appends /bin to the directory it is given, so we pass FOUNDRY_DIR.
   cargo install --path ./cli --bins --locked --force --root $FOUNDRY_DIR
+
+  # Try to also manually build and install the man pages
+  if ! command -v help2man &> /dev/null ; then
+    # Warning if help2man is not installed
+    echo "warning: help2man is not installed, so we could not automatically install man entries"
+
+    if [[ "$PLATFORM" == "darwin" ]]; then
+      echo "You may need to install it manually on MacOS via Homebrew (`brew install help2man`)."
+    elif [[ "$PLATFORM" == "linux" ]]; then
+      echo "You may need to install it manually using your package manager."
+    fi
+    exit 0
+  fi
+
+  help2man -N $FOUNDRY_BIN_DIR/forge > $FOUNDRY_MAN_DIR/forge.1
+  help2man -N $FOUNDRY_BIN_DIR/cast > $FOUNDRY_MAN_DIR/cast.1
 fi'
 
 BINARY="$FOUNDRY_BIN_DIR/foundryup"
@@ -105,6 +127,9 @@ BINARY="$FOUNDRY_BIN_DIR/foundryup"
 mkdir -p $FOUNDRY_BIN_DIR
 echo "$FOUNDRYUP" > $BINARY
 chmod +x $BINARY
+
+# Create the man directory for future man files if it doesn't exist.
+mkdir -p $FOUNDRY_MAN_DIR
 
 # Store the correct profile file (i.e. .profile for bash or .zshrc for ZSH).
 case $SHELL in


### PR DESCRIPTION
I wanted to be able to do `man forge` and `man cast` and now we can. :)

This uses `help2man` a handy tool which creates man pages from the `-h` flag output. In the future, we could make the man pages more comprehensive but I think this is a good start.

Cleaned up some of the attribute placement from clap so that the name in the `-h` flag output is correct (it used to say `foundry-cli` for both `forge` and `cast`) and so that it also now has a `-V, --version` flag (which `help2man` needs). It uses clap's default and reads it from the `Cargo.toml` file.

Extended the GitHub actions to build and publish the man pages, and `foundryup` to either download them or build them if you go the building path.

Edit: you can see the updated release GitHub action tested and working here: https://github.com/devanonon/foundry/runs/4884690473?check_suite_focus=true