### PR TITLE
fix(evm-adapters): index out of bounds panic if expected length > input length

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1508,9 +1508,9 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
 
             // handle expected calls
             if let Some(expecteds) = self.state_mut().expected_calls.get_mut(&code_address) {
-                if let Some(found_match) =
-                    expecteds.iter().position(|expected| expected == &input[..expected.len()])
-                {
+                if let Some(found_match) = expecteds.iter().position(|expected| {
+                    expected.len() <= input.len() && expected == &input[..expected.len()]
+                }) {
                     expecteds.remove(found_match);
                 }
             }

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -561,6 +561,15 @@ contract CheatCodes is DSTest {
         );
     }
 
+    function testFailExpectCallWithMoreParameters() public {
+        MockMe target = new MockMe();
+        hevm.expectCall(
+            address(target),
+            abi.encodeWithSelector(target.add.selector, 3, 3, 3)
+        );
+        target.add(3, 3);
+    }
+
     function testGetCode() public {
         bytes memory contractCode = hevm.getCode("./testdata/Contract.json");
         assertEq(


### PR DESCRIPTION
Right now, if you provide `calldata`-  via `expectCall` cheatcode - with more parameters than actual call input, it causes a panic. 

This should be handled gracefully. If no match was found it fails the test anyway.