### PR TITLE
fix(forge): verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.3.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
+checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bech32"
@@ -529,7 +529,7 @@ dependencies = [
  "coins-core",
  "digest 0.9.0",
  "getrandom",
- "hmac",
+ "hmac 0.11.0",
  "k256",
  "lazy_static",
  "serde",
@@ -547,8 +547,8 @@ dependencies = [
  "coins-bip32",
  "getrandom",
  "hex",
- "hmac",
- "pbkdf2",
+ "hmac 0.11.0",
+ "pbkdf2 0.8.0",
  "rand",
  "sha2 0.9.9",
  "thiserror",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -947,6 +947,7 @@ dependencies = [
  "block-buffer 0.10.0",
  "crypto-common",
  "generic-array 0.14.5",
+ "subtle",
 ]
 
 [[package]]
@@ -1064,22 +1065,22 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 
 [[package]]
 name = "eth-keystore"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47d900a7dea08593d398104f8288e37858b0ad714c8d08cd03fdb86563e6402"
+checksum = "aff9543a3535519a0d2ebbb6ae0afd58175258162e2fa4c1b57981edaad60fcb"
 dependencies = [
  "aes",
  "ctr",
- "digest 0.9.0",
+ "digest 0.10.1",
  "hex",
- "hmac",
- "pbkdf2",
+ "hmac 0.12.0",
+ "pbkdf2 0.10.0",
  "rand",
  "scrypt",
  "serde",
  "serde_json",
- "sha2 0.9.9",
- "sha3 0.9.1",
+ "sha2 0.10.1",
+ "sha3 0.10.0",
  "thiserror",
  "uuid",
 ]
@@ -1153,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1168,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1179,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1197,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1220,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1234,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1262,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1276,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1299,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1331,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1354,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
+source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
 dependencies = [
  "colored",
  "dunce",
@@ -1967,6 +1968,15 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
+dependencies = [
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -2726,6 +2736,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,9 +2754,21 @@ checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "base64ct",
  "crypto-mac 0.11.1",
- "hmac",
- "password-hash",
+ "hmac 0.11.0",
+ "password-hash 0.2.3",
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4628cc3cf953b82edcd3c1388c5715401420ce5524fedbab426bd5aba017434"
+dependencies = [
+ "digest 0.10.1",
+ "hmac 0.12.0",
+ "password-hash 0.3.2",
+ "sha2 0.10.1",
 ]
 
 [[package]]
@@ -3056,14 +3089,13 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -3083,15 +3115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -3245,7 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
 dependencies = [
  "crypto-bigint",
- "hmac",
+ "hmac 0.11.0",
  "zeroize",
 ]
 
@@ -3393,9 +3416,9 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "salsa20"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
 dependencies = [
  "cipher",
 ]
@@ -3452,16 +3475,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879588d8f90906e73302547e20fffefdd240eb3e0e744e142321f5d49dea0518"
+checksum = "e73d6d7c6311ebdbd9184ad6c4447b2f36337e327bda107d3ba9e3c374f9d325"
 dependencies = [
- "base64ct",
- "hmac",
- "password-hash",
- "pbkdf2",
+ "hmac 0.12.0",
+ "password-hash 0.3.2",
+ "pbkdf2 0.10.0",
  "salsa20",
- "sha2 0.9.9",
+ "sha2 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#272c1a15af602b0ab56003780381b1e29ec2864c"
+source = "git+https://github.com/gakonst/ethers-rs#78161f07e7295b203c7df9c939e4db5060cd4c1f"
 dependencies = [
  "colored",
  "dunce",

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -507,7 +507,8 @@ async fn main() -> eyre::Result<()> {
                 match path {
                     Some(path) => {
                         let password = read_secret(password, unsafe_password)?;
-                        let (key, uuid) = LocalWallet::new_keystore(&path, &mut rng, password)?;
+                        let (key, uuid) =
+                            LocalWallet::new_keystore(&path, &mut rng, password, None)?;
                         let address = SimpleCast::checksum_address(&key.address())?;
                         let filepath = format!(
                             "{}/{}",

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -1,23 +1,23 @@
 //! Verify contract source on etherscan
 
-use crate::cmd::build::BuildArgs;
+use crate::{cmd::build::BuildArgs, opts::forge::ContractInfo};
 use clap::Parser;
 use ethers::{
     abi::Address,
     etherscan::{contract::VerifyContract, Client},
 };
 
-/// Command to list remappings
+/// Verification arguments
 #[derive(Debug, Clone, Parser)]
 pub struct VerifyArgs {
     #[clap(help = "the target contract address")]
     address: Address,
 
-    #[clap(help = "the target contract path")]
-    contract: String,
+    #[clap(help = "the contract source info `<path>:<contractname>`")]
+    contract: ContractInfo,
 
-    #[clap(long, help = "the encoded constructor arguments calldata")]
-    args: Option<String>,
+    #[clap(long, help = "the encoded constructor arguments")]
+    constructor_args: Option<String>,
 
     #[clap(long, help = "the compiler version used during build")]
     compiler_version: String,
@@ -36,24 +36,46 @@ pub struct VerifyArgs {
     opts: BuildArgs,
 }
 
+/// Check verification status arguments
+#[derive(Debug, Clone, Parser)]
+pub struct VerifyCheckArgs {
+    #[clap(help = "the verification guid")]
+    guid: String,
+
+    // TODO: Allow choosing network using the provider or chainid as string
+    #[clap(long, help = "the chain id of the network you are verifying for", default_value = "1")]
+    chain_id: u64,
+
+    #[clap(help = "your etherscan api key", env = "ETHERSCAN_API_KEY")]
+    etherscan_key: String,
+}
+
 /// Run the verify command to submit the contract's source code for verification on etherscan
-pub async fn run(args: &VerifyArgs) -> eyre::Result<()> {
-    if args.etherscan_key == "" {
-        eyre::bail!("Etherscan API key is required");
+pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
+    if args.contract.path.is_none() {
+        eyre::bail!("Contract info must be provided in the format <path>:<name>")
     }
 
     let project = args.opts.project()?;
     let contract = project
-        .flatten(&project.root().join(&args.contract))
+        .flatten(&project.root().join(args.contract.path.as_ref().unwrap()))
         .map_err(|err| eyre::eyre!("Failed to flatten contract: {}", err))?;
 
     let etherscan = Client::new(args.chain_id.try_into()?, &args.etherscan_key)
         .map_err(|err| eyre::eyre!("Failed to create etherscan client: {}", err))?;
 
-    let mut verify_args = VerifyContract::new(args.address, contract, String::new());
+    let mut verify_args = VerifyContract::new(
+        args.address,
+        args.contract.name.clone(),
+        contract,
+        args.compiler_version.clone(),
+    )
+    .constructor_arguments(args.constructor_args.clone());
 
     if let Some(optimizations) = args.num_of_optimizations {
         verify_args = verify_args.optimization(true).runs(optimizations);
+    } else {
+        verify_args = verify_args.optimization(false);
     }
 
     let resp = etherscan
@@ -83,5 +105,31 @@ pub async fn run(args: &VerifyArgs) -> eyre::Result<()> {
         resp.result,
         etherscan.address_url(args.address)
     );
+    Ok(())
+}
+
+pub async fn run_verify_check(args: &VerifyCheckArgs) -> eyre::Result<()> {
+    let etherscan = Client::new(args.chain_id.try_into()?, &args.etherscan_key)
+        .map_err(|err| eyre::eyre!("Failed to create etherscan client: {}", err))?;
+
+    let resp = etherscan
+        .check_contract_verification_status(args.guid.clone())
+        .await
+        .map_err(|err| eyre::eyre!("Failed to request verification status: {}", err))?;
+
+    if resp.status == "0" {
+        if resp.result == "Pending in queue" {
+            println!("Verification is pending...");
+            return Ok(())
+        }
+
+        eyre::bail!(
+            "Contract verification failed:\nResponse: `{}`\nDetails: `{}`",
+            resp.message,
+            resp.result
+        );
+    }
+
+    println!("Contract successfully verified.");
     Ok(())
 }

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -1,6 +1,6 @@
 //! Verify contract source on etherscan
 
-use crate::{cmd::build::BuildArgs, opts::forge::FullContractInfo};
+use crate::cmd::build::BuildArgs;
 use clap::Parser;
 use ethers::{
     abi::Address,
@@ -10,16 +10,13 @@ use ethers::{
 /// Command to list remappings
 #[derive(Debug, Clone, Parser)]
 pub struct VerifyArgs {
-    #[structopt(flatten)]
-    opts: BuildArgs,
-
     #[structopt(help = "the target contract address")]
     address: Address,
 
-    #[clap(help = "contract source info `<path>:<contractname>`")]
-    contract: FullContractInfo,
+    #[clap(help = "the target contract path")]
+    contract: String,
 
-    #[structopt(help = "the encoded constructor arguments calldata")]
+    #[structopt(long, help = "the encoded constructor arguments calldata")]
     args: Option<String>,
 
     #[structopt(long, help = "the compiler version used during build")]
@@ -38,13 +35,16 @@ pub struct VerifyArgs {
 
     #[structopt(help = "your etherscan api key", env = "ETHERSCAN_API_KEY")]
     etherscan_key: String,
+
+    #[structopt(flatten)]
+    opts: BuildArgs,
 }
 
 /// Run the verify command to submit the contract's source code for verification on etherscan
 pub async fn run(args: &VerifyArgs) -> eyre::Result<()> {
     let project = args.opts.project()?;
     let contract = project
-        .flatten(&project.root().join(&args.contract.path))
+        .flatten(&project.root().join(&args.contract))
         .map_err(|err| eyre::eyre!("Failed to flatten contract: {}", err))?;
 
     let etherscan = Client::new(args.chain_id.try_into()?, &args.etherscan_key)

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -1,110 +1,87 @@
 //! Verify contract source on etherscan
 
-use crate::utils;
-use cast::SimpleCast;
+use crate::{cmd::build::BuildArgs, opts::forge::FullContractInfo};
+use clap::Parser;
 use ethers::{
-    abi::{Address, Function, FunctionExt},
-    core::types::Chain,
+    abi::Address,
     etherscan::{contract::VerifyContract, Client},
-    prelude::Provider,
-    providers::Middleware,
 };
-use eyre::ContextCompat;
-use std::convert::TryFrom;
+
+/// Command to list remappings
+#[derive(Debug, Clone, Parser)]
+pub struct VerifyArgs {
+    #[structopt(flatten)]
+    opts: BuildArgs,
+
+    #[structopt(help = "the target contract address")]
+    address: Address,
+
+    #[clap(help = "contract source info `<path>:<contractname>`")]
+    contract: FullContractInfo,
+
+    #[structopt(help = "the encoded constructor arguments calldata")]
+    args: Option<String>,
+
+    #[structopt(long, help = "the compiler version used during build")]
+    compiler_version: String,
+
+    #[structopt(long, help = "the number of optimization runs used")]
+    num_of_optimizations: Option<u32>,
+
+    // TODO: Allow choosing network using the provider or chainid as string
+    #[structopt(
+        long,
+        help = "the chain id of the network you are verifying for",
+        default_value = "1"
+    )]
+    chain_id: u64,
+
+    #[structopt(help = "your etherscan api key", env = "ETHERSCAN_API_KEY")]
+    etherscan_key: String,
+}
 
 /// Run the verify command to submit the contract's source code for verification on etherscan
-pub async fn run(
-    path: String,
-    name: String,
-    address: Address,
-    args: Vec<String>,
-) -> eyre::Result<()> {
-    let etherscan_api_key = foundry_utils::etherscan_api_key()?;
-    let rpc_url = utils::rpc_url();
-    let provider = Provider::try_from(rpc_url)?;
-    let chain = provider
-        .get_chainid()
-        .await
-        .map_err(|err| {
-            eyre::eyre!(
-                r#"Please make sure that you are running a local Ethereum node:
-        For example, try running either `parity' or `geth --rpc'.
-        You could also try connecting to an external Ethereum node:
-        For example, try `export ETH_RPC_URL=https://mainnet.infura.io'.
-        If you have an Infura API key, add it to the end of the URL.
+pub async fn run(args: &VerifyArgs) -> eyre::Result<()> {
+    let project = args.opts.project()?;
+    let contract = project
+        .flatten(&project.root().join(&args.contract.path))
+        .map_err(|err| eyre::eyre!("Failed to flatten contract: {}", err))?;
 
-        Error: {}"#,
-                err
-            )
-        })?
-        .as_u64();
-
-    let contract = utils::find_dapp_json_contract(&path, &name)?;
-    std::fs::write("meta.json", serde_json::to_string_pretty(&contract).unwrap()).unwrap();
-    let metadata = contract.metadata.wrap_err("No compiler version found")?;
-    let compiler_version = format!("v{}", metadata.compiler.version);
-    let mut constructor_args = None;
-    if let Some(constructor) = contract.abi.unwrap().constructor {
-        // convert constructor into function
-        #[allow(deprecated)]
-        let fun = Function {
-            name: "constructor".to_string(),
-            inputs: constructor.inputs,
-            outputs: vec![],
-            constant: None,
-            state_mutability: Default::default(),
-        };
-
-        constructor_args = Some(SimpleCast::calldata(fun.abi_signature(), &args)?);
-    } else if !args.is_empty() {
-        eyre::bail!("No constructor found but contract arguments provided")
-    }
-
-    let chain = match chain {
-        1 => Chain::Mainnet,
-        3 => Chain::Ropsten,
-        4 => Chain::Rinkeby,
-        5 => Chain::Goerli,
-        42 => Chain::Kovan,
-        100 => Chain::XDai,
-        _ => eyre::bail!("unexpected chain {}", chain),
-    };
-    let etherscan = Client::new(chain, etherscan_api_key)
+    let etherscan = Client::new(args.chain_id.try_into()?, &args.etherscan_key)
         .map_err(|err| eyre::eyre!("Failed to create etherscan client: {}", err))?;
 
-    let source = std::fs::read_to_string(&path)?;
+    let mut verify_args = VerifyContract::new(args.address, contract, String::new());
 
-    let contract = VerifyContract::new(address, source, compiler_version)
-        .constructor_arguments(constructor_args)
-        .optimization(metadata.settings.optimizer.enabled.unwrap_or_default())
-        .runs(metadata.settings.optimizer.runs.unwrap_or_default() as u32);
+    if let Some(optimizations) = args.num_of_optimizations {
+        verify_args = verify_args.optimization(true).runs(optimizations);
+    }
 
     let resp = etherscan
-        .submit_contract_verification(&contract)
+        .submit_contract_verification(&verify_args)
         .await
         .map_err(|err| eyre::eyre!("Failed to submit contract verification: {}", err))?;
 
     if resp.status == "0" {
         if resp.message == "Contract source code already verified" {
             println!("Contract source code already verified.");
-            Ok(())
-        } else {
-            eyre::bail!(
-                "Encountered an error verifying this contract:\nResponse: `{}`\nDetails: `{}`",
-                resp.message,
-                resp.result
-            );
+            return Ok(())
         }
-    } else {
-        println!(
-            r#"Submitted contract for verification:
-            Response: `{}`
-            GUID: `{}`
-            url: {}#code"#,
+
+        eyre::bail!(
+            "Encountered an error verifying this contract:\nResponse: `{}`\nDetails: `{}`",
             resp.message,
-            resp.result,
-            etherscan.address_url(address)
+            resp.result
         );
-        Ok(())
     }
+
+    println!(
+        r#"Submitted contract for verification:
+                Response: `{}`
+                GUID: `{}`
+                url: {}#code"#,
+        resp.message,
+        resp.result,
+        etherscan.address_url(args.address)
+    );
+    Ok(())
 }

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -42,6 +42,10 @@ pub struct VerifyArgs {
 
 /// Run the verify command to submit the contract's source code for verification on etherscan
 pub async fn run(args: &VerifyArgs) -> eyre::Result<()> {
+    if args.etherscan_key == "" {
+        eyre::bail!("Etherscan API key is required");
+    }
+
     let project = args.opts.project()?;
     let contract = project
         .flatten(&project.root().join(&args.contract))

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -5,7 +5,7 @@ mod utils;
 use crate::cmd::Cmd;
 
 use ethers::solc::{Project, ProjectPathsConfig};
-use opts::forge::{Dependency, FullContractInfo, Opts, Subcommands};
+use opts::forge::{Dependency, Opts, Subcommands};
 use std::process::Command;
 
 use clap::{IntoApp, Parser};

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -33,7 +33,11 @@ fn main() -> eyre::Result<()> {
         }
         Subcommands::VerifyContract(args) => {
             let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
-            rt.block_on(cmd::verify::run(&args))?;
+            rt.block_on(cmd::verify::run_verify(&args))?;
+        }
+        Subcommands::VerifyCheck(args) => {
+            let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
+            rt.block_on(cmd::verify::run_verify_check(&args))?;
         }
         Subcommands::Create(cmd) => {
             cmd.run()?;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -5,7 +5,7 @@ mod utils;
 use crate::cmd::Cmd;
 
 use ethers::solc::{self, report::BasicStdoutReporter, Project, ProjectPathsConfig};
-use opts::forge::{Dependency, FullContractInfo, Opts, Subcommands};
+use opts::forge::{Dependency, Opts, Subcommands};
 use std::process::Command;
 
 use clap::{IntoApp, Parser};

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -30,10 +30,9 @@ fn main() -> eyre::Result<()> {
         Subcommands::Run(cmd) => {
             cmd.run()?;
         }
-        Subcommands::VerifyContract { contract, address, constructor_args } => {
-            let FullContractInfo { path, name } = contract;
+        Subcommands::VerifyContract(args) => {
             let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
-            rt.block_on(cmd::verify::run(path, name, address, constructor_args))?;
+            rt.block_on(cmd::verify::run(&args))?;
         }
         Subcommands::Create(cmd) => {
             cmd.run()?;

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -4,9 +4,17 @@ use ethers::solc::EvmVersion;
 use std::{path::PathBuf, str::FromStr};
 
 use crate::cmd::{
-    bind::BindArgs, build::BuildArgs, config, create::CreateArgs, flatten, init::InitArgs,
-    install::InstallArgs, remappings::RemappingArgs, run::RunArgs, snapshot, test,
-    verify::VerifyArgs,
+    bind::BindArgs,
+    build::BuildArgs,
+    config,
+    create::CreateArgs,
+    flatten,
+    init::InitArgs,
+    install::InstallArgs,
+    remappings::RemappingArgs,
+    run::RunArgs,
+    snapshot, test,
+    verify::{VerifyArgs, VerifyCheckArgs},
 };
 use serde::Serialize;
 
@@ -70,6 +78,11 @@ pub enum Subcommands {
         about = "Verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
     )]
     VerifyContract(VerifyArgs),
+
+    #[clap(
+        about = "Check verification status on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
+    )]
+    VerifyCheck(VerifyCheckArgs),
 
     #[clap(alias = "c", about = "Deploy a compiled contract")]
     Create(CreateArgs),

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand, ValueHint};
 
-use ethers::{solc::EvmVersion, types::Address};
+use ethers::solc::EvmVersion;
 use std::{path::PathBuf, str::FromStr};
 
 use crate::cmd::{

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -6,6 +6,7 @@ use std::{path::PathBuf, str::FromStr};
 use crate::cmd::{
     bind::BindArgs, build::BuildArgs, config, create::CreateArgs, flatten, init::InitArgs,
     install::InstallArgs, remappings::RemappingArgs, run::RunArgs, snapshot, test,
+    verify::VerifyArgs,
 };
 use serde::Serialize;
 
@@ -62,14 +63,7 @@ pub enum Subcommands {
     #[clap(
         about = "verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
     )]
-    VerifyContract {
-        #[clap(help = "contract source info `<path>:<contractname>`")]
-        contract: FullContractInfo,
-        #[clap(help = "the address of the contract to verify.")]
-        address: Address,
-        #[clap(help = "constructor args calldata arguments.")]
-        constructor_args: Vec<String>,
-    },
+    VerifyContract(VerifyArgs),
 
     #[clap(alias = "c", about = "deploy a compiled contract")]
     Create(CreateArgs),

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,22 +1,12 @@
-use std::{path::PathBuf, str::FromStr};
+use std::str::FromStr;
 
-use ethers::{
-    solc::{artifacts::Contract, EvmVersion},
-    types::U256,
-};
-use eyre::{ContextCompat, WrapErr};
+use ethers::{solc::EvmVersion, types::U256};
 #[cfg(feature = "sputnik-evm")]
 use sputnik::Config;
 
 // reexport all `foundry_config::utils`
 #[doc(hidden)]
 pub use foundry_config::utils::*;
-
-/// Default local RPC endpoint
-const LOCAL_RPC_URL: &str = "http://127.0.0.1:8545";
-
-/// Default Path to where the contract artifacts are stored
-pub const DAPP_JSON: &str = "./out/dapp.sol.json";
 
 /// The version message for the current program, like
 /// `forge 0.1.0 (f01b232bc 2022-01-22T23:28:39.493201+00:00)`
@@ -36,42 +26,6 @@ pub fn subscriber() {
         // .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
-}
-
-/// The rpc url to use
-/// If the `ETH_RPC_URL` is not present, it falls back to the default `http://127.0.0.1:8545`
-pub fn rpc_url() -> String {
-    std::env::var("ETH_RPC_URL").unwrap_or_else(|_| LOCAL_RPC_URL.to_string())
-}
-
-/// The path to where the contract artifacts are stored
-pub fn dapp_json_path() -> PathBuf {
-    PathBuf::from(DAPP_JSON)
-}
-
-/// Tries to extract the `Contract` in the `DAPP_JSON` file
-pub fn find_dapp_json_contract(path: &str, name: &str) -> eyre::Result<Contract> {
-    let dapp_json = dapp_json_path();
-    let file = std::io::BufReader::new(std::fs::File::open(&dapp_json)?);
-    let mut value: serde_json::Value =
-        serde_json::from_reader(file).wrap_err("Failed to read DAPP_JSON artifacts")?;
-
-    let contracts = value["contracts"]
-        .as_object_mut()
-        .wrap_err_with(|| format!("No `contracts` found in `{}`", dapp_json.display()))?;
-
-    let contract = if let serde_json::Value::Object(mut contract) = contracts[path].take() {
-        contract
-            .remove(name)
-            .wrap_err_with(|| format!("No contract found at `.contract.{}.{}`", path, name))?
-    } else {
-        let key = format!("{}:{}", path, name);
-        contracts
-            .remove(&key)
-            .wrap_err_with(|| format!("No contract found at `.contract.{}`", key))?
-    };
-
-    Ok(serde_json::from_value(contract)?)
 }
 
 #[cfg(feature = "sputnik-evm")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

fixes https://github.com/gakonst/foundry/issues/311

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

`verify-contract` command takes a project configuration and build information from arguments, flattens the target contract and submits it for verification.

`verify-check` command takes the verification guid and queries Etherscan API for verification status. 

Next steps would be:
- taking build info (compiler version, number of optimization runs etc) from the artifacts instead of taking it from cli args
- taking raw constructor arguments and ABI encoding them before submission
- renaming `chain_id` argument to `chain` & adding the ability to pass in chain id as well as the chain name.
   i.e. `--chain 1` and `--chain mainnet` should both be valid
