### PR TITLE
feat/forge: add extra output types to config and CompilerArgs on build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1264,7 +1264,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1275,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1316,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1358,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#67f7dc017d1f03c0f70b6173f6a20f3c41dc1311"
+source = "git+https://github.com/gakonst/ethers-rs#dd915c99f6f2f4a169eb61de8b425579b7e9d429"
 dependencies = [
  "colored",
  "dunce",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "solang-parser"
 version = "0.1.1"
-source = "git+https://github.com/hyperledger-labs/solang#dd1aa90240078f1834573308b61a7418996d9795"
+source = "git+https://github.com/hyperledger-labs/solang#16d124657b2b832269e2249f9489e0a5188203ba"
 dependencies = [
  "lalrpop",
  "lalrpop-util",

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -209,6 +209,10 @@ impl Provider for BuildArgs {
             dict.insert("optimizer".to_string(), self.compiler.optimize.into());
         }
 
+        if let Some(extra) = &self.compiler.extra_output {
+            dict.insert("extra_output".to_string(), extra.clone().into());
+        }
+
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -120,7 +120,7 @@ pub struct CompilerArgs {
     pub optimize_runs: Option<usize>,
 
     #[clap(
-        help = "extra output types [evm.assembly, ewasm, ir, irOptimized] eg: `--extra-output asm`",
+        help = "extra output types [evm.assembly, ewasm, ir, irOptimized] eg: `--extra-output evm.assembly`",
         long
     )]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -118,6 +118,13 @@ pub struct CompilerArgs {
     #[clap(help = "optimizer parameter runs", long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optimize_runs: Option<usize>,
+
+    #[clap(
+        help = "extra output types [evm.assembly, ewasm, ir, irOptimized] eg: `--extra-output asm`",
+        long
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_output: Option<Vec<String>>,
 }
 
 /// Represents the common dapp argument pattern for `<path>:<contractname>` where `<path>:` is

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -416,7 +416,8 @@ impl Config {
             libraries,
             output_selection,
             ..Default::default()
-        }).with_ast())
+        })
+        .with_ast())
     }
 
     /// Returns the default figment

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -388,24 +388,16 @@ impl Config {
     }
 
     pub fn output_selection(&self) -> BTreeMap<String, BTreeMap<String, Vec<String>>> {
-        let mut outputs = vec![
-            "abi".to_string(),
-            "evm.bytecode".to_string(),
-            "evm.deployedBytecode".to_string(),
-            "evm.methodIdentifiers".to_string(),
-        ];
+        let mut output_selection = Settings::default_output_selection();
 
         if let Some(extras) = &self.extra_output {
-            outputs.extend_from_slice(extras.as_slice());
+            output_selection.entry("*".to_string()).and_modify(|e1| {
+                e1.entry("*".to_string()).and_modify(|e2| {
+                    e2.extend_from_slice(extras.as_slice());
+                });
+            });
         }
 
-        let mut output_selection = BTreeMap::default();
-        let mut output = BTreeMap::default();
-
-        output.insert("*".to_string(), outputs);
-        output.insert("".to_string(), vec!["ast".to_string()]);
-
-        output_selection.insert("*".to_string(), output);
         output_selection
     }
 
@@ -418,13 +410,13 @@ impl Config {
         let optimizer = self.optimizer();
         let output_selection = self.output_selection();
 
-        Ok(Settings {
+        Ok((Settings {
             optimizer,
             evm_version: Some(self.evm_version),
             libraries,
             output_selection,
             ..Default::default()
-        })
+        }).with_ast())
     }
 
     /// Returns the default figment


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ref #611 
It prints into `out/Contract.sol/` the requested output type[s].

~~Requires PR: https://github.com/gakonst/ethers-rs/pull/847~~

---
Usage:

foundry.toml:
```
[default]
optimizer = true
optimizer_runs = 1_000_000
extra_output = ["ir", "ewasm", "irOptimized", "evm.assembly"]
```
or
```
forge build --extra-output evm.assembly --extra-output ir --extra-output irOptimized --extra-output ewasm
```

`$ ls out/C.sol/`
```
C.asm  C.ewasm  C.ir  C.iropt  C.json  ERC20.asm  ERC20.ewasm  ERC20.ir  ERC20.iropt  ERC20.json  VM.asm  VM.ewasm  VM.ir  VM.iropt  VM.json
```


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
