### PR TITLE
Community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: File a bug report
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the bug has not already been filed in the issue tracker.
+
+        Thanks for taking the time to report this bug!
+  - type: dropdown
+    attributes:
+      label: Component
+      description: What component is the bug in?
+      multiple: true
+      options:
+        - Forge
+        - Cast
+        - Foundryup
+        - Other (please describe)
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Have you ensured that all of these are up to date?
+      options:
+        - label: Foundry
+        - label: Foundryup
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Operating System
+      description: What operating system are you on?
+      options:
+        - Windows
+        - macOS (amd)
+        - macOS (M1)
+        - Linux
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Please include what you expected to happen as well, if relevant.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -30,6 +30,10 @@ body:
       required: true
   - type: input
     attributes:
+      label: What version of Foundry are you on?
+      placeholder: "Run forge --version and paste the output here"
+  - type: input
+    attributes:
       label: What command(s) is the bug in?
       description: Leave empty if not relevant
       placeholder: "For example: forge test"

--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -28,6 +28,11 @@ body:
         - label: Foundryup
     validations:
       required: true
+  - type: input
+    attributes:
+      label: What command(s) is the bug in?
+      description: Leave empty if not relevant
+      placeholder: "For example: forge test"
   - type: dropdown
     attributes:
       label: Operating System

--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -45,6 +45,6 @@ body:
   - type: textarea
     attributes:
       label: Describe the bug
-      description: Please include what you expected to happen as well, if relevant.
+      description: Please include relevant Solidity snippets as well if relevant.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: File a bug report
+labels: ["T-bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a feature
+labels: ["T-feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the feature has not already been requested in the issue tracker.
+
+        Thanks for helping us improve Foundry!
+  - type: dropdown
+    attributes:
+      label: Component
+      description: What component is the feature for?
+      multiple: true
+      options:
+        - Forge
+        - Cast
+        - Foundryup
+        - Other (please describe)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the feature you would like
+      description: Please also describe what the feature is aiming to solve, if relevant.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: true
+contact_links:
+  - name: Support
+    url: https://t.me/foundry_support
+    about: This issue tracker is only for bugs and feature requests. Support is available on Telegram!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Thank you for your Pull Request. Please provide a description above and review
+the requirements below.
+
+Bug fixes and new features should include tests.
+-->
+
+## Motivation
+
+<!--
+Explain the context and why you're making that change. What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of as being the motivation for your change.
+-->
+
+## Solution
+
+<!--
+Summarize the solution and provide any necessary context needed to understand
+the code change.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,181 @@
+## Contributing to Foundry
+
+Thanks for your interest in improving Foundry!
+
+There are multiple opportunities to contribute at any level. If doesn't matter if you are just getting started with Rust or are the most weathered expert, we can use your help.
+
+**No contribution is too small and all contributions are valued.**
+
+This document will help you get started. **Do not let the document intimidate you**.
+It should be considered as a guide to help you navigate the process.
+
+The [dev Telegram][dev-tg] is available for any concerns you may have that are not covered in this guide.
+
+### Code of Conduct
+
+The Foundry project adheres to the [Rust Code of Conduct][rust-coc]. This code of conduct describes the _minimum_ behavior expected from all contributors.
+
+Instances of violations of the Code of Conduct can be reported by conacting the team at [me@gakonst.com](mailto:me@gakonst.com).
+
+### Ways to contribute
+
+There are fundamentally four ways an individual can contribute:
+
+1. **By opening an issue:** For example, if you believe that you have uncovered a bug
+   in Foundry, creating a new issue in the issue tracker is the way to report it.
+2. **By adding context:** Providing additional context to existing issues,
+   such as screenshots, code snippets and helps resolve issues.
+3. **By resolving issues:** Typically this is done in the form of either
+   demonstrating that the issue reported is not a problem after all, or more often,
+   by opening a pull request that fixes the underlying problem, in a concrete and
+   reviewable manner.
+
+**Anybody can participate in any stage of contribution**. We urge you to participate in the discussion
+around bugs and participate in reviewing PRs.
+
+### Asking for help
+
+If you have reviewed existing documentation and still have questions, or you are having problems, you can get help in the following ways:
+
+- **Asking in the support Telegram:** The [Foundry Support Telegram][support-tg] is a fast and easy way to ask questions.
+- **Opening a discussion:** This repository comes with a discussions board where you can also ask for help. Click the "Discussions" tab in the top.
+
+As Foundry is still in heavy development, the documentation can be a bit scattered.
+The [Foundry Book][foundry-book] is our current best-effort attempt at keeping up-to-date information.
+
+### Submitting a bug report
+
+When filing a new bug report in the issue tracker, you will be presented with a basic form to fill out.
+
+If you believe that you have uncovered a bug, please fill out the form to the best of your ability. Do not worry if you cannot answer every detail,
+just fill in what you can. Contributors will ask follow up questions if something is unclear.
+
+The most important pieces of information we need in a bug report are:
+
+- The Foundry version you are on (and that it is up to date)
+- The platform you are on (Windows, macOS, an M1 Mac or Windows)
+- Code snippets if this is happening in relation to testing or building code
+- Concrete steps to reproduce the bug
+
+In order to rule out the possibility of the bug being in your project, the code snippets should be as minimal
+as possible. It is better if you can reproduce the bug with a small snippet as opposed to an entire project!
+
+See [this guide][mcve] on how to create a minimal, complete, and verifiable example.
+
+### Submitting a feature request
+
+When adding a feature request in the issue tracker, you will be presented with a basic form to fill out.
+
+Please include as detailed of an explanation as possible of the feature you would like, adding additional context if necessary.
+
+If you have examples of other tools that have the feature you are requesting, please include them as well.
+
+### Resolving an issue
+
+Pull requests are the way concrete changes are made to the code, documentation, and dependencies of Foundry.
+
+Even tiny pull requests, like fixing wording, are greatly appreciated. Before making a large change, it is usually
+a good idea to first open an issue describing the change to solicit feedback and guidance. This will increase
+the likelihood of the PR getting merged.
+
+Please also make sure that the following commands pass if you have changed the code:
+
+```sh
+cargo check --all
+cargo test --all --all-features
+cargo +nightly fmt -- --check
+cargo +nightly clippy -all --all-features -- -D warnings
+```
+
+If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other contributors are not duplicating work.
+
+#### Adding tests
+
+If the change being proposed alters code, it is either adding new functionality to Foundry, or fixing existing, broken functionality.
+In both of these cases, the pull request should include one or more tests to ensure that Foundry does not regress
+in the future.
+
+Types of tests include:
+
+- **Unit tests**: Functions which have very specific tasks should be unit tested.
+- **Integration tests**: For general purpose, far reaching functionality, integration tests should be added.
+  The best way to add a new integration test is to look at existing ones and follow the style.
+
+#### Commits
+
+It is a recommended best practice to keep your changes as logically grouped as possible within individual commits. There is no limit to the number of commits any single pull request may have, and many contributors find it easier to review changes that are split across multiple commits.
+
+That said, if you have a number of commits that are "checkpoints" and don't represent a single logical change, please squash those together.
+
+#### Opening the pull request
+
+From within GitHub, opening a new pull request will present you with a template that should be filled out. Please try your best at filling out the details, but feel free to skip parts if you're not sure what to put.
+
+#### Discuss and update
+
+You will probably get feedback or requests for changes to your pull request.
+This is a big part of the submission process, so don't be discouraged! Some contributors may sign off on the pull request right away, others may have more detailed comments or feedback.
+This is a necessary part of the process in order to evaluate whether the changes are correct and necessary.
+
+**Any community member can review a PR, so you might get conflicting feedback**.
+Keep an eye out for comments from code owners to provide guidance on conflicting feedback.
+
+#### Reviewing pull requests
+
+**Any Foundry community member is welcome to review any pull request**.
+
+All contributors wo choose to review and provide feedback on pull requests have a responsibility to both the project and individual making the contribution. Reviews and feedback must be helpful, insightful, and geared towards improving the contribution as opposed to simply blocking it. If there are reasons why you feel the PR should not be merged, explain what those are. Do not exepct to be able to block a PR from advancing simply because you say "no" without giving an explanation. Be open to having your mind changed. Be open to working *with* the contributor to make the pull request better.
+
+Reviews that are dismissive or disrespectful of the contributor or any other reviewers are strictly counter to the Code of Conduct.
+
+When reviewing a pull request, the primary goals are for the codebase to improve and for the person submitting the request to succeed. **Even if a pull request is not merged, the submitter should come away from the experience feeling like their effort was not unappreciated**. Every PR from a new contributor is an opportunity to grow the community.
+
+##### Review a bit at a time
+
+Do not overwhelm new contributors.
+
+It is tempting to micro-optimize and make everythign about relative performance, perfect grammar, or exact style matches. Do not succumb to that temptation..
+
+Focus first on the most significant aspects of the change:
+
+1. Does this change make sense for Foundry?
+2. Does this change make Foundry better, even if only incrementally?
+3. Are there clear bugs or larger scale issues that need attending?
+4. Are the commit messages readable and correct? If it contains a breaking change, is it clear enough?
+
+Note that only **incremental** improvement is needed to land a PR. This means that the PR does not need to be perfect, only better than the status quo. Follow-up PRs may be opened to continue iterating.
+
+When changes are necessary, *request* them, do not *demand* them, and **do not assume that the submitter already knows how to add a test or run a benchmark**.
+
+Specific performance optimization techniques, coding styles and conventions change over time. The first impression you give to a new contributor never does.
+
+Nits (requests for small changes that are not essential) are fine, but try to avoid stalling the pull request. Most nits can typically be fixed by the Foundry maintainers merging the pull request, but they can also be an opportunity for the contributor to learn a bit more about the project.
+
+It is always good to clearly indicate nits when you comment, e.g.: `Nit: change foo() to bar(). But this is not blocking`.
+
+If your comments were addressed but were not folded after new commits, or if they proved to be mistaken, please, [hide them][hiding-a-comment] with the appropriate reason to keep the converstaion flow concise and relevant.
+
+##### Be aware of the person behind the code
+
+Be aware that *how* you communicate requests and reviews in your feedback can have a significant impact on the success of the pull request. Yes, we may merge a particular change that makes Foundry better, but the individual might just not want to have anything to do with Foundry ever again. The goal is not just having good code.
+
+##### Abandoned or stale pull requests
+
+If a pull request appears to be abandoned or stalled, it is polite to first check with the contributor to see if they intend to continue the work before checking if they would mind if you took it over (especially if it just has nits left). When doing so, it is courteous to give the original contributor credit for the work they started, either by preserving their name and e-mail address in the commit log, or by using the `Author: ` or `Co-authored-by: ` metadata tag in the commits.
+
+_Adapted from the [ethers-rs contributing guide](https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md)_.
+
+### Releasing
+
+Releases are automatically done by the release workflow when a tag is pushed, however, these steps still need to be taken:
+
+1. Ensure that the versions in the relevant `Cargo.toml` files are up-to-date.
+2. Update documentation lins
+3. Perform a final audit for breaking changes.
+
+[rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
+[dev-tg]: https://t.me/foundry_rs
+[foundry-book]: https://github.com/onbjerg/foundry-book
+[support-tg]: https://t.me/foundry_support
+[mcve]: https://stackoverflow.com/help/mcve
+[hiding-a-comment]: https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The [dev Telegram][dev-tg] is available for any concerns you may have that are n
 
 The Foundry project adheres to the [Rust Code of Conduct][rust-coc]. This code of conduct describes the _minimum_ behavior expected from all contributors.
 
-Instances of violations of the Code of Conduct can be reported by conacting the team at [me@gakonst.com](mailto:me@gakonst.com).
+Instances of violations of the Code of Conduct can be reported by contacting the team at [me@gakonst.com](mailto:me@gakonst.com).
 
 ### Ways to contribute
 
@@ -124,7 +124,7 @@ Keep an eye out for comments from code owners to provide guidance on conflicting
 
 **Any Foundry community member is welcome to review any pull request**.
 
-All contributors wo choose to review and provide feedback on pull requests have a responsibility to both the project and individual making the contribution. Reviews and feedback must be helpful, insightful, and geared towards improving the contribution as opposed to simply blocking it. If there are reasons why you feel the PR should not be merged, explain what those are. Do not exepct to be able to block a PR from advancing simply because you say "no" without giving an explanation. Be open to having your mind changed. Be open to working *with* the contributor to make the pull request better.
+All contributors who choose to review and provide feedback on pull requests have a responsibility to both the project and individual making the contribution. Reviews and feedback must be helpful, insightful, and geared towards improving the contribution as opposed to simply blocking it. If there are reasons why you feel the PR should not be merged, explain what those are. Do not expect to be able to block a PR from advancing simply because you say "no" without giving an explanation. Be open to having your mind changed. Be open to working *with* the contributor to make the pull request better.
 
 Reviews that are dismissive or disrespectful of the contributor or any other reviewers are strictly counter to the Code of Conduct.
 
@@ -134,7 +134,7 @@ When reviewing a pull request, the primary goals are for the codebase to improve
 
 Do not overwhelm new contributors.
 
-It is tempting to micro-optimize and make everythign about relative performance, perfect grammar, or exact style matches. Do not succumb to that temptation..
+It is tempting to micro-optimize and make everything about relative performance, perfect grammar, or exact style matches. Do not succumb to that temptation..
 
 Focus first on the most significant aspects of the change:
 
@@ -153,7 +153,7 @@ Nits (requests for small changes that are not essential) are fine, but try to av
 
 It is always good to clearly indicate nits when you comment, e.g.: `Nit: change foo() to bar(). But this is not blocking`.
 
-If your comments were addressed but were not folded after new commits, or if they proved to be mistaken, please, [hide them][hiding-a-comment] with the appropriate reason to keep the converstaion flow concise and relevant.
+If your comments were addressed but were not folded after new commits, or if they proved to be mistaken, please, [hide them][hiding-a-comment] with the appropriate reason to keep the conversation flow concise and relevant.
 
 ##### Be aware of the person behind the code
 
@@ -170,7 +170,7 @@ _Adapted from the [ethers-rs contributing guide](https://github.com/gakonst/ethe
 Releases are automatically done by the release workflow when a tag is pushed, however, these steps still need to be taken:
 
 1. Ensure that the versions in the relevant `Cargo.toml` files are up-to-date.
-2. Update documentation lins
+2. Update documentation links
 3. Perform a final audit for breaking changes.
 
 [rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # <h1 align="center"> foundry </h1>
 
 ![Github Actions](https://github.com/gakonst/foundry/workflows/Tests/badge.svg)
-[![Telegram Chat](https://img.shields.io/endpoint?color=neon&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Ffoundry_rs)](https://t.me/foundry_rs)
+[![Telegram Chat][tg-badge]][tg-url]
 [![Crates.io][crates-badge]][crates-url]
 
 [crates-badge]: https://img.shields.io/crates/v/foundry.svg
-
 [crates-url]: https://crates.io/crates/foundry-rs
+[tg-badge]: https://img.shields.io/endpoint?color=neon&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Ffoundry_rs
+[tg-url]: https://t.me/foundry_rs
 
 **Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
 

--- a/README.md
+++ b/README.md
@@ -170,45 +170,7 @@ source ~/.zshrc
 
 ## Contributing
 
-### Directory structure
-
-This repository contains several Rust crates:
-
-- [`forge`](forge): Library for building and testing a Solidity repository.
-- [`cast`](cast): Library for interacting with a live Ethereum JSON-RPC compatible node, or for parsing data.
-- [`cli`](cli): Command line interfaces to `cast` and `forge`.
-- [`evm-adapters`](evm-adapters): Unified layer of abstraction over multiple EVM types. Currently supported EVMs:
-  [Sputnik](https://github.com/rust-blockchain/evm/),
-  [Evmodin](https://github.com/vorot93/evmodin).
-- [`utils`](utils): Utilities for parsing ABI data, will eventually be upstreamed
-  to [ethers-rs](https://github.com/gakonst/ethers-rs/).
-
-### Rust Toolchain
-
-We use the stable Rust toolchain. Install by running:
-`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`.
-
-#### Minimum Supported Rust Version
-
-The current minimum supported Rust version is
-`rustc 1.54.0 (a178d0322 2021-07-26)`.
-
-### Testing
-
-```shell
-cargo check
-cargo test
-cargo doc --open
-```
-
-### Formatting
-
-We use the nightly toolchain for formatting and linting.
-
-```
-cargo +nightly fmt
-cargo +nightly clippy --all-features -- -D warnings
-```
+See our [contributing guidelines](./CONTRIBUTING.md).
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -17,26 +17,30 @@ Foundry consists of:
 - [**Cast**](./cast): Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain
   data.
 
+**To get started, read the [Foundry Book][foundry-book] (wip)!**
+
+[foundry-book]: https://onbjerg.github.io/foundry-book/
+
 ![demo](./assets/demo.svg)
 
 ## Installation
 
 First run the command below to get `foundryup`, the Foundry toolchain installer:
 
-```
+```sh
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-Then in a new terminal session or after reloading your PATH, run it to get the latest `forge` and `cast` binaries:
+Then, in a new terminal session or after reloading your `PATH`, run it to get the latest `forge` and `cast` binaries:
 
-```
+```sh
 foundryup
 ```
 
-Advanced ways to use `foundryup` and other documentation can be found in the [foundryup package](./foundryup/README.md).
+Advanced ways to use `foundryup`, and other documentation, can be found in the [foundryup package](./foundryup/README.md).
 Happy forging!
 
-### Libusb error when running forge/cast
+### `libusb` error when running `forge`/`cast`
 
 If you are using the binaries as released, you may see the following error on MacOS:
 
@@ -46,7 +50,7 @@ dyld: Library not loaded: /usr/local/opt/libusb/lib/libusb-1.0.0.dylib
 
 In order to fix this, you must install `libusb` like so:
 
-```
+```sh
 brew install libusb 
 ```
 
@@ -56,21 +60,21 @@ More documentation can be found in the [forge package](./forge/README.md) and in
 
 ### Features
 
-1. Fast & flexible compilation pipeline:
-    1. Automatic Solidity compiler version detection & installation (under
+- **Fast & flexible compilation pipeline**
+    - Automatic Solidity compiler version detection & installation (under
        `~/.svm`)
-    1. Incremental compilation & caching: Only changed files are re-compiled
-    1. Parallel compilation
-    1. Non-standard directory structures support (e.g. can build
+    - **Incremental compilation & caching**: Only changed files are re-compiled
+    - Parallel compilation
+    - Non-standard directory structures support (e.g. 
        [Hardhat repos](https://twitter.com/gakonst/status/1461289225337421829))
-1. Tests are written in Solidity (like in DappTools)
-1. Fast fuzz Tests with shrinking of inputs & printing of counter-examples
-1. Fast remote RPC forking mode leveraging Rust's async infrastructure like tokio
-1. Flexible debug logging:
-    1. Dapptools-style, using `DsTest`'s emitted logs
-    1. Hardhat-style, using the popular `console.sol` contract
-1. Portable (5-10MB) & easy to install statically linked binary without requiring Nix or any other package manager
-1. Abstracted over EVM implementations (currently supported: Sputnik, EvmOdin)
+- **Tests are written in Solidity** (like in DappTools)
+- **Fast fuzz testing** with shrinking of inputs & printing of counter-examples
+- **Fast remote RPC forking mode**, leveraging Rust's async infrastructure like tokio
+- **Flexible debug logging**
+    - Dapptools-style, using `DsTest`'s emitted logs
+    - Hardhat-style, using the popular `console.sol` contract
+- **Portable (5-10MB) & easy to install** without requiring Nix or any other package manager
+- **Abstracted over EVM implementations** (currently supported: Sputnik, EvmOdin)
 
 ### How Fast?
 
@@ -101,16 +105,15 @@ More documentation can be found in the [cast package](./cast/README.md).
 
 ## Setup
 
-### Configuring foundry/forge
+### Configuring Foundry
 
-foundry is designed to be very configurable. You can create a TOML file called [`foundry.toml`](./config/README.md)
-place it in the project or any other parent directory, and it will apply the options in that file. See [_Config
-Readme_](./config/README.md#all-options) for all available options.
+Foundry is designed to be very configurable. You can create a TOML file called [`foundry.toml`](./config/README.md)
+place it in the project or any other parent directory, and it will apply the options in that file. See [config package](./config/README.md#all-options) for all available options.
 
 Configurations can be arbitrarily namespaced by profiles. Foundry's default configuration is also named `default`. The
 selected profile is the value of the `FOUNDRY_PROFILE` environment variable, or if it is not set, "default".
-`FOUNDRY_` or `DAPP_` prefixed environment variables, like `FOUNDRY_SRC` take precedence, [see _Default
-Profile_](./config/README.md#default-profile)
+`FOUNDRY_` or `DAPP_` prefixed environment variables, like `FOUNDRY_SRC` take precedence, [see "Default
+Profile"](./config/README.md#default-profile)
 
 `forge init` creates a basic, extendable `foundry.toml` file.
 
@@ -121,52 +124,15 @@ run `forge config --basic`, this can be used to create a new `foundry.toml` file
 with `forge config --basic > foundry.toml`. By default `forge config` shows the currently selected foundry profile and
 its values. It also accepts the same arguments as `forge build`.
 
-### VSCode
+### Additional Setup
 
-[juanfranblanco/vscode-solidity](https://github.com/juanfranblanco/vscode-solidity) describes in detail how to configure
-the `vscode` extension.
+You can find additional setup guides in the [Foundry Book][foundry-book]:
 
-If you're using dependency libraries, then you'll need [_
-Remappings_](https://github.com/juanfranblanco/vscode-solidity#remappings) so the extension can find the imports.
+- [Setting up VSCode][vscode-setup]
+- [Shell autocompletions][shell-setup]
 
-The easiest way to add remappings is creating a `remappings.txt` file in the root folder, which can be generated with
-auto inferred remappings:
-
-```shell
-forge remappings > remappings.txt
-```
-
-See also [./cli/README.md](./cli/README.md#Remappings).
-
-Alternatively you can use the extension's dir structure settings to configure your contracts and dependency directory.
-If your contracts are stored in `./src` and libraries in `./lib`, you can add
-
-```json
-"solidity.packageDefaultDependenciesContractsDirectory": "src",
-"solidity.packageDefaultDependenciesDirectory": "lib"
-```
-
-to your `.vscode` file
-
-It's also recommended to specify a solc compiler version for the
-extension, [read more](https://github.com/juanfranblanco/vscode-solidity#remote-download):
-
-```json
-"solidity.compileUsingRemoteVersion": "v0.8.10"
-```
-
-## Autocompletion
-
-You can generate autocompletion shell scripts for bash, elvish, fish, powershell, and zsh.
-
-Example (zsh / [oh-my-zsh](https://ohmyz.sh/))
-
-```shell
-mkdir -p ~/.oh-my-zsh/completions
-forge completions zsh > ~/.oh-my-zsh/completions/_forge
-cast completions zsh > ~/.oh-my-zsh/completions/_cast
-source ~/.zshrc
-```
+[vscode-setup]: https://onbjerg.github.io/foundry-book/guides/vscode.html
+[shell-setup]: https://onbjerg.github.io/foundry-book/guides/shell-autocompletion.html
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ More documentation can be found in the [forge package](./forge/README.md) and in
     - Dapptools-style, using `DsTest`'s emitted logs
     - Hardhat-style, using the popular `console.sol` contract
 - **Portable (5-10MB) & easy to install** without requiring Nix or any other package manager
-- **Abstracted over EVM implementations** (currently supported: Sputnik, EvmOdin)
+- **Fast CI** with the [Foundry GitHub action][foundry-gha].
+
+[foundry-gha]: https://github.com/onbjerg/foundry-toolchain
 
 ### How Fast?
 


### PR DESCRIPTION
Adds two issue forms:

- Bug report
- Feature request

**You can see what the forms look like by going to "Files change" and clicking "View file" (accessible by the 3 dots in the top right) on the form**

Also adds:

- A link to the Foundry Support telegram when opening an issue
- A very minimal PR template
- Contributing guidelines (inspired by the one in ethers-rs)

Finally, does a pass on the README with some formatting nits and callouts to read the book.

For more info on the new issue forms: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

Anything missing in the forms?

