### PR TITLE
ci: build arm64 linux nightlies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,12 @@ jobs:
           echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
+      - name: Linux ARM setup
+        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build binaries
         env:
           RUSTFLAGS: -C link-args=-s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,11 +72,15 @@ jobs:
           # The OS is used for the runner
           # The platform is a generic platform name
           # The target is used by Cargo
-          # The arch is either 386 or amd64
+          # The arch is either 386, arm64 or amd64
           - os: ubuntu-latest
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
+          - os: ubuntu-latest
+            platform: linux
+            target: aarch64-unknown-linux-gnu
+            arch: arm64
           - os: macos-latest
             platform: darwin
             target: x86_64-apple-darwin

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -203,7 +203,14 @@ impl Provider for BuildArgs {
         }
 
         #[cfg(target_arch = "aarch64")]
-        dict.insert("auto_detect_solc".to_string(), false.into());
+        {
+            if !self.no_auto_detect {
+                println!("Solidity compiler autodetection is disabled on ARM.");
+                println!("You can track progress on ARM support in https://github.com/gakonst/foundry/issues/525");
+                println!("To silence this warning use --no-auto-detect");
+            }
+            dict.insert("auto_detect_solc".to_string(), false.into());
+        }
 
         if self.force {
             dict.insert("force".to_string(), self.force.into());

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -197,9 +197,13 @@ impl Provider for BuildArgs {
             dict.insert("libs".to_string(), libs.into());
         }
 
+        #[cfg(not(target_arch = "aarch64"))]
         if self.no_auto_detect {
             dict.insert("auto_detect_solc".to_string(), false.into());
         }
+
+        #[cfg(target_arch = "aarch64")]
+        dict.insert("auto_detect_solc".to_string(), false.into());
 
         if self.force {
             dict.insert("force".to_string(), self.force.into());


### PR DESCRIPTION
If I read `foundryup` correctly this should already be supported, so this is the only change needed, given Cargo doesn't complain

Closes #684