### PR TITLE
Fix macOS release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,13 @@ jobs:
           TARGET: ${{ matrix.job.target }}
           ARCH: ${{ matrix.job.arch }}
         run: |
-          if [ "$PLATFORM_NAME" != "win32" ]; then
+          if [ "$PLATFORM_NAME" == "linux" ]; then
             tar -czvf "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
+            echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
+          elif [ "$PLATFORM_NAME" == "darwin" ]; then
+            # We need to use gtar here otherwise the archive is corrupt.
+            # See: https://github.com/actions/virtual-environments/issues/2619
+            gtar -czvf "foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./target/${TARGET}/release forge cast
             echo "::set-output name=file_name::foundry_${TAG_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           else
             cd ./target/${TARGET}/release


### PR DESCRIPTION
Turns out that we were building the binaries correctly but for whatever reason `tar` (defaults to BSD tar) on macOS sometimes corrupts the binaries for LLVM projects (incl. Rust) in GitHub actions. The solution is to use GNU tar.

More info: https://github.com/actions/virtual-environments/issues/2619

Closes #531 