### PR TITLE
chore: bump ethers version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1274,7 +1274,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1352,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#d28e6959db45a899bf5c4b6fc1feaa6efcb10aa1"
+source = "git+https://github.com/gakonst/ethers-rs#faba6e014da854e296d095541679e852e2288eec"
 dependencies = [
  "colored",
  "dunce",


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Updating `ethers-rs` so that https://github.com/gakonst/foundry/pull/682 can be pushed over the line

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Bumps `ethers` and associated dependencies to
[faba6e014da854e296d095541679e852e2288eec](https://github.com/gakonst/ethers-rs/commit/faba6e014da854e296d095541679e852e2288eec).
This was done by running the command `cargo update -p ethers-solc`.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
