### PR TITLE
add legacy option to `SendTx`

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -176,7 +176,7 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(&provider).transaction(hash, field, to_json).await?)
         }
-        Subcommands::SendTx { eth, to, sig, cast_async, args, gas, value, nonce } => {
+        Subcommands::SendTx { eth, to, sig, cast_async, args, gas, value, nonce, legacy } => {
             let provider = Provider::try_from(eth.rpc_url()?)?;
             let chain_id = Cast::new(&provider).chain_id().await?;
 
@@ -194,6 +194,7 @@ async fn main() -> eyre::Result<()> {
                             eth.chain,
                             eth.etherscan_api_key,
                             cast_async,
+                            legacy,
                         )
                         .await?;
                     }
@@ -209,6 +210,7 @@ async fn main() -> eyre::Result<()> {
                             eth.chain,
                             eth.etherscan_api_key,
                             cast_async,
+                            legacy,
                         )
                         .await?;
                     }
@@ -224,6 +226,7 @@ async fn main() -> eyre::Result<()> {
                             eth.chain,
                             eth.etherscan_api_key,
                             cast_async,
+                            legacy,
                         )
                         .await?;
                     }
@@ -241,6 +244,7 @@ async fn main() -> eyre::Result<()> {
                     eth.chain,
                     eth.etherscan_api_key,
                     cast_async,
+                    legacy,
                 )
                 .await?;
             }
@@ -599,6 +603,7 @@ async fn cast_send<M: Middleware, F: Into<NameOrAddress>, T: Into<NameOrAddress>
     chain: Chain,
     etherscan_api_key: Option<String>,
     cast_async: bool,
+    legacy: bool,
 ) -> eyre::Result<()>
 where
     M::Error: 'static,
@@ -609,7 +614,7 @@ where
     let params = args.1;
     let params = if !sig.is_empty() { Some((&sig[..], params)) } else { None };
     let pending_tx =
-        cast.send(from, to, params, gas, value, nonce, chain, etherscan_api_key).await?;
+        cast.send(from, to, params, gas, value, nonce, chain, etherscan_api_key, legacy).await?;
     let tx_hash = *pending_tx;
 
     if cast_async {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -189,6 +189,11 @@ pub enum Subcommands {
         cast_async: bool,
         #[clap(flatten)]
         eth: EthereumOpts,
+        #[clap(
+            long,
+            help = "use legacy transactions instead of EIP1559 ones. this is auto-enabled for common networks without EIP1559"
+        )]
+        legacy: bool,
     },
     #[clap(name = "publish")]
     #[clap(about = "Publish a raw transaction to the network")]


### PR DESCRIPTION
Adds `legacy` option to `SendTx` for `cast send`.

Closes #579 
