### PR TITLE
fix: add rpc url alias

### DIFF
--- a/cli/src/cmd/config.rs
+++ b/cli/src/cmd/config.rs
@@ -1,8 +1,13 @@
 //! config command
 
-use crate::cmd::{build::BuildArgs, Cmd};
+use crate::{
+    cmd::{build::BuildArgs, Cmd},
+    opts::evm::EvmArgs,
+};
 use clap::Parser;
-use foundry_config::{figment::Figment, Config};
+use foundry_config::Config;
+
+foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_opts);
 
 /// Command to list currently set config values
 #[derive(Debug, Clone, Parser)]
@@ -14,14 +19,15 @@ pub struct ConfigArgs {
     // support nested build arguments
     #[clap(flatten)]
     opts: BuildArgs,
+    #[clap(flatten)]
+    evm_opts: EvmArgs,
 }
 
 impl Cmd for ConfigArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let figment: Figment = From::from(&self.opts);
-        let config = Config::from_provider(figment);
+        let config: Config = From::from(&self);
 
         let s = if self.basic {
             let config = config.into_basic();

--- a/cli/src/cmd/config.rs
+++ b/cli/src/cmd/config.rs
@@ -5,7 +5,7 @@ use crate::{
     opts::evm::EvmArgs,
 };
 use clap::Parser;
-use foundry_config::Config;
+use foundry_config::{figment::Figment, Config};
 
 foundry_config::impl_figment_convert!(ConfigArgs, opts, evm_opts);
 
@@ -27,8 +27,8 @@ impl Cmd for ConfigArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<Self::Output> {
-        let config: Config = From::from(&self);
-
+        let figment: Figment = From::from(&self);
+        let config = Config::from_provider(figment);
         let s = if self.basic {
             let config = config.into_basic();
             if self.json {

--- a/cli/src/opts/evm.rs
+++ b/cli/src/opts/evm.rs
@@ -66,6 +66,7 @@ pub struct EvmArgs {
     pub sender: Option<Address>,
 
     #[clap(help = "enables the FFI cheatcode", long)]
+    #[serde(skip)]
     pub ffi: bool,
 
     #[clap(
@@ -99,6 +100,10 @@ impl Provider for EvmArgs {
         if self.verbosity > 0 {
             // need to merge that manually otherwise `from_occurrences` does not work
             dict.insert("verbosity".to_string(), self.verbosity.into());
+        }
+
+        if self.ffi {
+            dict.insert("ffi".to_string(), self.ffi.into());
         }
 
         Ok(Map::from([(Config::selected_profile(), dict)]))

--- a/cli/src/opts/evm.rs
+++ b/cli/src/opts/evm.rs
@@ -66,7 +66,6 @@ pub struct EvmArgs {
     pub sender: Option<Address>,
 
     #[clap(help = "enables the FFI cheatcode", long)]
-    #[serde(skip)]
     pub ffi: bool,
 
     #[clap(

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -171,9 +171,7 @@ impl TestProject {
         A: AsRef<OsStr>,
     {
         let mut cmd = self.bin();
-        cmd.arg("config");
-        cmd.args(args);
-        cmd.arg("--json");
+        cmd.arg("config").arg("--root").arg(self.root()).args(args).arg("--json");
         let output = cmd.output().unwrap();
         let c = String::from_utf8_lossy(&output.stdout);
         let config: Config = serde_json::from_str(c.as_ref()).unwrap();

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -1,4 +1,5 @@
 //! Contains various tests for checking forge's commands
+use evm_adapters::evm_opts::{EvmOpts, EvmType};
 use foundry_cli_test_utils::{
     ethers_solc::{remappings::Remapping, PathStyle},
     forgetest, forgetest_ignore, forgetest_init, pretty_eq,
@@ -141,6 +142,21 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     cmd.set_cmd(prj.bin()).args(["config", "--basic"]);
     let expected = profile.into_basic().to_string_pretty().unwrap();
     pretty_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
+});
+
+// checks that `clean` removes dapptools style paths
+forgetest_init!(can_get_evm_opts, |prj: TestProject, mut cmd: TestCommand| {
+    let url = "http://127.0.0.1:8545";
+    let config = prj.config_from_output(["--rpc-url", url]);
+    assert_eq!(config.eth_rpc_url, Some(url.to_string()));
+
+    cmd.set_current_dir(prj.root());
+    cmd.set_env("FOUNDRY_ETH_RPC_URL", url);
+    let figment = Config::figment_with_root(prj.root())
+        .merge(("evm_type", EvmType::Sputnik))
+        .merge(("debug", false));
+    let evm_opts: EvmOpts = figment.extract().unwrap();
+    assert_eq!(evm_opts.fork_url, Some(url.to_string()));
 });
 
 // checks that `clean` removes dapptools style paths

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -147,8 +147,9 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
 // checks that `clean` removes dapptools style paths
 forgetest_init!(can_get_evm_opts, |prj: TestProject, mut cmd: TestCommand| {
     let url = "http://127.0.0.1:8545";
-    let config = prj.config_from_output(["--rpc-url", url]);
+    let config = prj.config_from_output(["--rpc-url", url, "--ffi"]);
     assert_eq!(config.eth_rpc_url, Some(url.to_string()));
+    assert!(config.ffi);
 
     cmd.set_current_dir(prj.root());
     cmd.set_env("FOUNDRY_ETH_RPC_URL", url);

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -112,7 +112,7 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
 
     cmd.arg("config");
     let expected = profile.to_string_pretty().unwrap();
-    pretty_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
+    assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
     // remappings work
     let remappings_txt = prj.create_file("remappings.txt", "from-file/=lib/from-file/");
@@ -146,12 +146,12 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
 
 // checks that `clean` removes dapptools style paths
 forgetest_init!(can_get_evm_opts, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.set_current_dir(prj.root());
     let url = "http://127.0.0.1:8545";
     let config = prj.config_from_output(["--rpc-url", url, "--ffi"]);
     assert_eq!(config.eth_rpc_url, Some(url.to_string()));
     assert!(config.ffi);
 
-    cmd.set_current_dir(prj.root());
     cmd.set_env("FOUNDRY_ETH_RPC_URL", url);
     let figment = Config::figment_with_root(prj.root())
         .merge(("evm_type", EvmType::Sputnik))

--- a/evm-adapters/src/evm_opts.rs
+++ b/evm-adapters/src/evm_opts.rs
@@ -56,6 +56,7 @@ pub struct EvmOpts {
     pub evm_type: EvmType,
 
     /// fetch state over a remote instead of starting from empty state
+    #[serde(rename = "eth_rpc_url")]
     pub fork_url: Option<String>,
 
     /// pins the block number for the state fork


### PR DESCRIPTION
add missing rpc url alias for `EmvArgs` -> `EmvOpts` conversion