### PR TITLE
Fix incorrect remapping lib -> libs

### DIFF
--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -56,7 +56,7 @@ forgetest!(can_init_repo_with_config, |prj: TestProject, mut cmd: TestCommand| {
     // check ds-test is detected
     assert_eq!(
         basic.remappings,
-        vec![Remapping::from_str("ds-test/=lib/ds-test/src/").unwrap().into()]
+        vec![Remapping::from_str("ds-test/=libs/ds-test/src/").unwrap().into()]
     );
     assert_eq!(basic, Config::load_with_root(prj.root()).into_basic());
 


### PR DESCRIPTION
just installed the nightly, running `forge init` then `forge test` gives me the following error:

```
compiling...
Error:
   0: "/Users/terence/new_forge_example/lib/ds-test/src/test.sol": No such file or directory (os error 2)
```

taking a look at my repository from `forge init` shows that the folder name is `libs` not `lib`