### PR TITLE
fix(foundryup): discard any local changes when updating version via git

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -97,11 +97,10 @@ else
   REPO_PATH="${FOUNDRY_DIR}/${FOUNDRYUP_REPO}"
   
   if [ -d $REPO_PATH ]; then
-    # If the repo path exists move to it git pull and checkout the branch.
+    # If the repo path exists move to it and do a force checkout, discarding any local changes
     cd $REPO_PATH
-    git pull
-    git checkout ${FOUNDRYUP_BRANCH}
-    git pull
+    git fetch
+    git reset --hard origin/${FOUNDRYUP_BRANCH}
   else
     # Repo path did not exist, grab the author from the repo, make a directory in .foundry, cd to it and clone.
     IFS="/" read -ra AUTHOR <<< "$FOUNDRYUP_REPO"


### PR DESCRIPTION
Discard local changes when installing new version of foundry via foundryup when pulling from git.

## Motivation

`Cargo.lock` gets occasionally locally modified when building new version. Thus, when running e.g. `foundryup --branch master` next time, it causes a conflict, preventing the checkout and thus the update.

## Solution

Instead of doing a pull and checkout, it should fetch and do a force checkout (via `git reset --hard`), discarding any local changes.
