### PR TITLE
feat(forge create): print tx hash after deployment

### DIFF
--- a/cli/src/cmd/create.rs
+++ b/cli/src/cmd/create.rs
@@ -137,10 +137,11 @@ impl CreateArgs {
             deployer
         };
 
-        let deployed_contract = deployer.send().await?;
+        let (deployed_contract, receipt) = deployer.send_with_receipt().await?;
 
         println!("Deployer: {:?}", deployer_address);
         println!("Deployed to: {:?}", deployed_contract.address());
+        println!("Transaction hash: {:?}", receipt.transaction_hash);
 
         Ok(())
     }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Improve the devex of `forge create`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This commit prints the transaction hash of the deployment
transaction after running `forge create`. This is useful
for looking up the deployment transaction after the fact.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
