### PR TITLE
Checkout sources in prepare step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
       changelog: ${{ steps.build_changelog.outputs.changelog }}
 
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
       - name: Move nightly tag
         if: ${{ env.IS_NIGHTLY }}
         uses: actions/github-script@v5


### PR DESCRIPTION
First few steps that prepare the release are not working since we haven't checked out the sources, so the GH scripts action can't find our script