### PR TITLE
Configure changelog

### DIFF
--- a/.github/changelog.json
+++ b/.github/changelog.json
@@ -1,0 +1,15 @@
+{
+  "categories": [{
+    "title": "## Features",
+    "labels": ["T-feature"]
+  }, {
+    "title": "## Fixes",
+    "labels": ["T-bug", "T-fix"]
+  }],
+  "ignore_labels": [
+    "L-ignore"
+  ],
+  "template": "${{CHANGELOG}}\n## Other\n\n${{UNCATEGORIZED}}",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
+  "empty_template": "- No changes"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2
         with:
+          configuration: "./.github/changelog.json"
           fromTag: ${{ env.IS_NIGHTLY && 'nightly' || '' }}
           toTag: ${{ steps.release_info.outputs.tag_name }}
         env:


### PR DESCRIPTION
Currently all of our releases have no description, because our changelog builder action hides uncategorized PRs by default.

This configures the action to show the uncategorized PRs under a special section called "Other", and it also configures the labels required for the other sections of the changelog:

- Feature PRs should now be tagged with `T-feature`
- Bug fix PRs should be tagged with `T-bug` (I also added `T-fix` even though it doesn't exist if we want to add that instead)
- To omit a PR entirely from the changelog, add `L-ignore` to the PR.

Any other PR without any of these labels will end up in the "Other" section of the changelog for the release.