### PR TITLE
feat: roll with hash 

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/backend.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/backend.rs
@@ -29,7 +29,11 @@ impl<B: Backend> Backend for CheatcodeBackend<B> {
     }
 
     fn block_hash(&self, number: U256) -> H256 {
-        self.backend.block_hash(number)
+        self.cheats
+            .block_hashes
+            .get(&number)
+            .cloned()
+            .unwrap_or_else(|| self.backend.block_hash(number))
     }
 
     fn block_number(&self) -> U256 {

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -610,6 +610,8 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             HEVMCalls::Roll(inner) => {
                 self.add_debug(CheatOp::ROLL);
                 self.state_mut().backend.cheats.block_number = Some(inner.0);
+                // insert a random block hash for the specified block number
+                self.state_mut().backend.cheats.block_hashes.insert(inner.0, H256::random());
             }
             HEVMCalls::Fee(inner) => {
                 self.add_debug(CheatOp::FEE);

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -610,8 +610,14 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
             HEVMCalls::Roll(inner) => {
                 self.add_debug(CheatOp::ROLL);
                 self.state_mut().backend.cheats.block_number = Some(inner.0);
-                // insert a random block hash for the specified block number
-                self.state_mut().backend.cheats.block_hashes.insert(inner.0, H256::random());
+                // insert a random block hash for the specified block number if it was not
+                // specified already
+                self.state_mut()
+                    .backend
+                    .cheats
+                    .block_hashes
+                    .entry(inner.0)
+                    .or_insert_with(H256::random);
             }
             HEVMCalls::Fee(inner) => {
                 self.add_debug(CheatOp::FEE);

--- a/evm-adapters/src/sputnik/cheatcodes/mod.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/mod.rs
@@ -29,6 +29,9 @@ pub struct Cheatcodes {
     pub accounts: HashMap<Address, MemoryAccount>,
     /// The overriden tx.origin
     pub origin: Option<Address>,
+    /// The overridden block hashes, whenever `roll` gets
+    /// called.
+    pub block_hashes: HashMap<U256, H256>,
 }
 
 /// Extension trait over [`Backend`] which provides additional methods for interacting with the

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -1,6 +1,6 @@
 // Taken from:
 // https://github.com/dapphub/dapptools/blob/e41b6cd9119bbd494aba1236838b859f2136696b/src/dapp-tests/pass/cheatCodes.sol
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.10;
 pragma experimental ABIEncoderV2;
 
 import "./DsTest.sol";
@@ -115,6 +115,21 @@ contract CheatCodes is DSTest {
         uint pre = block.number;
         hevm.roll(block.number + jump);
         require(block.number == pre + jump, "roll failed");
+        require(blockhash(block.number) != 0x0);
+    }
+
+    function testRollHash() public {
+        require(blockhash(block.number) == 0x0);
+        hevm.roll(5);
+        bytes32 hash = blockhash(5);
+        require(hash != 0x0);
+
+        hevm.roll(10);
+        require(blockhash(10) != 0x0);
+
+        // rolling back to 5 maintains the same hash
+        hevm.roll(5);
+        require(blockhash(5) == hash);
     }
 
     function testFailRoll(uint32 jump) public {
@@ -226,7 +241,7 @@ contract CheatCodes is DSTest {
 
         address new_sender = address(1337);
         hevm.deal(new_sender, 10 ether);
-        
+
         hevm.prank(new_sender);
         prank.payableBar{value: 1 ether}(new_sender);
         assertEq(new_sender.balance, 9 ether);
@@ -489,7 +504,7 @@ contract CheatCodes is DSTest {
             abi.encode(11)
         );
 
-        assertEq(target.add(5, 5), 11); 
+        assertEq(target.add(5, 5), 11);
         assertEq(target.add(6, 4), 10);
     }
 
@@ -503,7 +518,7 @@ contract CheatCodes is DSTest {
         );
 
         assertEq(target.numberA(), 1);
-        assertEq(target.numberB(), 10); 
+        assertEq(target.numberB(), 10);
 
         hevm.clearMockedCalls();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

When instantiating the environment, the block hashes are [empty](https://github.com/gakonst/foundry/blob/aabfb0ed15a9213f2eb26c9eb6635fdb6aee0a3c/evm-adapters/src/evm_opts.rs#L190). This makes sense as there's no notion of a blockchain in foundry, everything gets done at the evm level

However, this meant that if somebody wanted to get the blockhash at a height, they'd always get 0, e.g. [Ethernaut here](https://github.com/OpenZeppelin/ethernaut/blob/4f80f8afa47793d9133f03b6c247d8b6b0adc673/contracts/contracts/levels/CoinFlip.sol#L18). 

## Solution

Whenever a call to `roll(...)` is made, we also insert a randomly generated block hash if there was none before. In the above example, assuming the current block number is `num`, the solver of the puzzle would need to `vm.roll(num - 1)` so that the hash is populated, then `vm.roll(num)` so that the hash is used for the blockhash call.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
