### PR TITLE
chore(cli): update clap, clap-complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
 dependencies = [
  "atty",
  "bitflags",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fff450c061c4de8162fd6fa0a7a73f70f10c211869a34897724823ed9ec0046"
+checksum = "d044e9db8cd0f68191becdeb5246b7462e4cf0c069b19ae00d1bf3fa9889498d"
 dependencies = [
  "clap",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,16 +7,20 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-vergen = { version = "6.0.0", default-features = false, features = ["build", "rustc", "git"] }
+vergen = { version = "6.0.0", default-features = false, features = [
+    "build",
+    "rustc",
+    "git",
+] }
 
 [dependencies]
-clap = { version = "3.0.7", features = [
+clap = { version = "3.0.10", features = [
     "derive",
     "env",
     "unicode",
     "wrap_help",
 ] }
-clap_complete = "3.0.3"
+clap_complete = "3.0.4"
 foundry-utils = { path = "../utils" }
 forge = { path = "../forge" }
 foundry-config = { path = "../config" }


### PR DESCRIPTION
fixes zsh completion bug https://github.com/clap-rs/clap/pull/3295 that first appeared in https://github.com/gakonst/foundry/pull/469