### PR TITLE
fix: don't prompt for keystore password on cast call

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -155,7 +155,7 @@ async fn main() -> eyre::Result<()> {
                 "{}",
                 Cast::new(provider)
                     .call(
-                        eth.sender().await,
+                        eth.from.unwrap_or(Address::zero()),
                         address,
                         (&sig, args),
                         eth.chain,


### PR DESCRIPTION
## Motivation

In https://github.com/gakonst/foundry/pull/398, the `call` method was modified to take a from address as an input, and `cast call` was configured to use `eth.sender().await` as the from address. This resulted in every usage of `cast call` prompting the user for a keystore password before executing the call

## Solution

`cast call` now defaults to using the zero address as the from address, unless one is specified with the `--from` flag. This is consistent with [seth's](https://github.com/dapphub/dapptools/blob/1be7d796a468f52a5eb5b6830591d76a3b4b1c49/src/seth/libexec/seth/seth-call#L60) and [geth's](https://geth.ethereum.org/docs/rpc/ns-eth#eth_call) behavior
