### PR TITLE
feat(cast): implement `cast receipt`

### DIFF
--- a/cast/README.md
+++ b/cast/README.md
@@ -50,7 +50,7 @@
 - [x] `namehash`
 - [x] `nonce`
 - [x] `publish`
-- [ ] `receipt`
+- [x] `receipt`
 - [x] `resolve-name`
 - [ ] `run-tx`
 - [x] `send` (partial)

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -399,6 +399,10 @@ async fn main() -> eyre::Result<()> {
             let value = provider.get_storage_at(address, slot, block).await?;
             println!("{:?}", value);
         }
+        Subcommands::Receipt { hash, field, to_json, rpc_url } => {
+            let provider = Provider::try_from(rpc_url)?;
+            println!("{}", Cast::new(provider).receipt(hash, field, to_json).await?);
+        }
         Subcommands::Nonce { block, who, rpc_url } => {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).nonce(who, block).await?);

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -399,9 +399,14 @@ async fn main() -> eyre::Result<()> {
             let value = provider.get_storage_at(address, slot, block).await?;
             println!("{:?}", value);
         }
-        Subcommands::Receipt { hash, field, to_json, rpc_url } => {
+        Subcommands::Receipt { hash, field, to_json, rpc_url, cast_async, confirmations } => {
             let provider = Provider::try_from(rpc_url)?;
-            println!("{}", Cast::new(provider).receipt(hash, field, to_json).await?);
+            println!(
+                "{}",
+                Cast::new(provider)
+                    .receipt(hash, field, confirmations, cast_async, to_json)
+                    .await?
+            );
         }
         Subcommands::Nonce { block, who, rpc_url } => {
             let provider = Provider::try_from(rpc_url)?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -138,6 +138,16 @@ pub enum Subcommands {
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
+    #[clap(name = "receipt")]
+    #[clap(about = "Print information about the transaction receipt for <tx-hash>")]
+    Receipt {
+        hash: String,
+        field: Option<String>,
+        #[clap(long = "json", short = 'j')]
+        to_json: bool,
+        #[clap(long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+    },
     #[clap(name = "send")]
     #[clap(about = "Publish a transaction signed by <from> to call <to> with <data>")]
     SendTx {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -55,8 +55,8 @@ pub enum Subcommands {
     ToUint256 { value: Option<String> },
     #[clap(name = "--to-unit")]
     #[clap(
-        about = r#"convert an ETH amount into a specified unit: ether, gwei or wei (default: wei). 
-    Usage: 
+        about = r#"convert an ETH amount into a specified unit: ether, gwei or wei (default: wei).
+    Usage:
       - 1ether wei     | converts 1 ether to wei
       - "1 ether" wei  | converts 1 ether to wei
       - 1ether         | converts 1 ether to wei
@@ -143,6 +143,15 @@ pub enum Subcommands {
     Receipt {
         hash: String,
         field: Option<String>,
+        #[clap(
+            short,
+            long,
+            help = "the number of confirmations until the receipt is fetched",
+            default_value = "1"
+        )]
+        confirmations: usize,
+        #[clap(long, env = "CAST_ASYNC")]
+        cast_async: bool,
         #[clap(long = "json", short = 'j')]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL")]


### PR DESCRIPTION
This commit implements `cast receipt`. If the receipt is not
found, it will poll until it is found. Similar to `seth`,
an optional field can be passed to only print a particular
field on the receipt response. Unlike `seth`, there is a
`--json/-j` flag that will render the receipt as JSON.

Example usage:

```bash
cast receipt --rpc-url https://mainnet.optimism.io \
    0xa9fc1761ecad57693d7000b7bd8aea8ae5c3c34a1fcf966097778068c82c86cc
```