### PR TITLE
fix(forge): Better gas reporting

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -188,6 +188,15 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> SputnikExecutor<CheatcodeStackState<'
         U256::from(self.state().metadata().gasometer().gas())
     }
 
+    fn gas_used(&self) -> U256 {
+        // NB: We do this to avoid `function cannot return without recursing`
+        U256::from(self.state().metadata().gasometer().total_used_gas())
+    }
+
+    fn gas_refund(&self) -> U256 {
+        U256::from(self.state().metadata().gasometer().refunded_gas())
+    }
+
     fn all_logs(&self) -> Vec<String> {
         self.handler.state().all_logs.clone()
     }

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -69,6 +69,8 @@ pub trait SputnikExecutor<S> {
     fn debug_calls(&self) -> Vec<DebugArena>;
     fn all_logs(&self) -> Vec<String>;
     fn gas_left(&self) -> U256;
+    fn gas_used(&self) -> U256;
+    fn gas_refund(&self) -> U256;
     fn transact_call(
         &mut self,
         caller: H160,
@@ -149,6 +151,14 @@ impl<'a, 'b, S: StackState<'a>, P: PrecompileSet> SputnikExecutor<S>
     fn gas_left(&self) -> U256 {
         // NB: We do this to avoid `function cannot return without recursing`
         U256::from(self.state().metadata().gasometer().gas())
+    }
+
+    fn gas_used(&self) -> U256 {
+        U256::from(self.state().metadata().gasometer().total_used_gas())
+    }
+
+    fn gas_refund(&self) -> U256 {
+        U256::from(self.state().metadata().gasometer().refunded_gas())
     }
 
     fn transact_call(

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -62,7 +62,7 @@ pub fn remove_extra_costs(gas: U256, calldata: &[u8]) -> U256 {
             calldata_cost += 8;
         }
     }
-    gas - calldata_cost - BASE_TX_COST
+    gas.saturating_sub(calldata_cost.into()).saturating_sub(BASE_TX_COST.into())
 }
 
 /// Flattens a group of contracts into maps of all events and functions


### PR DESCRIPTION
This makes the reported gas in `TestResult` actually match closer to the execution costs and matches the `trace` gas usages. Basically we use `gas_used - gas_refund - tx_costs`, where `tx_costs` is calldata cost + base tx cost (21k).