### PR TITLE
fix: flip autodetect flag

### DIFF
--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -163,7 +163,7 @@ impl Provider for BuildArgs {
         }
 
         if self.no_auto_detect {
-            dict.insert("auto_detect_solc".to_string(), self.no_auto_detect.into());
+            dict.insert("auto_detect_solc".to_string(), false.into());
         }
 
         if self.force {

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -181,6 +181,21 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     pretty_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 });
 
+forgetest_init!(can_detect_config_vals, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.set_current_dir(prj.root());
+
+    let config = prj.config_from_output(["--no-auto-detect"]);
+    assert!(!config.auto_detect_solc);
+
+    let mut config = Config::load_with_root(prj.root());
+
+    config.auto_detect_solc = false;
+    // write to `foundry.toml`
+    prj.create_file(Config::FILE_NAME, &config.to_string_pretty().unwrap());
+    let config = prj.config_from_output(["--force"]);
+    assert!(!config.auto_detect_solc);
+});
+
 // checks that `clean` removes dapptools style paths
 forgetest_init!(can_get_evm_opts, |prj: TestProject, mut cmd: TestCommand| {
     cmd.set_current_dir(prj.root());


### PR DESCRIPTION
the CLI arg is `--no-auto-detect` but the Config var is `auto_detect_solc` which is `! no_auto_detect`

so we need to insert `false` in the figment if `--no-auto-detect` is present

Ref https://github.com/gakonst/foundry/issues/525#issuecomment-1019424812