### PR TITLE
Nightly backwards compatability

### DIFF
--- a/.github/scripts/create-tag.js
+++ b/.github/scripts/create-tag.js
@@ -1,0 +1,14 @@
+module.exports = async ({github, context}, tagName) => {
+  try {
+    await github.rest.git.createRef({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: `refs/tags/${tagName}`,
+      sha: context.sha,
+      force: true
+    })
+  } catch (err) {
+    console.error(`Failed to create tag: ${tagName}`)
+    console.error(err)
+  }
+}

--- a/.github/scripts/prune-prereleases.js
+++ b/.github/scripts/prune-prereleases.js
@@ -5,8 +5,10 @@ module.exports = async ({github, context}) => {
     owner: context.repo.owner,
     repo: context.repo.repo
   })
+
+  // Only consider releases tagged `nightly-${SHA}` for deletion
   let nightlies = releases.filter(
-    (release) => release.tag_name.includes('nightly')
+    (release) => release.tag_name.includes('nightly') && release.tag_name !== 'nightly'
   )
 
   // Keep newest 3 nightlies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Move nightly tag
-        if: ${{ env.IS_NIGHTLY }}
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const moveTag = require('./.github/scripts/move-tag.js')
-            await moveTag({ github, context }, 'nightly')
-
       - name: Compute release name and tag
         id: release_info
         run: |
@@ -46,11 +38,37 @@ jobs:
             echo "::set-output name=release_name::${GITHUB_REF_NAME}"
           fi
 
+      # Creates a `nightly-SHA` tag for this specific nightly
+      # This tag is used for this specific nightly version's release
+      # which allows users to roll back. It is also used to build
+      # the changelog.
+      - name: Create build-specific nightly tag
+        if: ${{ env.IS_NIGHTLY }}
+        uses: actions/github-script@v5
+        env:
+          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
+        with:
+          script: |
+            const createTag = require('./.github/scripts/create-tag.js')
+            await createTag({ github, context }, process.env.TAG_NAME)
+
       - name: Build changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2
+        with:
+          fromTag: ${{ env.IS_NIGHTLY && 'nightly' || '' }}
+          toTag: ${{ steps.release_info.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Moves the `nightly` tag to `HEAD`
+      - name: Move nightly tag
+        if: ${{ env.IS_NIGHTLY }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const moveTag = require('./.github/scripts/move-tag.js')
+            await moveTag({ github, context }, 'nightly')
 
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
@@ -151,6 +169,7 @@ jobs:
           echo "::set-output name=foundry_man::foundry_man_${VERSION_NAME}.tar.gz"
         shell: bash
 
+      # Creates the release for this specific version
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
@@ -161,6 +180,21 @@ jobs:
           files: |
             ${{ steps.artifacts.outputs.file_name }}
             ${{ steps.man.outputs.foundry_man }}
+
+      # If this is a nightly release, it also updates the release
+      # tagged `nightly` for compatability with `foundryup`
+      - name: Update nightly release
+        if: ${{ env.IS_NIGHTLY }}
+        uses: softprops/action-gh-release@v1
+        with:
+          name: 'Nightly'
+          tag_name: 'nightly'
+          prerelease: true
+          body: ${{ needs.prepare.outputs.changelog }}
+          files: |
+            ${{ steps.artifacts.outputs.file_name }}
+            ${{ steps.man.outputs.foundry_man }}
+
   cleanup:
     name: Release cleanup
     runs-on: ubuntu-latest
@@ -169,6 +203,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Delete old nightlies
         uses: actions/github-script@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,15 +61,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Moves the `nightly` tag to `HEAD`
-      - name: Move nightly tag
-        if: ${{ env.IS_NIGHTLY }}
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const moveTag = require('./.github/scripts/move-tag.js')
-            await moveTag({ github, context }, 'nightly')
-
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
@@ -203,6 +194,15 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
+      # Moves the `nightly` tag to `HEAD`
+      - name: Move nightly tag
+        if: ${{ env.IS_NIGHTLY }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const moveTag = require('./.github/scripts/move-tag.js')
+            await moveTag({ github, context }, 'nightly')
 
       - name: Delete old nightlies
         uses: actions/github-script@v5


### PR DESCRIPTION
Always maintains an up-to-date release tagged `nightly` so that we don't break existing `foundryup` installations, in addition to 3 nightly releases tagged `nightly-${SHA}` which allows you to roll-back to a previous nightly build if you want to.

@_@

Successful run: https://github.com/onbjerg/foundry/actions/runs/1743111245