### PR TITLE
feat(forge compile): print compiled contract names

### DIFF
--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -113,6 +113,18 @@ pub struct BuildArgs {
     #[serde(flatten)]
     pub compiler: CompilerArgs,
 
+    #[clap(
+        help = "print compiled contract names",
+        long = "names",
+    )]
+    pub names: bool,
+
+    #[clap(
+        help = "print compiled contract sizes",
+        long = "sizes",
+    )]
+    pub sizes: bool,
+
     #[clap(help = "ignore warnings with specific error codes", long)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub ignored_error_codes: Vec<u64>,
@@ -155,7 +167,7 @@ impl Cmd for BuildArgs {
     type Output = ProjectCompileOutput;
     fn run(self) -> eyre::Result<Self::Output> {
         let project = self.project()?;
-        super::compile(&project)
+        super::compile(&project, self.names, self.sizes)
     }
 }
 

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -113,16 +113,10 @@ pub struct BuildArgs {
     #[serde(flatten)]
     pub compiler: CompilerArgs,
 
-    #[clap(
-        help = "print compiled contract names",
-        long = "names",
-    )]
+    #[clap(help = "print compiled contract names", long = "names")]
     pub names: bool,
 
-    #[clap(
-        help = "print compiled contract sizes",
-        long = "sizes",
-    )]
+    #[clap(help = "print compiled contract sizes", long = "sizes")]
     pub sizes: bool,
 
     #[clap(help = "ignore warnings with specific error codes", long)]

--- a/cli/src/cmd/create.rs
+++ b/cli/src/cmd/create.rs
@@ -60,7 +60,7 @@ impl Cmd for CreateArgs {
     fn run(self) -> Result<Self::Output> {
         // Find Project & Compile
         let project = self.opts.project()?;
-        let compiled = super::compile(&project)?;
+        let compiled = super::compile(&project, self.opts.names, self.opts.sizes)?;
 
         // Get ABI and BIN
         let (abi, bin, _) = super::read_artifact(&project, compiled, self.contract.clone())?;

--- a/cli/src/cmd/flatten.rs
+++ b/cli/src/cmd/flatten.rs
@@ -73,6 +73,8 @@ impl Cmd for FlattenArgs {
             lib_paths,
             out_path: None,
             compiler: Default::default(),
+            names: false,
+            sizes: false,
             ignored_error_codes: vec![],
             no_auto_detect: false,
             offline: false,

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -108,6 +108,10 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
             }
         }
         if print_sizes {
+            // add extra newline if names were already printed
+            if print_names {
+                println!();
+            }
             let compiled_contracts = output.compiled_contracts_by_compiler_version();
             let mut sizes = BTreeMap::new();
             for (_, contracts) in compiled_contracts.into_iter() {

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -59,7 +59,6 @@ use ethers::{
 };
 use std::{collections::BTreeMap, path::PathBuf};
 
-
 /// Common trait for all cli commands
 pub trait Cmd: clap::Parser + Sized {
     type Output;
@@ -72,7 +71,11 @@ use foundry_utils::to_table;
 
 /// Compiles the provided [`Project`], throws if there's any compiler error and logs whether
 /// compilation was successful or if there was a cache hit.
-pub fn compile(project: &Project, print_names: bool, print_sizes: bool) -> eyre::Result<ProjectCompileOutput> {
+pub fn compile(
+    project: &Project,
+    print_names: bool,
+    print_sizes: bool,
+) -> eyre::Result<ProjectCompileOutput> {
     if !project.paths.sources.exists() {
         eyre::bail!(
             r#"no contracts to compile, contracts folder "{}" does not exist.
@@ -95,7 +98,10 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
             let compiled_contracts = output.compiled_contracts_by_compiler_version();
             println!("compiled contracts:");
             for (version, contracts) in compiled_contracts.into_iter() {
-                println!("  compiler version: {}.{}.{}", version.major, version.minor, version.patch);
+                println!(
+                    "  compiler version: {}.{}.{}",
+                    version.major, version.minor, version.patch
+                );
                 for (name, _) in contracts {
                     println!("    - {}", name.to_string());
                 }
@@ -124,7 +130,6 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
             println!("-----------------------------");
             println!("{}", to_table(json));
         }
-
 
         println!("{}", output);
         println!("success.");

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -57,7 +57,7 @@ use ethers::{
     prelude::artifacts::{CompactBytecode, CompactDeployedBytecode},
     solc::cache::SolFilesCache,
 };
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 /// Common trait for all cli commands
 pub trait Cmd: clap::Parser + Sized {
@@ -88,9 +88,28 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
     } else if output.is_unchanged() {
         println!("no files changed, compilation skipped.");
     } else {
+        let mut contracts = BTreeMap::new();
+        for (_, name, _, version) in
+            output.clone().output().contracts.contracts_with_files_and_version()
+        {
+            contracts
+                .entry(version.to_string())
+                .or_insert(Vec::<String>::new())
+                .push(name.to_string());
+        }
+
+        println!("compiled contracts:");
+        for (key, value) in contracts.clone().into_iter() {
+            println!("compiler version: {}", key);
+            for name in value {
+                println!("  - {}", name);
+            }
+        }
+
         println!("{}", output);
         println!("success.");
     }
+
     Ok(output)
 }
 

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -103,7 +103,7 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
                     version.major, version.minor, version.patch
                 );
                 for (name, _) in contracts {
-                    println!("    - {}", name.to_string());
+                    println!("    - {}", name);
                 }
             }
         }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -186,6 +186,10 @@ pub struct Config {
     /// by proptest, to be encountered during usage of `vm.assume`
     /// cheatcode.
     pub fuzz_max_global_rejects: u32,
+    /// Print the names of the compiled contracts
+    pub names: bool,
+    /// Print the sizes of the compiled contracts
+    pub sizes: bool,
     /// The root path where the config detection started from, `Config::with_root`
     #[doc(hidden)]
     //  We're skipping serialization here, so it won't be included in the [`Config::to_string()`]
@@ -800,6 +804,8 @@ impl Default for Config {
             optimizer_details: None,
             extra_output: Default::default(),
             extra_output_files: Default::default(),
+            names: false,
+            sizes: false,
             fuzz_runs: 256,
             fuzz_max_local_rejects: 1024,
             fuzz_max_global_rejects: 65536,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

I want to know which contracts were compiled when running
`forge build` and the compiler version that was used.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Print the names of the compiled contracts after
running `forge compile`. Its useful to know which
contracts were compiled and the compiler version
that was used.

The output looks like this:

```bash
$ forge build --hardhat --names --sizes

compiling...
Compiling 1 files with 0.5.17
Compiling 79 files with 0.8.11
Compilation finished successfully
Compilation finished successfully
compiled contracts:
  compiler version: 0.5.17
    - WETH9
  compiler version: 0.8.11
    - AddressDictator
    - ChugSplashDictator
    - IL1CrossDomainMessenger
    - IL1ERC20Bridge
    - IL1StandardBridge
    - L1CrossDomainMessenger
    - L1StandardBridge
    - CanonicalTransactionChain
    - ChainStorageContainer
    - ICanonicalTransactionChain
    - IChainStorageContainer
    - IStateCommitmentChain
    - StateCommitmentChain
    - TeleportrDeposit
    - BondManager
    - IBondManager
    - IL2CrossDomainMessenger
    - IL2ERC20Bridge
    - L2CrossDomainMessenger
    - L2StandardBridge
    - L2StandardTokenFactory
    - OVM_DeployerWhitelist
... <more contracts, removed for brevity>
name             size (bytes)
-----------------------------
Address              141
AddressAliasHelper   141
AddressDictator      2926
BondManager          940
CanonicalTransactionChain 5689
ChainStorageContainer 3220
ChugSplashDictator   1733
Context              0
ContextUpgradeable   0
CrossDomainEnabled   291
ERC165Checker        141
ERC20                2902
FailingReceiver      159
Helper_SimpleProxy   595
IBondManager         0
ICanonicalTransactionChain 0
IChainStorageContainer 0
ICrossDomainMessenger 0
IERC165              0
IERC20               0
IERC20Metadata       0
IL1CrossDomainMessenger 0
IL1ERC20Bridge       0
IL1StandardBridge    0
IL2CrossDomainMessenger 0
IL2ERC20Bridge       0
IL2StandardERC20     0
IStateCommitmentChain 0
Initializable        0
L1ChugSplashProxy    2065
L1CrossDomainMessenger 12799
L1StandardBridge     5179
L2CrossDomainMessenger 2524
L2StandardBridge     3383
L2StandardERC20      4275
L2StandardTokenFactory 5115
Lib_AddressManager   1444
Lib_AddressResolver  0
Lib_Buffer           141
Lib_Bytes32Utils     141
Lib_BytesUtils       141
Lib_CrossDomainUtils 141
Lib_DefaultValues    141
Lib_MerkleTree       141
Lib_MerkleTrie       141
Lib_OVMCodec         141
Lib_PredeployAddresses 141
Lib_RLPReader        141
Lib_RLPWriter        141
Lib_ResolvedDelegateProxy 1262
Lib_SecureMerkleTrie 141
OVM_DeployerWhitelist 1196
OVM_ETH              3404
OVM_GasPriceOracle   2718
OVM_L2ToL1MessagePasser 610
OVM_SequencerFeeVault 843
Ownable              0
OwnableUpgradeable   0
PausableUpgradeable  0
ReentrancyGuardUpgradeable 0
SafeERC20            141
StateCommitmentChain 7274
TeleportrDeposit     2160
TeleportrDisburser   1964
TestERC20            1522
TestLib_AddressAliasHelper 307
TestLib_Buffer       1330
TestLib_Bytes32Utils 483
TestLib_BytesUtils   3904
TestLib_CrossDomainUtils 743
TestLib_MerkleTree   2853
TestLib_MerkleTrie   11208
TestLib_OVMCodec     1016
TestLib_RLPReader    3808
TestLib_RLPWriter    4784
TestLib_SecureMerkleTrie 11363
WETH9                2055
iL1ChugSplashDeployer 0
iOVM_L1BlockNumber   0
iOVM_L2ToL1MessagePasser 0
success.
```

Not sure how much I like the output of `--sizes` when using `foundry_utils::to_table`. I think iterating and printing similarly to `--names` could look better. Thoughts?