### PR TITLE
Allow build failure too on some integration tests

### DIFF
--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -29,10 +29,15 @@ function runTests() {
 
     # update the deps
     $FORGE update
-    # always have the ffi flag turned on
-    $FORGE test --ffi $FORK_ARGS
 
-    cd -
+    # always have the ffi flag turned on
+    $FORGE test --ffi $FORK_ARGS || {
+        if [[ "${FORGE_ALLOW_FAILURE}" == 1 ]]; then
+            exit 0
+        else
+            exit 1
+        fi
+    }
 }
 
 runTests $REPO


### PR DESCRIPTION
Currently `geb` is failing to build due to some Solidity version detection bug (?). This PR allows builds to fail too on select integration tests we allow test failure on.

Thoughts?