### PR TITLE
ci: Linux Arm64 Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Build man page
         id: man
-        if: ${{ matrix.job.platform == 'linux' }}
+        if: ${{ matrix.job.target == 'x86_64-unknown-linux-gnu' }}
         env:
           PLATFORM_NAME: ${{ matrix.job.platform }}
           TARGET: ${{ matrix.job.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,12 @@ jobs:
           echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
+      - name: Linux ARM setup
+        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build binaries
         env:
           RUSTFLAGS: -C link-args=-s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,11 +72,15 @@ jobs:
           # The OS is used for the runner
           # The platform is a generic platform name
           # The target is used by Cargo
-          # The arch is either 386 or amd64
+          # The arch is either 386, arm64 or amd64
           - os: ubuntu-latest
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
+          - os: ubuntu-latest
+            platform: linux
+            target: aarch64-unknown-linux-gnu
+            arch: arm64
           - os: macos-latest
             platform: darwin
             target: x86_64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build binaries
         env:

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -18,7 +18,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 
 eyre = { version = "0.6.5", default-features = false }
 hex = "0.4.3"
-reqwest = { version = "0.11.8", features = ["json"] }
+reqwest = { version = "0.11.8", default-features = false, features = ["json", "rustls"] }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = "1.0.132"
 serde_json = { version = "1.0.67", default-features = false }


### PR DESCRIPTION
Follow-up on https://github.com/gakonst/foundry/pull/694

1. Try to address the OpenSSL-Sys issue that @onbjerg wrote in #694 by making `reqwest`'s `default-features = false`. The lockfile didn't change though, so I am inclined to believe that this isn't sufficient. Let's see
2. SVM-rs now supports arm linux builds, ref https://github.com/gakonst/foundry/issues/684#issuecomment-1032575637, https://github.com/nikitastupin/solc, https://github.com/roynalnaruto/svm-rs/pull/17