### PR TITLE
Honor `--chain-id` even when using fork mode

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -123,7 +123,7 @@ pub struct Config {
     /// pins the block number for the state fork
     pub fork_block_number: Option<u64>,
     /// the chainid opcode value
-    pub chain_id: Chain,
+    pub chain_id: Option<Chain>,
     /// Block gas limit
     pub gas_limit: u64,
     /// `tx.gasprice` value during EVM execution"
@@ -650,7 +650,7 @@ impl Default for Config {
             initial_balance: U256::from(0xffffffffffffffffffffffffu128),
             block_number: 0,
             fork_block_number: None,
-            chain_id: Chain::Id(1),
+            chain_id: None,
             // toml-rs can't handle larger number because integers are stored signed
             // https://github.com/alexcrichton/toml-rs/issues/256
             gas_limit: i64::MAX as u64,

--- a/evm-adapters/src/evm_opts.rs
+++ b/evm-adapters/src/evm_opts.rs
@@ -137,6 +137,7 @@ mod sputnik_helpers {
                 let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
                 rt.block_on(crate::sputnik::vicinity(
                     &provider,
+                    self.env.chain_id,
                     self.fork_block_number,
                     Some(self.env.tx_origin),
                 ))?
@@ -153,7 +154,7 @@ pub struct Env {
     pub gas_limit: u64,
 
     /// the chainid opcode value
-    pub chain_id: u64,
+    pub chain_id: Option<u64>,
 
     /// the tx.gasprice value during EVM execution
     pub gas_price: u64,
@@ -185,7 +186,7 @@ impl Env {
     #[cfg(feature = "sputnik")]
     pub fn sputnik_state(&self) -> MemoryVicinity {
         MemoryVicinity {
-            chain_id: self.chain_id.into(),
+            chain_id: self.chain_id.unwrap_or(1).into(),
 
             gas_price: self.gas_price.into(),
             origin: self.tx_origin,

--- a/evm-adapters/src/evm_opts.rs
+++ b/evm-adapters/src/evm_opts.rs
@@ -205,7 +205,7 @@ impl Env {
     pub fn evmodin_state(&self) -> MockedHost {
         let mut host = MockedHost::default();
 
-        host.tx_context.chain_id = self.chain_id.into();
+        host.tx_context.chain_id = self.chain_id.unwrap_or(1).into();
         host.tx_context.tx_gas_price = self.gas_price.into();
         host.tx_context.tx_origin = self.tx_origin;
         host.tx_context.block_coinbase = self.block_coinbase;

--- a/evm-adapters/src/sputnik/forked_backend/cache.rs
+++ b/evm-adapters/src/sputnik/forked_backend/cache.rs
@@ -525,7 +525,7 @@ mod tests {
         let address: Address = "63091244180ae240c87d1f528f5f269134cb07b3".parse().unwrap();
 
         let rt = Runtime::new().unwrap();
-        let vicinity = rt.block_on(vicinity(&provider, None, None)).unwrap();
+        let vicinity = rt.block_on(vicinity(&provider, None, None, None)).unwrap();
         let cache = new_shared_cache(MemCache::default());
 
         let backend = SharedBackend::new(Arc::new(provider), cache.clone(), vicinity, None);

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -224,7 +224,7 @@ mod tests {
         .unwrap();
         let rt = Runtime::new().unwrap();
         let blk = Some(13292465);
-        let vicinity = rt.block_on(vicinity(&provider, blk, None)).unwrap();
+        let vicinity = rt.block_on(vicinity(&provider, None, blk, None)).unwrap();
         let backend = new_backend(&vicinity, Default::default());
         let backend = ForkMemoryBackend::new(provider, backend, blk, Default::default());
 

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -28,6 +28,7 @@ use sputnik_evm::executor::stack::PrecompileSet;
 /// the live chain data returned by the provider.
 pub async fn vicinity<M: Middleware>(
     provider: &M,
+    passed_chain_id: Option<u64>,
     pin_block: Option<u64>,
     origin: Option<H160>,
 ) -> Result<MemoryVicinity, M::Error> {
@@ -36,7 +37,7 @@ pub async fn vicinity<M: Middleware>(
     } else {
         provider.get_block_number().await?.as_u64()
     };
-    let (gas_price, chain_id, block) = tokio::try_join!(
+    let (gas_price, rpc_chain_id, block) = tokio::try_join!(
         provider.get_gas_price(),
         provider.get_chainid(),
         provider.get_block(block_number)
@@ -45,7 +46,7 @@ pub async fn vicinity<M: Middleware>(
 
     Ok(MemoryVicinity {
         origin: origin.unwrap_or_default(),
-        chain_id,
+        chain_id: passed_chain_id.map_or(rpc_chain_id, Into::into),
         block_hashes: Vec::new(),
         block_number: block.number.expect("block number not found").as_u64().into(),
         block_coinbase: block.author,

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -28,7 +28,7 @@ use sputnik_evm::executor::stack::PrecompileSet;
 /// the live chain data returned by the provider.
 pub async fn vicinity<M: Middleware>(
     provider: &M,
-    passed_chain_id: Option<u64>,
+    override_chain_id: Option<u64>,
     pin_block: Option<u64>,
     origin: Option<H160>,
 ) -> Result<MemoryVicinity, M::Error> {
@@ -46,7 +46,7 @@ pub async fn vicinity<M: Middleware>(
 
     Ok(MemoryVicinity {
         origin: origin.unwrap_or_default(),
-        chain_id: passed_chain_id.map_or(rpc_chain_id, Into::into),
+        chain_id: override_chain_id.map_or(rpc_chain_id, Into::into),
         block_hashes: Vec::new(),
         block_number: block.number.expect("block number not found").as_u64().into(),
         block_coinbase: block.author,

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -35,7 +35,7 @@ pub mod test_helpers {
     });
 
     pub static EVM_OPTS: Lazy<EvmOpts> = Lazy::new(|| EvmOpts {
-        env: Env { gas_limit: 18446744073709551615, chain_id: 1, ..Default::default() },
+        env: Env { gas_limit: 18446744073709551615, chain_id: Some(1), ..Default::default() },
         initial_balance: U256::MAX,
         evm_type: EvmType::Sputnik,
         ..Default::default()


### PR DESCRIPTION
## Motivation

DappTools always used chain ID 99, even when forking from a remote RPC, whereas Foundry just falls back to the chain ID of the RPC. The motivation here is DappTools compatability

## Solution

I made chain ID optional and:

- If we're forking from a remote RPC, we override the chain ID if specified anywhere in the config (`foundry.toml`, CLI arg, environment)
- If we're not using fork mode, but the chain ID has not been specified, we still default to chain ID 1.

Closes #601 and fixes drai integration test