### PR TITLE
Support `DAPP_TEST_NUMBER` in fork scenarios

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -755,6 +755,11 @@ impl Provider for DappEnvCompatProvider {
                 "fork_block_number".to_string(),
                 val.parse::<u64>().map_err(figment::Error::custom)?.into(),
             );
+        } else if let Ok(val) = env::var("DAPP_TEST_NUMBER") {
+            dict.insert(
+                "fork_block_number".to_string(),
+                val.parse::<u64>().map_err(figment::Error::custom)?.into(),
+            );
         }
         if let Ok(val) = env::var("DAPP_TEST_TIMESTAMP") {
             dict.insert(


### PR DESCRIPTION
## Motivation

It is possible to specify the block to fork from in DappTools using `DAPP_TEST_NUMBER`. This behavior is not currently replicated in our codebase.

See [here](https://github.com/dapphub/dapptools/blob/e9d454af4953b1f61c7f3fcfad595601c3e14521/src/hevm/README.md#environment-variables) for DappTools docs

## Solution

Adds backwards support to use `DAPP_TEST_NUMBER` to specify the block to fork from, but only if `DAPP_FORK_BLOCK` is not specified.

Closes #530
