### PR TITLE
feat(config): add foundry dir and check for global foundry.toml

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/gakonst/foundry"
 readme = "README.md"
 
 [dependencies]
-dirs-next = "2.0"
+dirs-next = "2.0.0"
 semver = { version = "1.0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"

--- a/config/README.md
+++ b/config/README.md
@@ -14,8 +14,9 @@ in `FOUNDRY_PROFILE`.
 
 Foundry's tools search for a `foundry.toml`  or the filename in a `FOUNDRY_CONFIG` environment variable starting at the
 current working directory. If it is not found, the parent directory, its parent directory, and so on are searched until
-the file is found or the root is reached. The typical location for the global `foundry.toml` would be `~/foundry.toml`.
-If the path set in `FOUNDRY_CONFIG` is absolute, no such search takes place and the absolute path is used directly.
+the file is found or the root is reached. But the typical location for the global `foundry.toml` would
+be `~/.foundry/foundry.toml`, which is also checked. If the path set in `FOUNDRY_CONFIG` is absolute, no such search
+takes place and the absolute path is used directly.
 
 In `foundry.toml` you can define multiple profiles, therefore the file is assumed to be _nested_, so each top-level key
 declares a profile and its values configure the profile.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
* Introduce `~/.foundry` as global config dir
* Support `~/.foundry/foundry.toml` 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
if `~/.foundry/foundry.toml` exist, merge in into the `Figment`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
