### PR TITLE
Fixed wrong arguments in cargo +nightly clippy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Please also make sure that the following commands pass if you have changed the c
 cargo check --all
 cargo test --all --all-features
 cargo +nightly fmt -- --check
-cargo +nightly clippy -all --all-features -- -D warnings
+cargo +nightly clippy --all --all-features -- -D warnings
 ```
 
 If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other contributors are not duplicating work.


### PR DESCRIPTION
## Motivation

According do the docs, the following command should not throw any error. But `cargo +nightly clippy -all --all-features -- -D warnings` would throw an error as the flag -all is invalid.

## Solution

`cargo +nightly clippy --all --all-features -- -D warnings` is the right command. ( -all to --all)

Updating the doc with the same.