### PR TITLE
feat(forge): fuzz dictionary

### DIFF
--- a/evm-adapters/src/lib.rs
+++ b/evm-adapters/src/lib.rs
@@ -7,6 +7,7 @@ use crate::sputnik::cheatcodes::debugger::DebugArena;
 
 mod blocking_provider;
 use crate::call_tracing::CallTraceArena;
+use std::collections::HashSet;
 
 pub use blocking_provider::BlockingProvider;
 
@@ -222,6 +223,12 @@ pub trait Evm<State> {
 
     // TODO: Should we add a "deploy contract" function as well, or should we assume that
     // the EVM is instantiated with a DB that includes any needed contracts?
+
+    fn flatten_state(&self) -> HashSet<[u8; 32]>;
+}
+
+pub trait FuzzState {
+    fn flatten_state(&self) -> HashSet<[u8; 32]>;
 }
 
 // Test helpers which are generic over EVM implementation

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -8,7 +8,7 @@ use crate::{
     sputnik::{cheatcodes::memory_stackstate_owned::ExpectedEmit, Executor, SputnikExecutor},
     Evm,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use std::{fs::File, io::Read, path::Path};
 
@@ -34,14 +34,16 @@ use ethers::{
 
 use std::{convert::Infallible, str::FromStr};
 
-use crate::sputnik::cheatcodes::{
-    debugger::{CheatOp, DebugArena, DebugNode, DebugStep, OpCode},
-    memory_stackstate_owned::Prank,
-    patch_hardhat_console_log_selector,
+use crate::{
+    sputnik::cheatcodes::{
+        debugger::{CheatOp, DebugArena, DebugNode, DebugStep, OpCode},
+        memory_stackstate_owned::Prank,
+        patch_hardhat_console_log_selector,
+    },
+    FuzzState,
 };
-use once_cell::sync::Lazy;
-
 use ethers::abi::Tokenize;
+use once_cell::sync::Lazy;
 
 // This is now getting us the right hash? Also tried [..20]
 // Lazy::new(|| Address::from_slice(&keccak256("hevm cheat code")[12..]));
@@ -338,6 +340,10 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> SputnikExecutor<CheatcodeStackState<'
     fn logs(&self) -> Vec<String> {
         let logs = self.state().substate.logs().to_vec();
         logs.into_iter().filter_map(convert_log).chain(self.console_logs.clone()).collect()
+    }
+
+    fn flatten_state(&self) -> HashSet<[u8; 32]> {
+        self.state().flatten_state()
     }
 }
 

--- a/evm-adapters/src/sputnik/evm.rs
+++ b/evm-adapters/src/sputnik/evm.rs
@@ -1,4 +1,4 @@
-use crate::{call_tracing::CallTraceArena, Evm, FAUCET_ACCOUNT};
+use crate::{call_tracing::CallTraceArena, Evm, FuzzState, FAUCET_ACCOUNT};
 use ethers::types::{Address, Bytes, U256};
 
 use crate::sputnik::cheatcodes::debugger::DebugArena;
@@ -10,7 +10,10 @@ use sputnik::{
     },
     Config, CreateScheme, ExitReason, ExitRevert, Transfer,
 };
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::{
+    collections::{BTreeMap, HashSet},
+    marker::PhantomData,
+};
 
 use eyre::Result;
 
@@ -60,7 +63,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet>
 impl<'a, S, E> Evm<S> for Executor<S, E>
 where
     E: SputnikExecutor<S>,
-    S: StackState<'a>,
+    S: StackState<'a> + FuzzState,
 {
     type ReturnReason = ExitReason;
 
@@ -205,6 +208,10 @@ where
         self.executor.clear_logs();
 
         Ok((retdata.into(), status, gas.as_u64(), logs))
+    }
+
+    fn flatten_state(&self) -> HashSet<[u8; 32]> {
+        self.executor.flatten_state()
     }
 }
 

--- a/evm-adapters/src/sputnik/mod.rs
+++ b/evm-adapters/src/sputnik/mod.rs
@@ -23,6 +23,7 @@ use crate::{call_tracing::CallTraceArena, sputnik::cheatcodes::debugger::DebugAr
 
 pub use sputnik as sputnik_evm;
 use sputnik_evm::executor::stack::PrecompileSet;
+use std::collections::HashSet;
 
 /// Given an ethers provider and a block, it proceeds to construct a [`MemoryVicinity`] from
 /// the live chain data returned by the provider.
@@ -111,6 +112,8 @@ pub trait SputnikExecutor<S> {
     /// Clears all logs in the current EVM instance, so that subsequent calls to
     /// `logs` do not print duplicate logs on shared EVM instances.
     fn clear_logs(&mut self);
+
+    fn flatten_state(&self) -> HashSet<[u8; 32]>;
 }
 
 // The implementation for the base Stack Executor just forwards to the internal methods.
@@ -199,6 +202,10 @@ impl<'a, 'b, S: StackState<'a>, P: PrecompileSet> SputnikExecutor<S>
     }
 
     fn clear_logs(&mut self) {}
+
+    fn flatten_state(&self) -> HashSet<[u8; 32]> {
+        HashSet::new()
+    }
 }
 
 use std::borrow::Cow;


### PR DESCRIPTION
Implements a fuzzing dictionary per #387 

Takes a weighted union of 2 strategies, 40-60 weighted dictionary-random. Grabs state via a hack around the `deconstruct` method to get all state changes not applied (in our case, thats all of them), and flattens them into a hashset. We then pass this state hashset into the strategy creator which uses a selector to select a random value from the set as the input and transforms it into an input

Some limitations: bytes and strings types are only ever 32 bytes when pulling from state. probably improvements to be had there
