### PR TITLE
ci: temporarily disable windows nightlies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,10 @@ jobs:
             platform: darwin
             target: aarch64-apple-darwin
             arch: arm64
-          - os: windows-latest
-            platform: win32
-            target: x86_64-pc-windows-msvc
-            arch: amd64
+          #- os: windows-latest
+          #  platform: win32
+          #  target: x86_64-pc-windows-msvc
+          #  arch: amd64
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
The Windows build is running out of memory which prevents the nightlies from releasing properly. Since `foundryup` does not support Windows anyway, we should disable the Windows nightlies until we find a long-term solution so we don't break all other releases