### PR TITLE
Merge remappings

### DIFF
--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -6,19 +6,43 @@ use std::path::PathBuf;
 use crate::{cmd::Cmd, opts::forge::CompilerArgs};
 
 use clap::{Parser, ValueHint};
+use ethers::solc::remappings::Remapping;
 use foundry_config::{
     figment::{
         self,
         error::Kind::InvalidType,
         value::{Dict, Map, Value},
-        Metadata, Profile, Provider,
+        Figment, Metadata, Profile, Provider,
     },
-    remappings_from_env_var, Config,
+    find_project_root_path, remappings_from_env_var, Config,
 };
 use serde::Serialize;
 
 // Loads project's figment and merges the build cli arguments into it
-foundry_config::impl_figment_convert!(BuildArgs);
+impl<'a> From<&'a BuildArgs> for Figment {
+    fn from(args: &'a BuildArgs) -> Self {
+        let figment = if let Some(root) = args.root.clone() {
+            Config::figment_with_root(root)
+        } else {
+            Config::figment_with_root(find_project_root_path().unwrap())
+        };
+
+        // remappings should stack
+        let mut remappings = args.get_remappings();
+        remappings
+            .extend(figment.extract_inner::<Vec<Remapping>>("remappings").unwrap_or_default());
+        remappings.sort_by(|a, b| a.name.cmp(&b.name));
+        remappings.dedup_by(|a, b| a.name.eq(&b.name));
+        figment.merge(("remappings", remappings)).merge(args)
+    }
+}
+
+impl<'a> From<&'a BuildArgs> for Config {
+    fn from(args: &'a BuildArgs) -> Self {
+        let figment: Figment = args.into();
+        Config::from_provider(figment).sanitized()
+    }
+}
 
 /// All `forge build` related arguments
 ///
@@ -61,7 +85,7 @@ pub struct BuildArgs {
     pub contracts: Option<PathBuf>,
 
     #[clap(help = "the remappings", long, short)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip)]
     pub remappings: Vec<ethers::solc::remappings::Remapping>,
 
     #[clap(help = "the env var that holds remappings", long = "remappings-env")]
@@ -142,6 +166,17 @@ impl BuildArgs {
         }
         Ok(project)
     }
+
+    /// Returns the remappings to add to the config
+    pub fn get_remappings(&self) -> Vec<Remapping> {
+        let mut remappings = self.remappings.clone();
+        if let Some(env_remappings) =
+            self.remappings_env.as_ref().and_then(|env| remappings_from_env_var(env))
+        {
+            remappings.extend(env_remappings.expect("Failed to parse env var remappings"));
+        }
+        remappings
+    }
 }
 
 // Make this args a `figment::Provider` so that it can be merged into the `Config`
@@ -176,16 +211,6 @@ impl Provider for BuildArgs {
 
         if self.compiler.optimize {
             dict.insert("optimize".to_string(), self.compiler.optimize.into());
-        }
-
-        if let Some(env_remappings) =
-            self.remappings_env.as_ref().and_then(|env| remappings_from_env_var(env))
-        {
-            let remappings = env_remappings.map_err(|err| err.to_string())?;
-            dict.insert(
-                "remappings".to_string(),
-                remappings.iter().map(|r| r.to_string()).collect::<Vec<_>>().into(),
-            );
         }
 
         Ok(Map::from([(Config::selected_profile(), dict)]))

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -115,24 +115,25 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 
     // remappings work
-    let remappings_txt = prj.create_file("remappings.txt", "from-file/=lib/from-file/");
+    let remappings_txt = prj.create_file("remappings.txt", "ds-test/=lib/ds-test/from-file/");
     let config = forge_utils::load_config();
+    println!("{:?}", config.remappings);
     assert_eq!(
-        format!("from-file/={}/", prj.root().join("lib/from-file").display()),
+        format!("ds-test/={}/", prj.root().join("lib/ds-test/from-file").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
     // env vars work
-    cmd.set_env("DAPP_REMAPPINGS", "other/=lib/other/src/");
+    cmd.set_env("DAPP_REMAPPINGS", "ds-test/=lib/ds-test/from-env/");
     let config = forge_utils::load_config();
     assert_eq!(
-        format!("other/={}/", prj.root().join("lib/other/src").display()),
+        format!("ds-test/={}/", prj.root().join("lib/ds-test/from-env").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
-    let config = prj.config_from_output(["--remappings", "from-cli/=lib-from-cli"]);
+    let config = prj.config_from_output(["--remappings", "ds-test/=lib/ds-test/from-cli"]);
     assert_eq!(
-        format!("from-cli/={}/", prj.root().join("lib-from-cli").display()),
+        format!("ds-test/={}/", prj.root().join("lib/ds-test/from-cli").display()),
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -137,6 +137,13 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
         Remapping::from(config.remappings[0].clone()).to_string()
     );
 
+    let config = prj.config_from_output(["--remappings", "other-key/=lib/other/"]);
+    assert_eq!(config.remappings.len(), 2);
+    assert_eq!(
+        format!("other-key/={}/", prj.root().join("lib/other").display()),
+        Remapping::from(config.remappings[1].clone()).to_string()
+    );
+
     cmd.unset_env("DAPP_REMAPPINGS");
     pretty_err(&remappings_txt, fs::remove_file(&remappings_txt));
 


### PR DESCRIPTION
If you create a `remappings.txt` file after the config then auto-generated remappings are not included, so you can't remap just one dependency. In other words the remappings behave like an "or" (if env is set use that, otherwise use remappings file, otherwise use CLI parameters, otherwise use auto-generated remappings)

This PR re-implements the behavior in https://github.com/gakonst/foundry/pull/519