### PR TITLE
feat(cast): add ENS resolution for function parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "ethers-signers",
  "eyre",
  "foundry-utils",
+ "futures",
  "hex",
  "rustc-hex",
  "serde_json",

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 foundry-utils = { path = "../utils" }
+futures = "0.3.17"
 ethers-etherscan = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -273,7 +273,7 @@ where
 
         let func = if let Some((sig, args)) = args {
             let args = join_all(args.iter().map(|arg| async {
-                if arg.contains(".eth") {
+                if arg.ends_with(".eth") {
                     let val = format!(
                         "0x{}",
                         hex::encode(self.provider.resolve_name(arg).await?.as_bytes())

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -334,7 +334,7 @@ pub fn get_func(sig: &str) -> Result<Function> {
 pub async fn get_func_etherscan(
     function_name: &str,
     contract: Address,
-    args: Vec<String>,
+    args: &[String],
     chain: Chain,
     etherscan_api_key: String,
 ) -> Result<Function> {
@@ -352,7 +352,7 @@ pub async fn get_func_etherscan(
     let funcs = abi.functions.get(function_name).unwrap_or(&empty);
 
     for func in funcs {
-        let res = encode_args(func, &args);
+        let res = encode_args(func, args);
         if res.is_ok() {
             return Ok(func.clone())
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ENS resolution is not supported for function parameters in `cast call` and `cast send`. To see this error in actions, run `cast call dai balanceOf ncitron.eth`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This problem is solved by preprocessing all arguments in `build_tx` to check if the parameter contains the string ".eth". If it does, we automatically attempt to resolve the name.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
