### PR TITLE
feat: cast client

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -165,6 +165,10 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).chain_id().await?);
         }
+        Subcommands::Client { rpc_url } => {
+            let provider = Provider::try_from(rpc_url)?;
+            println!("{}", provider.client_version().await?);
+        }
         Subcommands::Code { block, who, rpc_url } => {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).code(who, block).await?);

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -138,6 +138,12 @@ pub enum Subcommands {
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
+    #[clap(name = "client")]
+    #[clap(about = "returns the current client version")]
+    Client {
+        #[clap(long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+    },
     #[clap(name = "namehash")]
     #[clap(about = "returns ENS namehash of provided name")]
     Namehash { name: String },


### PR DESCRIPTION
Adds `cast client` to return details on the current client version, analogous to [`seth client`](https://github.com/dapphub/dapptools/blob/master/src/seth/libexec/seth/seth-client)