### PR TITLE
fix(config): include root argument in deserialization

### DIFF
--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -135,7 +135,7 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(foundry_toml, file);
 
     let config = forge_utils::load_config();
-    let profile = Config::load();
+    let profile = Config::load_with_root(prj.root());
     assert_eq!(config, profile.clone().sanitized());
 
     // ensure remappings contain test
@@ -154,7 +154,6 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     // remappings work
     let remappings_txt = prj.create_file("remappings.txt", "ds-test/=lib/ds-test/from-file/");
     let config = forge_utils::load_config();
-    println!("{:?}", config.remappings);
     assert_eq!(
         format!("ds-test/={}/", prj.root().join("lib/ds-test/from-file").display()),
         Remapping::from(config.remappings[0].clone()).to_string()

--- a/config/src/macros.rs
+++ b/config/src/macros.rs
@@ -20,6 +20,7 @@
 /// use foundry_config::figment::value::*;
 /// #[derive(Default, Serialize)]
 /// struct MyArgs {
+///     #[serde(skip_serializing_if = "Option::is_none")]
 ///     root: Option<PathBuf>,
 /// }
 /// impl_figment_convert!(MyArgs);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
include `root` when deserialising `Config` from `Figment`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
