### PR TITLE
feat(cast/send): legacy txn sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1382,10 +1382,11 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "async-trait",
  "auto_impl",
+ "base64 0.13.0",
  "ethers-core",
  "futures-channel",
  "futures-core",
@@ -1412,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1435,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#6d7875a44c1053bdf9bb58dbca294652b8eeab32"
+source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
 dependencies = [
  "colored",
  "dunce",
@@ -3177,9 +3178,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -3895,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "solang-parser"
 version = "0.1.1"
-source = "git+https://github.com/hyperledger-labs/solang#67f1325a5aabd513289106585f97bdfe2efd647d"
+source = "git+https://github.com/hyperledger-labs/solang#4ad9d87881460fe89f2c4a0f762511f8fa445849"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,9 +1055,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4641673db66b0492d99edd8fd1cf2e6eb4ab91de525d1d2d6cc99442ed15f5"
+checksum = "23f80ad035a844638d4ce3d4a27ef4e00f2304e1a37f9f43c6a3c73622f39e79"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1393,6 +1393,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hex",
+ "http",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -1413,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1436,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#c22dd8eab4c7e4c848446f80ec1dc0e4a8e76079"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "colored",
  "dunce",
@@ -3983,7 +3984,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "svm-rs"
 version = "0.2.1"
-source = "git+https://github.com/roynalnaruto/svm-rs#5518296f756458f878958a76b985b6fe423acad4"
+source = "git+https://github.com/roynalnaruto/svm-rs#aca7b30ea8509300ef8c960b517716702cb847a0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -72,6 +72,7 @@ pub struct EthereumOpts {
 
     #[clap(long, env = "ETHERSCAN_API_KEY")]
     pub etherscan_api_key: Option<String>,
+
     #[clap(long, env = "CHAIN", default_value = "mainnet")]
     pub chain: Chain,
 }


### PR DESCRIPTION
Mostly good i think but hitting this issue after upgrading ethers-rs with `cargo update -p ethers`

```
cargo run --bin forge           
   Compiling ethers-providers v0.6.0 (https://github.com/gakonst/ethers-rs#c22dd8ea)
error[E0433]: failed to resolve: use of undeclared crate or module `http`
   --> /Users/tarrence/.cargo/git/checkouts/ethers-rs-c3a7c0a0ae0fe6be/c22dd8e/ethers-providers/src/transports/http.rs:162:27
    |
162 |     InvalidHeader(#[from] http::header::InvalidHeaderValue),
    |                           ^^^^ use of undeclared crate or module `http`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `ethers-providers` due to previous error
```