### PR TITLE
WIP: feat(forked-evm): dump / load cache from/to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "ansi_term",
  "bytes",
  "comfy-table",
+ "dirs-next",
  "ethers",
  "ethers-core",
  "evm",

--- a/cli/src/opts/evm.rs
+++ b/cli/src/opts/evm.rs
@@ -1,4 +1,6 @@
 //! cli arguments for configuring the evm settings
+use std::path::PathBuf;
+
 use clap::Parser;
 use ethers::types::{Address, U256};
 use evm_adapters::evm_opts::EvmType;
@@ -56,6 +58,10 @@ pub struct EvmArgs {
     #[clap(help = "pins the block number for the state fork", long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_block_number: Option<u64>,
+
+    #[clap(help = "the fork cache file path", long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_file: Option<Option<PathBuf>>,
 
     #[clap(help = "the initial balance of each deployed test contract", long)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -129,6 +129,8 @@ pub struct Config {
     pub block_number: u64,
     /// pins the block number for the state fork
     pub fork_block_number: Option<u64>,
+    /// pins the block number for the state fork
+    pub cache_file: Option<Option<PathBuf>>,
     /// the chainid opcode value
     pub chain_id: Option<Chain>,
     /// Block gas limit
@@ -716,6 +718,8 @@ impl Default for Config {
             initial_balance: U256::from(0xffffffffffffffffffffffffu128),
             block_number: 0,
             fork_block_number: None,
+            // default the cache to ~/.foundry/cache
+            cache_file: Some(None),
             chain_id: None,
             // toml-rs can't handle larger number because integers are stored signed
             // https://github.com/alexcrichton/toml-rs/issues/256

--- a/evm-adapters/Cargo.toml
+++ b/evm-adapters/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 foundry-utils = { path = "./../utils" }
 
-sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true, features = ["tracing"] }
+sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm",  optional = true, features = ["tracing", "with-serde"] }
 
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["solc-full"] }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
@@ -28,6 +28,7 @@ serde_json = "1.0.72"
 serde = "1.0.130"
 ansi_term = "0.12.1"
 comfy-table = "5.0.0"
+dirs-next = "2.0.0"
 
 [dev-dependencies]
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, features = ["solc-full", "solc-tests"] }

--- a/evm-adapters/src/evm_opts.rs
+++ b/evm-adapters/src/evm_opts.rs
@@ -1,6 +1,6 @@
 use ethers::types::{Address, U256};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 #[cfg(feature = "sputnik")]
 use sputnik::backend::MemoryVicinity;
@@ -51,6 +51,9 @@ pub struct EvmOpts {
 
     /// pins the block number for the state fork
     pub fork_block_number: Option<u64>,
+
+    /// the forking cache
+    pub cache_file: Option<Option<PathBuf>>,
 
     /// the initial balance of each deployed test contract
     pub initial_balance: U256,
@@ -111,6 +114,7 @@ mod sputnik_helpers {
                     cache,
                     vicinity.clone(),
                     self.fork_block_number.map(Into::into),
+                    self.cache_file.clone(),
                 );
                 BackendKind::Shared(backend)
             } else {

--- a/evm-adapters/src/sputnik/forked_backend/cache.rs
+++ b/evm-adapters/src/sputnik/forked_backend/cache.rs
@@ -553,7 +553,7 @@ mod tests {
         let vicinity = rt.block_on(vicinity(&provider, None, None, None)).unwrap();
         let cache = new_shared_cache(MemCache::default());
 
-        let backend = SharedBackend::new(Arc::new(provider), cache.clone(), vicinity, None);
+        let backend = SharedBackend::new(Arc::new(provider), cache.clone(), vicinity, None, None);
 
         let idx = H256::from_low_u64_be(0u64);
         let value = backend.storage(address, idx);

--- a/evm-adapters/src/sputnik/forked_backend/mod.rs
+++ b/evm-adapters/src/sputnik/forked_backend/mod.rs
@@ -28,7 +28,7 @@ pub fn dump(
     }
     .as_u64();
 
-    let res = match path {
+    let _res = match path {
         Some(Some(path)) => dump_cache(&path, cache),
         Some(None) => {
             let path = dirs_next::home_dir()
@@ -38,10 +38,6 @@ pub fn dump(
         }
         None => Ok(()),
     };
-
-    if let Err(err) = res {
-        tracing::error!("could not store fork cache to file. err: {}", err);
-    }
 }
 
 fn dump_cache(path: &PathBuf, cache: &BTreeMap<H160, MemoryAccount>) -> Result<(), ForkError> {

--- a/evm-adapters/src/sputnik/forked_backend/mod.rs
+++ b/evm-adapters/src/sputnik/forked_backend/mod.rs
@@ -2,3 +2,83 @@ pub mod cache;
 pub use cache::{new_shared_cache, MemCache, SharedBackend, SharedCache};
 pub mod rpc;
 pub use rpc::ForkMemoryBackend;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ForkError {
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("no cache file was specified")]
+    NoCache,
+}
+
+use ethers::types::{BlockId, BlockNumber, H160};
+use sputnik::backend::MemoryAccount;
+use std::{collections::BTreeMap, path::PathBuf};
+
+pub fn dump(
+    path: Option<&Option<PathBuf>>,
+    pin_block: Option<BlockId>,
+    cache: &BTreeMap<H160, MemoryAccount>,
+) {
+    let pin_block = match pin_block.expect("no pin block found; this should never happen") {
+        BlockId::Number(BlockNumber::Number(num)) => num,
+        _ => panic!("non block number pin blocks not supported"),
+    }
+    .as_u64();
+
+    let res = match path {
+        Some(Some(path)) => dump_cache(&path, cache),
+        Some(None) => {
+            let path = dirs_next::home_dir()
+                .map(|p| p.join(".foundry").join("cache").join(pin_block.to_string()))
+                .expect("could not construct pin block path");
+            dump_cache(&path, cache)
+        }
+        None => Ok(()),
+    };
+
+    if let Err(err) = res {
+        tracing::error!("could not store fork cache to file. err: {}", err);
+    }
+}
+
+fn dump_cache(path: &PathBuf, cache: &BTreeMap<H160, MemoryAccount>) -> Result<(), ForkError> {
+    std::fs::create_dir_all(path.parent().expect("no parent found"))?;
+    let file = std::fs::File::create(path)?;
+    let file = std::io::BufWriter::new(file);
+    serde_json::to_writer(file, cache)?;
+    Ok(())
+}
+
+pub fn load_cache(
+    path: Option<&Option<PathBuf>>,
+    pin_block: Option<BlockId>,
+) -> Result<BTreeMap<H160, MemoryAccount>, ForkError> {
+    let pin_block = match pin_block {
+        Some(inner) => inner,
+        None => return Err(ForkError::NoCache),
+    };
+
+    let pin_block = match pin_block {
+        BlockId::Number(BlockNumber::Number(num)) => num,
+        _ => panic!("non block number pin blocks not supported"),
+    }
+    .as_u64();
+
+    let path = match path {
+        Some(Some(path)) => path.clone(),
+        Some(None) => {
+            let path = dirs_next::home_dir()
+                .map(|p| p.join(".foundry").join("cache").join(pin_block.to_string()))
+                .expect("could not construct pin block path");
+            path
+        }
+        None => return Err(ForkError::NoCache),
+    };
+
+    let file = std::fs::File::open(path)?;
+    let file = std::io::BufReader::new(file);
+    Ok(serde_json::from_reader(file)?)
+}

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -240,7 +240,7 @@ mod tests {
         let blk = Some(13292465);
         let vicinity = rt.block_on(vicinity(&provider, None, blk, None)).unwrap();
         let backend = new_backend(&vicinity, Default::default());
-        let backend = ForkMemoryBackend::new(provider, backend, blk, Default::default());
+        let backend = ForkMemoryBackend::new(provider, backend, blk, Default::default(), None);
 
         let precompiles = PRECOMPILES_MAP.clone();
         let mut evm = Executor::new(12_000_000, &cfg, &backend, &precompiles);

--- a/evm-adapters/src/sputnik/state.rs
+++ b/evm-adapters/src/sputnik/state.rs
@@ -261,7 +261,7 @@ mod tests {
         )
         .unwrap();
         let vicinity = G_VICINITY.clone();
-        let backend = SharedBackend::new(Arc::new(provider), cache.clone(), vicinity, None);
+        let backend = SharedBackend::new(Arc::new(provider), cache.clone(), vicinity, None, None);
         GlobalBackend { cache, backend }
     });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

running forked tests against a pinned block should be able to cache rpc return values across test runs to improve speed

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

if a cache path and pin block is provided, the cache will be dumped to disk on Drop
and loaded on instantiation

todo: need to fix the cli