### PR TITLE
feature: bind precondition & empty checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
  "foundry-utils",
  "glob",
  "hex",
+ "locate-cargo-manifest",
  "once_cell",
  "pretty_assertions",
  "proptest",
@@ -2182,6 +2183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "k256"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2289,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "locate-cargo-manifest"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db985b63431fe09e8d71f50aeceffcc31e720cb86be8dad2f38d084c5a328466"
+dependencies = [
+ "json",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,7 @@ proptest = "1.0.0"
 glob = "0.3.0"
 semver = "1.0.4"
 once_cell = "1.9.0"
+locate-cargo-manifest = "0.2.2"
 
 [dev-dependencies]
 foundry-cli-test-utils = { path = "./test-utils" }


### PR DESCRIPTION
## Motivation

- Running bind in an unbuilt project generated no output with no message.
- Running bind outside of a cargo project panicked with no helpful message.

## Solution

- add an emptiness check that generates a helpful message if no artifacts are found
- add a precondition to bind that locates a cargo manifest, and displays a helpful message if none is found

