### PR TITLE
fix(cast): --gas-price flag in `cast send`

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -226,7 +226,7 @@ pub enum Subcommands {
         args: Vec<String>,
         #[clap(long, help = "gas quantity for the transaction", parse(try_from_str = parse_u256))]
         gas: Option<U256>,
-        #[clap(long, help = "gas price for the transaction", env = "ETH_GAS_PRICE", parse(try_from_str = parse_ether_value))]
+        #[clap(long = "gas-price", help = "gas price for the transaction", env = "ETH_GAS_PRICE", parse(try_from_str = parse_ether_value))]
         gas_price: Option<U256>,
         #[clap(long, help = "ether value (in wei or string with unit type e.g. 1ether, 10gwei, 0.01ether) for the transaction", parse(try_from_str = parse_ether_value))]
         value: Option<U256>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Currently, the gas price can only be set via environment variable in `cast send`. This diverges from seth and recently caused me quite a bit of confusion. I think that gas price is something users will want to quickly modify, so we should allow the --gas-price flag to work for convenience.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
I think the reason that `--gas-price` does not work as a flag even though `long` is specified in clap is due to the presence of an underscore. Explicitly specifying `long = "gas-price" seems to fix it.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
