### PR TITLE
Fix changelog builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Move nightly tag
         if: ${{ env.IS_NIGHTLY }}


### PR DESCRIPTION
Building the changelog failed without `fetch-depth: 0` which is strange because it didn't on my fork. Perhaps because we only have 1 tag?