### PR TITLE
feat(cast/abi-encode): support encoding function selector

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -325,8 +325,8 @@ async fn main() -> eyre::Result<()> {
             let tokens = foundry_utils::format_tokens(&tokens);
             tokens.for_each(|t| println!("{}", t));
         }
-        Subcommands::AbiEncode { sig, args } => {
-            println!("{}", SimpleCast::abi_encode(&sig, &args)?);
+        Subcommands::AbiEncode { sig, args, with_selector } => {
+            println!("{}", SimpleCast::abi_encode(&sig, &args, with_selector)?);
         }
         Subcommands::Index { from_type, to_type, from_value, slot_number } => {
             let encoded = SimpleCast::index(&from_type, &to_type, &from_value, &slot_number)?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -298,15 +298,15 @@ pub enum Subcommands {
         input: bool,
     },
     #[clap(name = "abi-encode")]
-    #[clap(
-        override_help = "ABI encodes the given arguments with the function signature, excluidng the selector"
-    )]
+    #[clap(about = "ABI encodes the given arguments with the function signature")]
     AbiEncode {
         #[clap(help = "the function signature")]
         sig: String,
         #[clap(help = "the list of function arguments")]
         #[clap(allow_hyphen_values = true)]
         args: Vec<String>,
+        #[clap(long, short, help = "include the 4byte function selector")]
+        with_selector: Option<bool>,
     },
     #[clap(name = "index")]
     #[clap(


### PR DESCRIPTION
adds support for including a function selector in the output of `abi-encode`

also fixes the commands docs