### PR TITLE
feat(cast): adds support for gas, value, nonce for send cmd & value for estimate cmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Please also make sure that the following commands pass if you have changed the c
 cargo check --all
 cargo test --all --all-features
 cargo +nightly fmt -- --check
-cargo +nightly clippy --all --all-features -- -D warnings
+cargo +nightly clippy -all --all-features -- -D warnings
 ```
 
 If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other contributors are not duplicating work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Please also make sure that the following commands pass if you have changed the c
 cargo check --all
 cargo test --all --all-features
 cargo +nightly fmt -- --check
-cargo +nightly clippy -all --all-features -- -D warnings
+cargo +nightly clippy -al --all-features -- -D warnings
 ```
 
 If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other contributors are not duplicating work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Please also make sure that the following commands pass if you have changed the c
 cargo check --all
 cargo test --all --all-features
 cargo +nightly fmt -- --check
-cargo +nightly clippy -al --all-features -- -D warnings
+cargo +nightly clippy --all --all-features -- -D warnings
 ```
 
 If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other contributors are not duplicating work.

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -74,7 +74,7 @@ where
         chain: Chain,
         etherscan_api_key: Option<String>,
     ) -> Result<String> {
-        let (tx, func) = self.build_tx(from, to, Some(args), chain, etherscan_api_key).await?;
+        let (tx, func) = self.build_tx(from, to, Some(args), None, None, None, chain, etherscan_api_key).await?;
         let tx = tx.into();
         let res = self.provider.call(&tx, None).await?;
 
@@ -119,7 +119,7 @@ where
     ///
     /// ```no_run
     /// use cast::Cast;
-    /// use ethers_core::types::{Address, Chain};
+    /// use ethers_core::types::{Address, Chain, U256};
     /// use ethers_providers::{Provider, Http};
     /// use std::{str::FromStr, convert::TryFrom};
     ///
@@ -130,7 +130,10 @@ where
     /// let to = Address::from_str("0xB3C95ff08316fb2F2e3E52Ee82F8e7b605Aa1304")?;
     /// let sig = "greet(string)()";
     /// let args = vec!["hello".to_owned()];
-    /// let data = cast.send(from, to, Some((sig, args)), Chain::Mainnet, None).await?;
+    /// let gas = U256::from_str("200000").unwrap();
+    /// let value = U256::from_str("1").unwrap();
+    /// let nonce = U256::from_str("1").unwrap();
+    /// let data = cast.send(from, to, Some((sig, args)), Some(gas), Some(value), Some(nonce), Chain::Mainnet, None).await?;
     /// println!("{}", *data);
     /// # Ok(())
     /// # }
@@ -140,10 +143,14 @@ where
         from: F,
         to: T,
         args: Option<(&str, Vec<String>)>,
+        gas: Option<U256>,
+        value: Option<U256>,
+        nonce: Option<U256>,
         chain: Chain,
         etherscan_api_key: Option<String>,
     ) -> Result<PendingTransaction<'_, M::Provider>> {
-        let (tx, _) = self.build_tx(from, to, args, chain, etherscan_api_key).await?;
+
+        let (tx, _) = self.build_tx(from, to, args, gas, value, nonce, chain, etherscan_api_key).await?;
         let res = self.provider.send_transaction(tx, None).await?;
 
         Ok::<_, eyre::Error>(res)
@@ -178,7 +185,7 @@ where
     ///
     /// ```no_run
     /// use cast::Cast;
-    /// use ethers_core::types::{Address, Chain};
+    /// use ethers_core::types::{Address, Chain, U256};
     /// use ethers_providers::{Provider, Http};
     /// use std::{str::FromStr, convert::TryFrom};
     ///
@@ -189,7 +196,8 @@ where
     /// let to = Address::from_str("0xB3C95ff08316fb2F2e3E52Ee82F8e7b605Aa1304")?;
     /// let sig = "greet(string)()";
     /// let args = vec!["5".to_owned()];
-    /// let data = cast.estimate(from, to, Some((sig, args)), Chain::Mainnet, None).await?;
+    /// let value = U256::from_str("1").unwrap();
+    /// let data = cast.estimate(from, to, Some((sig, args)), Some(value), Chain::Mainnet, None).await?;
     /// println!("{}", data);
     /// # Ok(())
     /// # }
@@ -199,10 +207,11 @@ where
         from: F,
         to: T,
         args: Option<(&str, Vec<String>)>,
+        value: Option<U256>,
         chain: Chain,
         etherscan_api_key: Option<String>,
     ) -> Result<U256> {
-        let (tx, _) = self.build_tx(from, to, args, chain, etherscan_api_key).await?;
+        let (tx, _) = self.build_tx(from, to, args, None, value, None, chain, etherscan_api_key).await?;
         let tx = tx.into();
         let res = self.provider.estimate_gas(&tx).await?;
 
@@ -214,6 +223,9 @@ where
         from: F,
         to: T,
         args: Option<(&str, Vec<String>)>,
+        gas: Option<U256>,
+        value: Option<U256>,
+        nonce: Option<U256>,
         chain: Chain,
         etherscan_api_key: Option<String>,
     ) -> Result<(Eip1559TransactionRequest, Option<ethers_core::abi::Function>)> {
@@ -252,6 +264,18 @@ where
         } else {
             None
         };
+
+        if let Some(gas) = gas {
+            tx = tx.gas(gas)
+        }
+
+        if let Some(value) = value {
+            tx = tx.value(value)
+        }
+
+        if let Some(nonce) = nonce {
+            tx = tx.nonce(nonce)
+        }
 
         Ok((tx, func))
     }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -147,11 +147,11 @@ pub enum Subcommands {
         sig: String,
         #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
-         #[clap(help = "gas quantity for the transaction")]
+        #[clap(long, help = "gas quantity for the transaction")]
         gas: Option<U256>,
-         #[clap(help = "ether value for the transaction")]
+        #[clap(long, help = "ether value for the transaction")]
         value: Option<U256>,
-         #[clap(help = "nonce for the transaction")]
+        #[clap(long, help = "nonce for the transaction")]
         nonce: Option<U256>,
         #[clap(long, env = "CAST_ASYNC")]
         cast_async: bool,
@@ -177,7 +177,7 @@ pub enum Subcommands {
         sig: String,
         #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
-        #[clap(help = "value for tx estimate")]
+        #[clap(long, help = "value for tx estimate")]
         value: Option<U256>,
         #[clap(flatten)]
         eth: EthereumOpts,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -149,7 +149,7 @@ pub enum Subcommands {
         args: Vec<String>,
         #[clap(long, help = "gas quantity for the transaction")]
         gas: Option<U256>,
-        #[clap(long, help = "ether value for the transaction")]
+        #[clap(long, help = "ether value (in wei) for the transaction")]
         value: Option<U256>,
         #[clap(long, help = "nonce for the transaction")]
         nonce: Option<U256>,
@@ -177,7 +177,7 @@ pub enum Subcommands {
         sig: String,
         #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
-        #[clap(long, help = "value for tx estimate")]
+        #[clap(long, help = "value for tx estimate (in wei)")]
         value: Option<U256>,
         #[clap(flatten)]
         eth: EthereumOpts,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use clap::{Parser, Subcommand};
-use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256};
+use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256, U256};
 
 use super::{ClapChain, EthereumOpts, Wallet};
 
@@ -147,6 +147,12 @@ pub enum Subcommands {
         sig: String,
         #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
+         #[clap(help = "gas quantity for the transaction")]
+        gas: Option<U256>,
+         #[clap(help = "ether value for the transaction")]
+        value: Option<U256>,
+         #[clap(help = "nonce for the transaction")]
+        nonce: Option<U256>,
         #[clap(long, env = "CAST_ASYNC")]
         cast_async: bool,
         #[clap(flatten)]
@@ -171,6 +177,8 @@ pub enum Subcommands {
         sig: String,
         #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
+        #[clap(help = "value for tx estimate")]
+        value: Option<U256>,
         #[clap(flatten)]
         eth: EthereumOpts,
     },

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -190,7 +190,7 @@ pub struct Wallet {
     #[clap(long = "private-key", help = "Your private key string")]
     pub private_key: Option<String>,
 
-    #[clap(long = "keystore", help = "Path to your keystore folder / file")]
+    #[clap(env = "ETH_KEYSTORE", long = "keystore", help = "Path to your keystore folder / file")]
     pub keystore_path: Option<String>,
 
     #[clap(long = "password", help = "Your keystore password", requires = "keystore-path")]


### PR DESCRIPTION
## Motivation

1.  Ability to supply gas amount, value, nonce with cast send cmd and value with cast estimate cmd  allows for greater flexibility when dealing with transactions.
2. Ability to specify ETH_KEYSTORE (like dapp) for wallet use allows one to avoid specifying keystore file every time.

## Solution

1. Added **gas**, **value**, and **nonce** options to **cast send** cmd.
For example -
`
cast send 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 "createProxyWithNonce(address,bytes,uint256)" 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 "" 13 --gas 250000 --value 1 --nonce 7 --private-key PV_KEY
`
2. Added **value** options to **cast estimate** cmd.
For example -
`
cast send 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 "createProxyWithNonce(address,bytes,uint256)" 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552 "" 13 --value 1
`
3. Added support for **ETH_KEYSTORE** env variable for specifying keystore file for wallet
For example, now can use wallet by specifying **ETH_KEYSTORE** in env like this  - 
`
export ETH_RPC_URL=PATH_TO_KEYSTORE_FILE
`