### PR TITLE
feat/cast: cast send ether without specify function sig

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -186,6 +186,7 @@ async fn main() -> eyre::Result<()> {
         Subcommands::SendTx { eth, to, sig, cast_async, args, gas, value, nonce, legacy } => {
             let provider = Provider::try_from(eth.rpc_url()?)?;
             let chain_id = Cast::new(&provider).chain_id().await?;
+            let sig = sig.unwrap_or_default();
 
             if let Some(signer) = eth.signer_with(chain_id, provider.clone()).await? {
                 match signer {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -188,7 +188,7 @@ pub enum Subcommands {
         #[clap(help = "the address you want to transact with", parse(try_from_str = parse_name_or_address))]
         to: NameOrAddress,
         #[clap(help = "the function signature or name you want to call")]
-        sig: String,
+        sig: Option<String>,
         #[clap(help = "the list of arguments you want to call the function with")]
         args: Vec<String>,
         #[clap(long, help = "gas quantity for the transaction", parse(try_from_str = parse_u256))]


### PR DESCRIPTION
now we don't need to specify the function sig to send ether value 

```bash
target/debug/cast send $addr --mnemonic-path ~/mnemonic.txt --value 0.001ether
target/debug/cast send $addr "test()" --mnemonic-path ~/mnemonic.txt --value 0.001ether
target/debug/cast send $addr "test(uint256,bool)" 1 true --mnemonic-path ~/mnemonic.txt --value 0.001ether 
```