### PR TITLE
feat(cast): Implemented cast index (seth feature parity #29)

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1041,8 +1041,8 @@ impl SimpleCast {
     /// ```
     pub fn keccak(data: &str) -> Result<String> {
         let hash: String = match data.as_bytes() {
-             // If has a 0x prefix, read it as hexdata.
-             // If has no 0x prefix, read it as text
+            // If has a 0x prefix, read it as hexdata.
+            // If has no 0x prefix, read it as text
             [b'0', b'x', rest @ ..] => keccak256(hex::decode(rest)?).to_hex(),
             _ => keccak256(data).to_hex(),
         };
@@ -1136,6 +1136,33 @@ impl SimpleCast {
         }
 
         Ok(code)
+    }
+    /// Prints the slot number for the specified mapping type and input data
+    /// Uses abi_encode to pad the data to 32 bytes.
+    /// For value types v, slot number of v is keccak256(concat(h(v) , p)) where h is the padding
+    /// function and p is slot number of the mapping.
+    /// ```
+    /// # use cast::SimpleCast as Cast;
+    ///
+    /// # fn main() -> eyre::Result<()> {
+    ///    
+    ///    assert_eq!(Cast{}.index("address", "uint256" ,"0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
+    ///    assert_eq!(Cast{}.index("uint256", "uint256" ,"42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
+    /// #    Ok(())
+    /// # }
+    /// ```
+
+    pub fn index(
+        &self,
+        from_type: &str,
+        to_type: &str,
+        from_value: &str,
+        slot_number: &str,
+    ) -> Result<String> {
+        let sig = format!("x({},{})", from_type, to_type);
+        let encoded = Self::abi_encode(&sig, &[from_value, slot_number])?;
+        let location: String = Self::keccak(&encoded)?;
+        Ok(location)
     }
 }
 

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -1146,14 +1146,13 @@ impl SimpleCast {
     ///
     /// # fn main() -> eyre::Result<()> {
     ///    
-    ///    assert_eq!(Cast{}.index("address", "uint256" ,"0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
-    ///    assert_eq!(Cast{}.index("uint256", "uint256" ,"42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
+    ///    assert_eq!(Cast::index("address", "uint256" ,"0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
+    ///    assert_eq!(Cast::index("uint256", "uint256" ,"42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
     /// #    Ok(())
     /// # }
     /// ```
 
     pub fn index(
-        &self,
         from_type: &str,
         to_type: &str,
         from_value: &str,

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -315,6 +315,10 @@ async fn main() -> eyre::Result<()> {
         Subcommands::AbiEncode { sig, args } => {
             println!("{}", SimpleCast::abi_encode(&sig, &args)?);
         }
+        Subcommands::Index { from_type, to_type, from_value, slot_number } => {
+            let encoded = SimpleCast {}.index(&from_type, &to_type, &from_value, &slot_number)?;
+            println!("{}", encoded);
+        }
         Subcommands::FourByte { selector } => {
             let sigs = foundry_utils::fourbyte(&selector).await?;
             sigs.iter().for_each(|sig| println!("{}", sig.0));

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -316,7 +316,7 @@ async fn main() -> eyre::Result<()> {
             println!("{}", SimpleCast::abi_encode(&sig, &args)?);
         }
         Subcommands::Index { from_type, to_type, from_value, slot_number } => {
-            let encoded = SimpleCast {}.index(&from_type, &to_type, &from_value, &slot_number)?;
+            let encoded = SimpleCast::index(&from_type, &to_type, &from_value, &slot_number)?;
             println!("{}", encoded);
         }
         Subcommands::FourByte { selector } => {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -268,6 +268,20 @@ pub enum Subcommands {
         #[clap(allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    #[clap(name = "index")]
+    #[clap(
+        about = "Get storage slot of value from mapping type, mapping slot number and input value"
+    )]
+    Index {
+        #[clap(help = "mapping key type")]
+        from_type: String,
+        #[clap(help = "mapping value type")]
+        to_type: String,
+        #[clap(help = "the value")]
+        from_value: String,
+        #[clap(help = "storage slot of the mapping")]
+        slot_number: String,
+    },
     #[clap(name = "4byte")]
     #[clap(about = "Fetches function signatures given the selector from 4byte.directory")]
     FourByte {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Implemented `cast index`

## Solution
Right now it has the same scope and behaviour as `seth index`. If there can be a better syntax please do comment. 
Note:
- The from_type and to_type is technically not required as `cast abi-encode` ignores the function signature. 
- But `cast abi-encode` requires that the signature matches the input parameters while `seth abi-encode` doesn't. 
-  `seth abi-encode "x(address,address)" 42 42` will work but `cast  abi-encode "x(address,address)" 42 42` won't. Just some observations.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
