### PR TITLE
fix(fuzz): reset state to pre-test state

### DIFF
--- a/evm-adapters/src/fuzz.rs
+++ b/evm-adapters/src/fuzz.rs
@@ -124,6 +124,7 @@ impl<'a, S, E: Evm<S>> FuzzedExecutor<'a, E, S> {
                 revert_reason: revert_reason.into_inner().expect("Revert error string must be set"),
             });
 
+        self.evm.borrow_mut().reset(pre_test_state);
         FuzzTestResult { cases: FuzzedCases::new(fuzz_cases.into_inner()), test_error }
     }
 }


### PR DESCRIPTION
fixes https://github.com/gakonst/foundry/issues/734

Before:

```
forge t -vvvv
compiling...
no files changed, compilation skipped.
Running 1 test for ContractTest.json:ContractTest
[FAIL. Counterexample: calldata=0xda273f4e0000000000000000000000000000000000000000000000000000000000000000, args=[0]] testStateFailure(uint256) (runs: 0, μ: 0, ~: 0)
Traces:

  [80337] ContractTest::setUp()
    ├─ → new Contract@0xce71…c246
    │   └─ ← 227 bytes of code
    └─ ← ()
  [26011] ContractTest::testStateFailure(0)
    ├─ [20394] Contract::init()
    │   └─ ← ()
    ├─ [2444] Contract::func1(0)
    │   └─ ← 0
    └─ ← ()


Failed tests:
[FAIL. Counterexample: calldata=0xda273f4e0000000000000000000000000000000000000000000000000000000000000000, args=[0]] testStateFailure(uint256) (runs: 0, μ: 0, ~: 0)

```

--

After
```
[FAIL. Counterexample: calldata=0xda273f4e0000000000000000000000000000000000000000000000000000000000000000, args=[0]] testStateFailure(uint256) (runs: 0, μ: 0, ~: 0)
Logs:
  Error: Assertion Failed

Traces:

  [80337] ContractTest::setUp()
    ├─ → new Contract@0xce71…c246
    │   └─ ← 227 bytes of code
    └─ ← ()
  [26011] ContractTest::testStateFailure(0)
    ├─ [20394] Contract::init()
    │   └─ ← ()
    ├─ emit log(: "Error: Assertion Failed")
    ├─ [2444] Contract::func1(0)
    │   └─ ← 0
    └─ ← ()


Failed tests:
[FAIL. Counterexample: calldata=0xda273f4e0000000000000000000000000000000000000000000000000000000000000000, args=[0]] testStateFailure(uint256) (runs: 0, μ: 0, ~: 0)


```