### PR TITLE
fix(config): parse libraries as string

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1395,8 +1395,7 @@ mod tests {
             );
             jail.set_env(
                 "DAPP_LIBRARIES",
-                "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6,src/
-            DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6",
+                "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6,src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6",
             );
             let config = Config::load();
             assert_eq!(

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -611,10 +611,12 @@ impl From<Config> for Figment {
             .merge(ForcedSnakeCaseData(
                 Toml::file(Env::var_or("FOUNDRY_CONFIG", Config::FILE_NAME)).nested(),
             ))
-            .merge(Env::prefixed("DAPP_").ignore(&["REMAPPINGS"]).global())
+            .merge(Env::prefixed("DAPP_").ignore(&["REMAPPINGS", "LIBRARIES"]).global())
             .merge(Env::prefixed("DAPP_TEST_").global())
             .merge(DappEnvCompatProvider)
-            .merge(Env::prefixed("FOUNDRY_").ignore(&["PROFILE", "REMAPPINGS"]).global())
+            .merge(
+                Env::prefixed("FOUNDRY_").ignore(&["PROFILE", "REMAPPINGS", "LIBRARIES"]).global(),
+            )
             .select(profile.clone());
 
         // we try to merge remappings after we've merged all other providers, this prevents
@@ -843,6 +845,11 @@ impl Provider for DappEnvCompatProvider {
                 .into())
             }
             dict.insert("optimizer".to_string(), (val == 1).into());
+        }
+
+        // libraries in env vars either as `[..]` or single string separated by comma
+        if let Ok(val) = env::var("DAPP_LIBRARIES").or_else(|_| env::var("FOUNDRY_LIBRARIES")) {
+            dict.insert("libraries".to_string(), utils::to_array_value(&val)?);
         }
 
         Ok(Map::from([(Config::selected_profile(), dict)]))
@@ -1368,6 +1375,39 @@ mod tests {
             assert_eq!(config.fork_block_number, Some(100));
             assert_eq!(config.optimizer_runs, 999);
             assert!(!config.optimizer);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn can_parse_libraries() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "DAPP_LIBRARIES",
+                "[src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6]",
+            );
+            let config = Config::load();
+            assert_eq!(
+                config.libraries,
+                vec!["src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"
+                    .to_string()]
+            );
+            jail.set_env(
+                "DAPP_LIBRARIES",
+                "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6,src/
+            DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6",
+            );
+            let config = Config::load();
+            assert_eq!(
+                config.libraries,
+                vec![
+                    "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"
+                        .to_string(),
+                    "src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6"
+                        .to_string()
+                ]
+            );
 
             Ok(())
         });

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -132,7 +132,7 @@ pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
         Value::String(_, val) => val
             .trim_start_matches('[')
             .trim_end_matches(']')
-            .split(']')
+            .split(',')
             .map(|s| s.to_string())
             .collect::<Vec<_>>()
             .into(),

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -7,6 +7,7 @@ use ethers_solc::{
     error::SolcError,
     remappings::{Remapping, RemappingError},
 };
+use figment::value::Value;
 
 /// Loads the config for the current project workspace
 pub fn load_config() -> Config {
@@ -121,4 +122,23 @@ pub fn parse_libraries(
             .insert(lib.to_string(), addr.to_string());
     }
     Ok(libraries)
+}
+
+/// Converts the `val` into a `figment::Value::Array`
+///
+/// The values should be separated by commas, surrounding brackets are also supported `[a,b,c]`
+pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
+    let value: Value = match Value::from(val) {
+        Value::String(_, val) => val
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .split(']')
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .into(),
+        Value::Empty(_, _) => Vec::<Value>::new().into(),
+        val @ Value::Array(_, _) => val,
+        _ => return Err(format!("Invalid value `{}`, expected an array", val).into()),
+    };
+    Ok(value)
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
the figment parser tries to parse env vars `src/DssSpell.sol:DssExecLib:0x8De6DDbCd5053d32292AAA0D2105A32d108484a6` as vec
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
manually parse figment arrays


also bumps ethers

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
