### PR TITLE
feat(forge): add gas reports for tests

### DIFF
--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -25,6 +25,7 @@ pub struct Filter {
 
     #[clap(
         long = "match-test",
+        alias = "mt",
         help = "only run test methods matching regex",
         conflicts_with = "pattern"
     )]
@@ -32,6 +33,7 @@ pub struct Filter {
 
     #[clap(
         long = "no-match-test",
+        alias = "nmt",
         help = "only run test methods not matching regex",
         conflicts_with = "pattern"
     )]
@@ -39,6 +41,7 @@ pub struct Filter {
 
     #[clap(
         long = "match-contract",
+        alias = "mc",
         help = "only run test methods in contracts matching regex",
         conflicts_with = "pattern"
     )]
@@ -46,6 +49,7 @@ pub struct Filter {
 
     #[clap(
         long = "no-match-contract",
+        alias = "nmc",
         help = "only run test methods in contracts not matching regex",
         conflicts_with = "pattern"
     )]

--- a/config/README.md
+++ b/config/README.md
@@ -69,6 +69,7 @@ libraries = []
 cache = true
 force = false
 evm_version = 'london'
+gas_reports = ["*"]
 ## Sets the concrete solc version to use, this overrides the `auto_detect_solc` value
 # solc_version = '0.8.10'
 auto_detect_solc = true

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -91,6 +91,8 @@ pub struct Config {
     /// evm version to use
     #[serde(with = "from_str_lowercase")]
     pub evm_version: EvmVersion,
+    /// list of contracts to report gas of
+    pub gas_reports: Vec<String>,
     /// Concrete solc version to use if any.
     ///
     /// This takes precedence over `auto_detect_solc`, if a version is set then this overrides
@@ -638,6 +640,7 @@ impl Default for Config {
             cache: true,
             force: false,
             evm_version: Default::default(),
+            gas_reports: vec![],
             solc_version: None,
             auto_detect_solc: true,
             optimizer: true,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -640,7 +640,7 @@ impl Default for Config {
             cache: true,
             force: false,
             evm_version: Default::default(),
-            gas_reports: vec![],
+            gas_reports: vec!["*".to_string()],
             solc_version: None,
             auto_detect_solc: true,
             optimizer: true,

--- a/evm-adapters/Cargo.toml
+++ b/evm-adapters/Cargo.toml
@@ -29,6 +29,7 @@ revm_precompiles = { git = "https://github.com/bluealloy/revm", default-features
 serde_json = "1.0.72"
 serde = "1.0.130"
 ansi_term = "0.12.1"
+comfy-table = "5.0.0"
 
 [dev-dependencies]
 evmodin = { git = "https://github.com/vorot93/evmodin", features = ["util"] }

--- a/evm-adapters/src/gas_report.rs
+++ b/evm-adapters/src/gas_report.rs
@@ -40,7 +40,7 @@ impl GasReport {
         traces: &[CallTraceArena],
         identified_contracts: &BTreeMap<H160, (String, Abi)>,
     ) {
-        let report_for_all = self.report_for.iter().any(|s| s == "*");
+        let report_for_all = self.report_for.is_empty() || self.report_for.iter().any(|s| s == "*");
         traces.iter().for_each(|trace| {
             self.analyze_trace(trace, identified_contracts, report_for_all);
         });

--- a/evm-adapters/src/gas_report.rs
+++ b/evm-adapters/src/gas_report.rs
@@ -1,0 +1,145 @@
+use crate::CallTraceArena;
+use ethers::{
+    abi::Abi,
+    types::{H160, U256},
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, fmt::Display};
+
+use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, *};
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct GasReport {
+    pub report_for: Vec<String>,
+    pub contracts: BTreeMap<String, ContractInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ContractInfo {
+    pub gas: U256,
+    pub size: U256,
+    pub functions: BTreeMap<String, GasInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GasInfo {
+    pub calls: Vec<U256>,
+    pub min: U256,
+    pub mean: U256,
+    pub median: U256,
+    pub max: U256,
+}
+
+impl GasReport {
+    pub fn new(report_for: Vec<String>) -> Self {
+        Self { report_for, ..Default::default() }
+    }
+
+    pub fn analyze(
+        &mut self,
+        traces: &[CallTraceArena],
+        identified_contracts: &BTreeMap<H160, (String, Abi)>,
+    ) {
+        let report_for_all = self.report_for.iter().any(|s| s == "*");
+        traces.iter().for_each(|trace| {
+            self.analyze_trace(trace, identified_contracts, report_for_all);
+        });
+    }
+
+    fn analyze_trace(
+        &mut self,
+        trace: &CallTraceArena,
+        identified_contracts: &BTreeMap<H160, (String, Abi)>,
+        report_for_all: bool,
+    ) {
+        self.analyze_node(trace.entry, trace, identified_contracts, report_for_all);
+    }
+
+    fn analyze_node(
+        &mut self,
+        node_index: usize,
+        arena: &CallTraceArena,
+        identified_contracts: &BTreeMap<H160, (String, Abi)>,
+        report_for_all: bool,
+    ) {
+        let node = &arena.arena[node_index];
+        let trace = &node.trace;
+        if let Some((name, abi)) = identified_contracts.get(&trace.addr) {
+            if self.report_for.iter().any(|s| s == name) || report_for_all {
+                // report for this contract
+                let mut contract =
+                    self.contracts.entry(name.to_string()).or_insert_with(Default::default);
+
+                if trace.created {
+                    contract.gas = trace.cost.into();
+                    contract.size = trace.data.len().into();
+                } else {
+                    let func =
+                        abi.functions().find(|func| func.short_signature() == trace.data[0..4]);
+
+                    if let Some(func) = func {
+                        let function = contract
+                            .functions
+                            .entry(func.name.clone())
+                            .or_insert_with(Default::default);
+                        function.calls.push(trace.cost.into());
+                    }
+                }
+            }
+        }
+        node.children.iter().for_each(|index| {
+            self.analyze_node(*index, arena, identified_contracts, report_for_all);
+        });
+    }
+
+    pub fn finalize(&mut self) {
+        self.contracts.iter_mut().for_each(|(_name, contract)| {
+            contract.functions.iter_mut().for_each(|(_name, func)| {
+                func.calls.sort();
+                func.min = func.calls.first().cloned().unwrap_or_default();
+                func.max = func.calls.last().cloned().unwrap_or_default();
+                func.mean =
+                    func.calls.iter().fold(U256::zero(), |acc, x| acc + x) / func.calls.len();
+                func.median = func.calls[func.calls.len() / 2];
+            });
+        });
+    }
+}
+
+impl Display for GasReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        for (name, contract) in self.contracts.iter() {
+            let mut table = Table::new();
+            table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+            table.set_header(vec![Cell::new(format!("{} contract", name))
+                .add_attribute(Attribute::Bold)
+                .fg(Color::Green)]);
+            table.add_row(vec![
+                Cell::new("Deployment Cost").add_attribute(Attribute::Bold).fg(Color::Cyan),
+                Cell::new("Deployment Size").add_attribute(Attribute::Bold).fg(Color::Cyan),
+            ]);
+            table.add_row(vec![contract.gas.to_string(), contract.size.to_string()]);
+
+            table.add_row(vec![
+                Cell::new("Function Name").add_attribute(Attribute::Bold).fg(Color::Magenta),
+                Cell::new("min").add_attribute(Attribute::Bold).fg(Color::Green),
+                Cell::new("avg").add_attribute(Attribute::Bold).fg(Color::Yellow),
+                Cell::new("median").add_attribute(Attribute::Bold).fg(Color::Yellow),
+                Cell::new("max").add_attribute(Attribute::Bold).fg(Color::Red),
+                Cell::new("# calls").add_attribute(Attribute::Bold),
+            ]);
+            contract.functions.iter().for_each(|(fname, function)| {
+                table.add_row(vec![
+                    Cell::new(fname.to_string()).add_attribute(Attribute::Bold),
+                    Cell::new(function.min.to_string()).fg(Color::Green),
+                    Cell::new(function.mean.to_string()).fg(Color::Yellow),
+                    Cell::new(function.median.to_string()).fg(Color::Yellow),
+                    Cell::new(function.max.to_string()).fg(Color::Red),
+                    Cell::new(function.calls.len().to_string()),
+                ]);
+            });
+            writeln!(f, "{}", table)?
+        }
+        Ok(())
+    }
+}

--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -18,6 +18,8 @@ pub mod fuzz;
 
 pub mod call_tracing;
 
+pub mod gas_report;
+
 /// Helpers for easily constructing EVM objects.
 pub mod evm_opts;
 


### PR DESCRIPTION
Adds `--gas-report` flag to `forge test`.

Adds `gas_reports` into `foundry.toml` which lets the user specify which contracts they want gas reports for, i.e:
```toml
gas_reports = ["MyContract", "MyContractFactory"]
```
or to produce a report for everything:
```toml
gas_reports = ["*"]
```

then if the user does `forge test --gas-report` they will get an output like:
![image](https://user-images.githubusercontent.com/31553173/151711055-560dbf7c-bee0-42dd-9298-3fcefa14f265.png)


Note: the colors you see here are a bit different than what may show up for you. My terminal theme is a bit off and it shows green as yellow and yellow as green.

Partially addresses #137 