### PR TITLE
feat(forge): label cheatcode

### DIFF
--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -87,7 +87,8 @@ impl Cmd for RunArgs {
         let bytecode = bin.into_bytes().unwrap();
         let needs_setup = abi.functions().any(|func| func.name == "setUp");
 
-        let cfg = crate::utils::sputnik_cfg(&evm_version);
+        let mut cfg = crate::utils::sputnik_cfg(&evm_version);
+        cfg.create_contract_limit = None;
         let vicinity = evm_opts.vicinity()?;
         let backend = evm_opts.backend(&vicinity)?;
 

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -172,21 +172,38 @@ impl Cmd for RunArgs {
                     let mut ident = identified_contracts.clone();
                     let (funcs, events, errors) =
                         foundry_utils::flatten_known_contracts(&known_contracts);
-                    let mut exec_info =
-                        ExecutionInfo::new(&known_contracts, &mut ident, &funcs, &events, &errors);
+                    let mut exec_info = ExecutionInfo::new(
+                        &known_contracts,
+                        &mut ident,
+                        &result.labeled_addresses,
+                        &funcs,
+                        &events,
+                        &errors,
+                    );
                     let vm = vm();
+                    let mut trace_string = "".to_string();
                     if evm_opts.verbosity > 4 || !result.success {
                         // print setup calls as well
                         traces.iter().for_each(|trace| {
-                            trace.pretty_print(0, &mut exec_info, &vm, "");
+                            trace.construct_trace_string(
+                                0,
+                                &mut exec_info,
+                                &vm,
+                                "",
+                                &mut trace_string,
+                            );
                         });
                     } else if !traces.is_empty() {
-                        traces.last().expect("no last but not empty").pretty_print(
+                        traces.last().expect("no last but not empty").construct_trace_string(
                             0,
                             &mut exec_info,
                             &vm,
                             "",
+                            &mut trace_string,
                         );
+                    }
+                    if !trace_string.is_empty() {
+                        println!("{}", trace_string);
                     }
                 }
                 println!();

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -305,28 +305,43 @@ fn test<A: ArtifactOutput + 'static>(
                             let mut exec_info = ExecutionInfo::new(
                                 &runner.known_contracts,
                                 &mut ident,
+                                &result.labeled_addresses,
                                 &funcs,
                                 &events,
                                 &errors,
                             );
                             let vm = vm();
+                            let mut trace_string = "".to_string();
                             if verbosity > 4 || !result.success {
                                 add_newline = true;
                                 println!("Traces:");
 
                                 // print setup calls as well
                                 traces.iter().for_each(|trace| {
-                                    trace.pretty_print(0, &mut exec_info, &vm, "  ");
+                                    trace.construct_trace_string(
+                                        0,
+                                        &mut exec_info,
+                                        &vm,
+                                        "  ",
+                                        &mut trace_string,
+                                    );
                                 });
                             } else if !traces.is_empty() {
                                 add_newline = true;
                                 println!("Traces:");
-                                traces.last().expect("no last but not empty").pretty_print(
-                                    0,
-                                    &mut exec_info,
-                                    &vm,
-                                    "  ",
-                                );
+                                traces
+                                    .last()
+                                    .expect("no last but not empty")
+                                    .construct_trace_string(
+                                        0,
+                                        &mut exec_info,
+                                        &vm,
+                                        "  ",
+                                        &mut trace_string,
+                                    );
+                            }
+                            if !trace_string.is_empty() {
+                                println!("{}", trace_string);
                             }
                         }
                     }

--- a/evm-adapters/src/call_tracing.rs
+++ b/evm-adapters/src/call_tracing.rs
@@ -407,6 +407,8 @@ pub struct CallTrace {
     pub idx: usize,
     /// Successful
     pub success: bool,
+    /// Label for an address
+    pub label: Option<String>,
     /// Callee
     pub addr: H160,
     /// Creation
@@ -463,7 +465,11 @@ impl CallTrace {
                     "{}[{}] {}::{}{}({})",
                     left,
                     self.cost,
-                    color.paint(name.unwrap_or(&self.addr.to_string())),
+                    color.paint(
+                        // clippy bug makes us do this
+                        #[allow(clippy::or_fun_call)]
+                        self.label.as_ref().unwrap_or(name.unwrap_or(&self.addr.to_string()))
+                    ),
                     color.paint(func.name.clone()),
                     if self.value > 0.into() {
                         format!("{{value: {}}}", self.value)
@@ -495,7 +501,11 @@ impl CallTrace {
                 "{}[{}] {}::fallback{}()",
                 left,
                 self.cost,
-                color.paint(name.unwrap_or(&self.addr.to_string())),
+                color.paint(
+                    // clippy bug makes us do this
+                    #[allow(clippy::or_fun_call)]
+                    self.label.as_ref().unwrap_or(name.unwrap_or(&self.addr.to_string()))
+                ),
                 if self.value > 0.into() {
                     format!("{{value: {}}}", self.value)
                 } else {
@@ -518,7 +528,7 @@ impl CallTrace {
             "{}[{}] {}::{}{}({})",
             left,
             self.cost,
-            color.paint(format!("{}", self.addr)),
+            color.paint(self.label.as_ref().unwrap_or(&self.addr.to_string()).to_string()),
             if self.data.len() >= 4 {
                 hex::encode(&self.data[0..4])
             } else {

--- a/evm-adapters/src/call_tracing.rs
+++ b/evm-adapters/src/call_tracing.rs
@@ -1,5 +1,5 @@
 use ethers::{
-    abi::{Abi, Event, Function, RawLog},
+    abi::{Abi, Event, Function, RawLog, Token},
     types::{H160, H256, U256},
 };
 use serde::{Deserialize, Serialize};
@@ -30,6 +30,20 @@ impl Default for CallTraceArena {
     }
 }
 
+// Gets pretty print strings for tokens
+pub fn format_labeled_token(param: &Token, exec_info: &ExecutionInfo<'_>) -> String {
+    match param {
+        Token::Address(addr) => {
+            if let Some(label) = exec_info.labeled_addrs.get(addr) {
+                format!("{} [{:?}]", label, addr)
+            } else {
+                format_token(param)
+            }
+        }
+        _ => format_token(param),
+    }
+}
+
 /// Function output type
 pub enum Output {
     /// Decoded vec of tokens
@@ -42,6 +56,7 @@ pub enum Output {
 pub struct ExecutionInfo<'a> {
     pub contracts: &'a BTreeMap<String, (Abi, Vec<u8>)>,
     pub identified_contracts: &'a mut BTreeMap<H160, (String, Abi)>,
+    pub labeled_addrs: &'a BTreeMap<H160, String>,
     pub funcs: &'a BTreeMap<[u8; 4], Function>,
     pub events: &'a BTreeMap<H256, Event>,
     pub errors: &'a Abi,
@@ -51,30 +66,40 @@ impl<'a> ExecutionInfo<'a> {
     pub fn new(
         contracts: &'a BTreeMap<String, (Abi, Vec<u8>)>,
         identified_contracts: &'a mut BTreeMap<H160, (String, Abi)>,
+        labeled_addrs: &'a BTreeMap<H160, String>,
         funcs: &'a BTreeMap<[u8; 4], Function>,
         events: &'a BTreeMap<H256, Event>,
         errors: &'a Abi,
     ) -> Self {
-        Self { contracts, identified_contracts, funcs, events, errors }
+        Self { contracts, identified_contracts, labeled_addrs, funcs, events, errors }
     }
 }
 
 impl Output {
-    /// Prints the output of a function call
-    pub fn print(self, color: Colour, left: &str) {
+    pub fn construct_string<'a, 'b>(
+        self,
+        exec_info: &'b ExecutionInfo<'a>,
+        color: Colour,
+        left: &str,
+        full_str: &mut String,
+    ) {
         match self {
             Output::Token(token) => {
-                let strings = token.iter().map(format_token).collect::<Vec<_>>().join(", ");
-                println!(
-                    "{}  └─ {} {}",
+                let strings = token
+                    .iter()
+                    .map(|token| format_labeled_token(token, exec_info))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                full_str.push_str(&*format!(
+                    "\n{}  └─ {} {}",
                     left.replace("├─", "│").replace("└─", "  "),
                     color.paint("←"),
                     if strings.is_empty() { "()" } else { &*strings }
-                );
+                ));
             }
             Output::Raw(bytes) => {
-                println!(
-                    "{}  └─ {} {}",
+                full_str.push_str(&*format!(
+                    "\n{}  └─ {} {}",
                     left.replace("├─", "│").replace("└─", "  "),
                     color.paint("←"),
                     if bytes.is_empty() {
@@ -82,7 +107,7 @@ impl Output {
                     } else {
                         "0x".to_string() + &hex::encode(&bytes)
                     }
-                );
+                ));
             }
         }
     }
@@ -181,7 +206,7 @@ impl CallTraceArena {
         });
     }
 
-    /// Pretty print a CallTraceArena
+    /// Construct a CallTraceArena trace string
     ///
     /// `idx` is the call arena index to start at. Generally this will be 0, but if you want to
     /// print a subset of the tree, you can pass in a different index
@@ -198,12 +223,13 @@ impl CallTraceArena {
     ///
     /// For a user, `left` input should generally be `""`. Left is used recursively
     /// to build the tree print out structure and is built up as we recurse down the tree.
-    pub fn pretty_print<'a, S: Clone, E: crate::Evm<S>>(
+    pub fn construct_trace_string<'a, S: Clone, E: crate::Evm<S>>(
         &self,
         idx: usize,
         exec_info: &mut ExecutionInfo<'a>,
         evm: &'a E,
         left: &str,
+        full_str: &mut String,
     ) {
         let trace = &self.arena[idx].trace;
 
@@ -248,72 +274,98 @@ impl CallTraceArena {
                 // found matching contract, insert and print
                 exec_info.identified_contracts.insert(trace.addr, (name.to_string(), abi.clone()));
                 if trace.created {
-                    println!("{}{} {}@{}", left, Colour::Yellow.paint("→ new"), name, trace.addr);
-                    self.print_children_and_logs(idx, exec_info, evm, left);
-                    println!(
-                        "{}  └─ {} {} bytes of code",
+                    full_str.push_str(&*format!(
+                        "\n{}{} {}@{}",
+                        left,
+                        Colour::Yellow.paint("→ new"),
+                        name,
+                        trace.addr
+                    ));
+                    self.construct_children_and_logs(idx, exec_info, evm, left, full_str);
+                    full_str.push_str(&*format!(
+                        "\n{}  └─ {} {} bytes of code",
                         left.replace("├─", "│").replace("└─", "  "),
                         color.paint("←"),
                         trace.output.len()
-                    );
+                    ));
                 } else {
                     // re-enter this function at the current node
-                    self.pretty_print(idx, exec_info, evm, left);
+                    self.construct_trace_string(idx, exec_info, evm, left, full_str);
                 }
             } else if trace.created {
                 // we couldn't identify, print the children and logs without the abi
-                println!("{}{} <Unknown>@{}", left, Colour::Yellow.paint("→ new"), trace.addr);
-                self.print_children_and_logs(idx, exec_info, evm, left);
-                println!(
-                    "{}  └─ {} {} bytes of code",
+                full_str.push_str(&*format!(
+                    "\n{}{} <Unknown>@{}",
+                    left,
+                    Colour::Yellow.paint("→ new"),
+                    trace.addr
+                ));
+                self.construct_children_and_logs(idx, exec_info, evm, left, full_str);
+                full_str.push_str(&*format!(
+                    "\n{}  └─ {} {} bytes of code",
                     left.replace("├─", "│").replace("└─", "  "),
                     color.paint("←"),
                     trace.output.len()
-                );
+                ));
             } else {
-                let output = trace.print_func_call(exec_info, None, color, left);
-                self.print_children_and_logs(idx, exec_info, evm, left);
-                output.print(color, left);
+                let output = trace.construct_func_call(exec_info, None, color, left, full_str);
+                self.construct_children_and_logs(idx, exec_info, evm, left, full_str);
+                output.construct_string(exec_info, color, left, full_str);
             }
         } else if let Some((name, _abi)) = res {
             if trace.created {
-                println!("{}{} {}@{}", left, Colour::Yellow.paint("→ new"), name, trace.addr);
-                self.print_children_and_logs(idx, exec_info, evm, left);
-                println!(
-                    "{}  └─ {} {} bytes of code",
+                full_str.push_str(&*format!(
+                    "\n{}{} {}@{}",
+                    left,
+                    Colour::Yellow.paint("→ new"),
+                    name,
+                    trace.addr
+                ));
+                self.construct_children_and_logs(idx, exec_info, evm, left, full_str);
+                full_str.push_str(&*format!(
+                    "\n{}  └─ {} {} bytes of code",
                     left.replace("├─", "│").replace("└─", "  "),
                     color.paint("←"),
                     trace.output.len()
-                );
+                ));
             } else {
-                let output = trace.print_func_call(exec_info, Some(&name), color, left);
-                self.print_children_and_logs(idx, exec_info, evm, left);
-                output.print(color, left);
+                let output =
+                    trace.construct_func_call(exec_info, Some(&name), color, left, full_str);
+                self.construct_children_and_logs(idx, exec_info, evm, left, full_str);
+                output.construct_string(exec_info, color, left, full_str);
             }
         }
     }
 
     /// Prints child calls and logs in order
-    pub fn print_children_and_logs<'a, S: Clone, E: crate::Evm<S>>(
+    pub fn construct_children_and_logs<'a, S: Clone, E: crate::Evm<S>>(
         &self,
         node_idx: usize,
         exec_info: &mut ExecutionInfo<'a>,
         evm: &'a E,
         left: &str,
+        full_str: &mut String,
     ) {
         // Ordering stores a vec of `LogCallOrder` which is populated based on if
         // a log or a call was called first. This makes it such that we always print
         // logs and calls in the correct order
         self.arena[node_idx].ordering.iter().for_each(|ordering| match ordering {
             LogCallOrder::Log(index) => {
-                self.arena[node_idx].print_log(*index, exec_info.events, left);
+                self.arena[node_idx].construct_log(
+                    exec_info,
+                    *index,
+                    exec_info.events,
+                    left,
+                    full_str,
+                );
             }
             LogCallOrder::Call(index) => {
-                self.pretty_print(
+                self.construct_trace_string(
                     self.arena[node_idx].children[*index],
                     exec_info,
                     evm,
                     &(left.replace("├─", "│").replace("└─", "  ") + "  ├─ "),
+                    full_str,
                 );
             }
         });
@@ -340,7 +392,14 @@ pub struct CallTraceNode {
 
 impl CallTraceNode {
     /// Prints a log at a particular index, optionally decoding if abi is provided
-    pub fn print_log(&self, index: usize, events: &BTreeMap<H256, Event>, left: &str) {
+    pub fn construct_log<'a, 'b>(
+        &self,
+        exec_info: &'b ExecutionInfo<'a>,
+        index: usize,
+        events: &BTreeMap<H256, Event>,
+        left: &str,
+        full_str: &mut String,
+    ) {
         let log = &self.logs[index];
         let right = "  ├─ ";
 
@@ -349,15 +408,17 @@ impl CallTraceNode {
                 let params = parsed.params;
                 let strings = params
                     .into_iter()
-                    .map(|param| format!("{}: {}", param.name, format_token(&param.value)))
+                    .map(|param| {
+                        format!("{}: {}", param.name, format_labeled_token(&param.value, exec_info))
+                    })
                     .collect::<Vec<String>>()
                     .join(", ");
-                println!(
-                    "{}emit {}({})",
+                full_str.push_str(&*format!(
+                    "\n{}emit {}({})",
                     left.replace("├─", "│") + right,
                     Colour::Cyan.paint(event.name.clone()),
                     strings
-                );
+                ));
                 return
             }
         }
@@ -369,8 +430,8 @@ impl CallTraceNode {
             } else {
                 "  ├─"
             };
-            println!(
-                "{}{}topic {}: {}",
+            full_str.push_str(&*format!(
+                "\n{}{}topic {}: {}",
                 if i == 0 {
                     left.replace("├─", "│") + right
                 } else {
@@ -379,13 +440,13 @@ impl CallTraceNode {
                 if i == 0 { " emit " } else { "      " },
                 i,
                 Colour::Cyan.paint(format!("0x{}", hex::encode(&topic)))
-            )
+            ))
         }
-        println!(
-            "{}        data: {}",
+        full_str.push_str(&*format!(
+            "\n{}        data: {}",
             left.replace("├─", "│").replace("└─", "  ") + "  │  ",
             Colour::Cyan.paint(format!("0x{}", hex::encode(&log.data)))
-        )
+        ))
     }
 }
 
@@ -435,12 +496,13 @@ impl CallTrace {
     }
 
     /// Prints function call, returning the decoded or raw output
-    pub fn print_func_call<'a>(
+    pub fn construct_func_call<'a>(
         &self,
         exec_info: &mut ExecutionInfo<'a>,
         name: Option<&String>,
         color: Colour,
         left: &str,
+        full_str: &mut String,
     ) -> Output {
         // Is data longer than 4, meaning we can attempt to decode it
         if self.data.len() >= 4 {
@@ -448,7 +510,11 @@ impl CallTrace {
                 let mut strings = "".to_string();
                 if !self.data[4..].is_empty() {
                     let params = func.decode_input(&self.data[4..]).expect("Bad func data decode");
-                    strings = params.iter().map(format_token).collect::<Vec<_>>().join(", ");
+                    strings = params
+                        .iter()
+                        .map(|token| format_labeled_token(token, exec_info))
+                        .collect::<Vec<_>>()
+                        .join(", ");
 
                     #[cfg(feature = "sputnik")]
                     if self.addr == *CHEATCODE_ADDRESS && func.name == "expectRevert" {
@@ -461,8 +527,8 @@ impl CallTrace {
                     }
                 }
 
-                println!(
-                    "{}[{}] {}::{}{}({})",
+                full_str.push_str(&*format!(
+                    "\n{}[{}] {}::{}{}({})",
                     left,
                     self.cost,
                     color.paint(
@@ -477,7 +543,7 @@ impl CallTrace {
                         "".to_string()
                     },
                     strings,
-                );
+                ));
 
                 if !self.output.is_empty() && self.success {
                     return Output::Token(
@@ -497,8 +563,8 @@ impl CallTrace {
             }
         } else {
             // fallback function
-            println!(
-                "{}[{}] {}::fallback{}()",
+            full_str.push_str(&*format!(
+                "\n{}[{}] {}::fallback{}()",
                 left,
                 self.cost,
                 color.paint(
@@ -511,7 +577,7 @@ impl CallTrace {
                 } else {
                     "".to_string()
                 }
-            );
+            ));
 
             if !self.success {
                 if let Ok(decoded_error) =
@@ -524,8 +590,8 @@ impl CallTrace {
         }
 
         // We couldn't decode the function call, so print it as an abstract call
-        println!(
-            "{}[{}] {}::{}{}({})",
+        full_str.push_str(&*format!(
+            "\n{}[{}] {}::{}{}({})",
             left,
             self.cost,
             color.paint(self.label.as_ref().unwrap_or(&self.addr.to_string()).to_string()),
@@ -544,7 +610,7 @@ impl CallTrace {
             } else {
                 hex::encode(&vec![][..])
             },
-        );
+        ));
 
         if !self.success {
             if let Ok(decoded_error) =

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -2146,8 +2146,12 @@ mod tests {
         );
         let mut identified = Default::default();
         let (funcs, events, errors) = foundry_utils::flatten_known_contracts(&mapping);
-        let mut exec_info = ExecutionInfo::new(&mapping, &mut identified, &funcs, &events, &errors);
-        evm.traces()[1].pretty_print(0, &mut exec_info, &evm, "");
+        let labels = BTreeMap::new();
+        let mut exec_info =
+            ExecutionInfo::new(&mapping, &mut identified, &labels, &funcs, &events, &errors);
+        let mut trace_string = "".to_string();
+        evm.traces()[1].construct_trace_string(0, &mut exec_info, &evm, "", &mut trace_string);
+        println!("{}", trace_string);
     }
 
     #[test]
@@ -2207,7 +2211,11 @@ mod tests {
         );
         let mut identified = Default::default();
         let (funcs, events, errors) = foundry_utils::flatten_known_contracts(&mapping);
-        let mut exec_info = ExecutionInfo::new(&mapping, &mut identified, &funcs, &events, &errors);
-        evm.traces()[1].pretty_print(0, &mut exec_info, &evm, "");
+        let labels = BTreeMap::new();
+        let mut exec_info =
+            ExecutionInfo::new(&mapping, &mut identified, &labels, &funcs, &events, &errors);
+        let mut trace_string = "".to_string();
+        evm.traces()[1].construct_trace_string(0, &mut exec_info, &evm, "", &mut trace_string);
+        println!("{}", trace_string);
     }
 }

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -867,6 +867,13 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 self.add_debug(CheatOp::EXPECTCALL);
                 self.state_mut().expected_calls.entry(inner.0).or_default().push(inner.1.to_vec());
             }
+            HEVMCalls::Label(inner) => {
+                self.add_debug(CheatOp::LABEL);
+                let address = inner.0;
+                let label = inner.1;
+
+                self.state_mut().labels.insert(address, label);
+            }
         };
 
         self.fill_trace(&trace, true, Some(res.clone()), pre_index);
@@ -1089,6 +1096,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 created: creation,
                 data: input,
                 value: transfer,
+                label: self.state().labels.get(&address).cloned(),
                 ..Default::default()
             };
 

--- a/evm-adapters/src/sputnik/cheatcodes/debugger.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/debugger.rs
@@ -179,6 +179,7 @@ pub enum CheatOp {
     CLEARMOCKEDCALLS,
     EXPECTCALL,
     GETCODE,
+    LABEL,
 }
 
 impl From<CheatOp> for OpCode {
@@ -212,6 +213,7 @@ impl CheatOp {
             CheatOp::CLEARMOCKEDCALLS => "VM_CLEARMOCKEDCALLS",
             CheatOp::EXPECTCALL => "VM_EXPECTCALL",
             CheatOp::GETCODE => "VM_GETCODE",
+            CheatOp::LABEL => "VM_LABEL",
         }
     }
 }

--- a/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/memory_stackstate_owned.rs
@@ -77,6 +77,8 @@ pub struct MemoryStackStateOwned<'config, B> {
     pub debug_steps: Vec<DebugArena>,
     /// Instruction pointers that maps an address to a mapping of pc to ic
     pub debug_instruction_pointers: Dip,
+    /// Labels for an address in call traces
+    pub labels: BTreeMap<H160, String>,
 }
 
 impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
@@ -143,6 +145,7 @@ impl<'config, B: Backend> MemoryStackStateOwned<'config, B> {
             debug_enabled,
             debug_steps: vec![Default::default()],
             debug_instruction_pointers: (BTreeMap::new(), BTreeMap::new()),
+            labels: BTreeMap::new(),
         }
     }
 }

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -72,6 +72,7 @@ ethers::contract::abigen!(
             clearMockedCalls()
             expectCall(address,bytes)
             getCode(string)
+            label(address,string)
     ]"#,
 );
 pub use hevm_mod::{HEVMCalls, HEVM_ABI};

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -593,6 +593,12 @@ contract CheatCodes is DSTest {
         bob.call{value: 100}("");
     }
 
+    function testLabelInputReturn() public {
+        Label labeled = new Label();
+        hevm.label(address(labeled), "MyCustomLabel");
+        labeled.withInput(address(labeled));
+    }
+
     function getCode(address who) internal returns (bytes memory o_code) {
         assembly {
             // retrieve the size of the code, this needs assembly
@@ -607,6 +613,12 @@ contract CheatCodes is DSTest {
             // actually retrieve the code, this needs assembly
             extcodecopy(who, add(o_code, 0x20), 0, size)
         }
+    }
+}
+
+contract Label {
+    function withInput(address labeled) public pure returns (address) {
+        return labeled;
     }
 }
 

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -57,8 +57,10 @@ interface Hevm {
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
     function expectCall(address,bytes calldata) external;
-
+    // Gets the code from an artifact file. Takes in the relative path to the json file
     function getCode(string calldata) external returns (bytes memory);
+    // Labels an address in call traces
+    function label(address, string calldata) external;
 }
 
 contract HasStorage {
@@ -583,6 +585,12 @@ contract CheatCodes is DSTest {
             string(contractCode),
             string(bytes(hex"608060405234801561001057600080fd5b5060b68061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80637ddeef2414602d575b600080fd5b60336047565b604051603e91906067565b60405180910390f35b60006007905090565b6000819050919050565b6061816050565b82525050565b6000602082019050607a6000830184605a565b9291505056fea2646970667358221220521a806ba8927fda1a9b7bf0458b0a0abf456e4611953e01489bee91783418b064736f6c634300080a0033"))
         );
+    }
+
+    function testLabel() public {
+        address bob = address(1337);
+        hevm.label(bob, "bob");
+        bob.call{value: 100}("");
     }
 
     function getCode(address who) internal returns (bytes memory o_code) {

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -75,6 +75,9 @@ pub struct TestResult {
     /// Debug Steps
     #[serde(skip)]
     pub debug_calls: Option<Vec<DebugArena>>,
+
+    /// Labeled addresses
+    pub labeled_addresses: BTreeMap<Address, String>,
 }
 
 impl TestResult {
@@ -326,6 +329,7 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
                         } else {
                             None
                         },
+                        labeled_addresses: evm.state().labels.clone(),
                     })
                 }
             };
@@ -380,6 +384,7 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
             traces,
             identified_contracts,
             debug_calls: if evm.state().debug_enabled { Some(evm.debug_calls()) } else { None },
+            labeled_addresses: evm.state().labels.clone(),
         })
     }
 
@@ -435,6 +440,7 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
                         } else {
                             None
                         },
+                        labeled_addresses: evm.state().labels.clone(),
                     })
                 }
             }
@@ -508,6 +514,7 @@ impl<'a, B: Backend + Clone + Send + Sync> ContractRunner<'a, B> {
             traces,
             identified_contracts,
             debug_calls: if evm.state().debug_enabled { Some(evm.debug_calls()) } else { None },
+            labeled_addresses: evm.state().labels.clone(),
         })
     }
 


### PR DESCRIPTION
Adds a `label(address,string)` cheatcode that allows users to label an address for use in stack traces. Also removes contract limit in `run` command.

Closes #553 