### PR TITLE
Use relative path for git commands in install cmd

### DIFF
--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -65,12 +65,11 @@ pub(crate) fn install(
 
     for dep in dependencies {
         let DependencyInstallOpts { no_git, no_commit, quiet } = opts;
-        let path = libs.join(&dep.name);
-        p_println!(!quiet => "Installing {} in {:?}, (url: {}, tag: {:?})", dep.name, path, dep.url, dep.tag);
+        p_println!(!quiet => "Installing {} in {:?}, (url: {}, tag: {:?})", dep.name, &libs.join(&dep.name), dep.url, dep.tag);
         if no_git {
-            install_as_folder(&dep, &path)?;
+            install_as_folder(&dep, &libs)?;
         } else {
-            install_as_submodule(&dep, root, &path, no_commit)?;
+            install_as_submodule(&dep, &libs, no_commit)?;
         }
 
         p_println!(!quiet => "    {} {}",    Colour::Green.paint("Installed"), dep.name);
@@ -79,9 +78,10 @@ pub(crate) fn install(
 }
 
 /// installs the dependency as an ordinary folder instead of a submodule
-fn install_as_folder(dep: &Dependency, path: &Path) -> eyre::Result<()> {
+fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
     Command::new("git")
-        .args(&["clone", &dep.url, &path.display().to_string()])
+        .args(&["clone", &dep.url, &dep.name])
+        .current_dir(&libs)
         .stdout(Stdio::piped())
         .spawn()?
         .wait()?;
@@ -89,7 +89,7 @@ fn install_as_folder(dep: &Dependency, path: &Path) -> eyre::Result<()> {
     if let Some(ref tag) = dep.tag {
         Command::new("git")
             .args(&["checkout", tag])
-            .current_dir(&path)
+            .current_dir(&libs.join(&dep.name))
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()?
@@ -97,38 +97,25 @@ fn install_as_folder(dep: &Dependency, path: &Path) -> eyre::Result<()> {
     }
 
     // rm git artifacts
-    std::fs::remove_dir_all(path.join(".git"))?;
+    std::fs::remove_dir_all(libs.join(&dep.name).join(".git"))?;
 
     Ok(())
 }
 
 /// installs the dependency as new submodule
-fn install_as_submodule(
-    dep: &Dependency,
-    root: &Path,
-    path: &Path,
-    no_commit: bool,
-) -> eyre::Result<()> {
-    let relative_path = path.strip_prefix(&root)?;
-
+fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre::Result<()> {
     // install the dep
     Command::new("git")
-        .args(&["submodule", "add", &dep.url, &relative_path.display().to_string()])
-        .current_dir(&root)
+        .args(&["submodule", "add", &dep.url, &dep.name])
+        .current_dir(&libs)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?
         .wait()?;
     // call update on it
     Command::new("git")
-        .args(&[
-            "submodule",
-            "update",
-            "--init",
-            "--recursive",
-            &relative_path.display().to_string(),
-        ])
-        .current_dir(&root)
+        .args(&["submodule", "update", "--init", "--recursive", &dep.name])
+        .current_dir(&libs)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?
@@ -138,14 +125,14 @@ fn install_as_submodule(
     let message = if let Some(ref tag) = dep.tag {
         Command::new("git")
             .args(&["checkout", "--recurse-submodules", tag])
-            .current_dir(&path)
+            .current_dir(&libs.join(&dep.name))
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()?
             .wait()?;
 
         if !no_commit {
-            Command::new("git").args(&["add", &path.display().to_string()]).spawn()?.wait()?;
+            Command::new("git").args(&["add", &libs.display().to_string()]).spawn()?.wait()?;
         }
         format!("forge install: {}\n\n{}", dep.name, tag)
     } else {
@@ -155,7 +142,7 @@ fn install_as_submodule(
     if !no_commit {
         Command::new("git")
             .args(&["commit", "-m", &message])
-            .current_dir(&root)
+            .current_dir(&libs)
             .stdout(Stdio::piped())
             .spawn()?
             .wait()?;

--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -109,9 +109,11 @@ fn install_as_submodule(
     path: &Path,
     no_commit: bool,
 ) -> eyre::Result<()> {
+    let relative_path = path.strip_prefix(&root)?;
+
     // install the dep
     Command::new("git")
-        .args(&["submodule", "add", &dep.url, &path.display().to_string()])
+        .args(&["submodule", "add", &dep.url, &relative_path.display().to_string()])
         .current_dir(&root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -119,7 +121,13 @@ fn install_as_submodule(
         .wait()?;
     // call update on it
     Command::new("git")
-        .args(&["submodule", "update", "--init", "--recursive", &path.display().to_string()])
+        .args(&[
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+            &relative_path.display().to_string(),
+        ])
         .current_dir(&root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Motivation

Paths to git commands when running `forge install` and `forge init` are broken on Windows.

## Solution

Make the paths relative to the root of the project where relevant, which fixes the issue - keeping this as a draft until I have tested it on Windows

**Remaining tasks**

- [ ] Test on Windows
- [ ] Check exit code of git commands so they don't fail silently

Fixes #621 and fixes #631
