### PR TITLE
fix: trim whitespace from ffi output before decoding it

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -636,7 +636,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
 
                 // get the hex string & decode it
                 let output = unsafe { std::str::from_utf8_unchecked(&output) };
-                let decoded = match hex::decode(&output[2..]) {
+                let decoded = match hex::decode(&output.trim()[2..]) {
                     Ok(res) => res,
                     Err(err) => return evm_error(&err.to_string()),
                 };


### PR DESCRIPTION
Makes `ffi` decoding a bit more robust, as you no longer have to trim new lines and whitespace in the script you're calling out to