### PR TITLE
fix(forge bind): fix typo in print statement

### DIFF
--- a/cli/src/cmd/bind.rs
+++ b/cli/src/cmd/bind.rs
@@ -104,7 +104,7 @@ impl BindArgs {
     /// Check that the existing bindings match the expected abigen output
     fn check_existing_bindings(&self) -> eyre::Result<()> {
         let bindings = self.get_multi()?.build()?;
-        println!("Checkign bindings for {} contracts", bindings.len());
+        println!("Checking bindings for {} contracts", bindings.len());
         if self.gen_crate() {
             bindings.ensure_consistent_crate(
                 &self.crate_name,


### PR DESCRIPTION
Misspelling of `checking` is corrected

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Typos are bad

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fix the typo