### PR TITLE
fix(forge): expectEmit with call

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -1595,7 +1595,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> Handler for CheatcodeStackExecutor<'a
                 return evm_error("Log != expected log")
             } else {
                 // empty out expected_emits after successfully capturing all of them
-                self.state_mut().expected_emits = Vec::new();
+                self.state_mut().expected_emits.retain(|expected| !expected.found);
             }
 
             self.expected_revert(ExpectRevertReturn::Call(res), expected_revert).into_call_inner()

--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -432,6 +432,25 @@ contract CheatCodes is DSTest {
         emitter.t();
     }
 
+    // Test should fail because the data is different
+    function testFailExpectEmitWithCall1() public {
+        ExpectEmit emitter = new ExpectEmit();
+        hevm.deal(address(this), 1 ether);
+        hevm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1338), 1 gwei);
+        emitter.t4(payable(address(1337)), 100 gwei);
+    }
+
+
+    // Test should fail because, t5 doesn't emit
+    function testFailExpectEmitWithCall2() public {
+        ExpectEmit emitter = new ExpectEmit();
+        hevm.deal(address(this), 1 ether);
+        hevm.expectEmit(true,true,false,true);
+        emit Transfer(address(this), address(1338), 100 gwei);
+        emitter.t5(payable(address(1337)), 100 gwei);
+    }
+
     // Test should fail if nothing is called
     // after expectRevert
     function testFailExpectRevert3() public {
@@ -804,6 +823,15 @@ contract ExpectEmit {
     function t3() public {
         emit Transfer(msg.sender, address(1337), 1337);
         emit Transfer(msg.sender, address(1337), 1337);
+    }
+
+    function t4(address payable to, uint256 amount) public {
+        (bool success, ) = to.call{value: amount, gas: 30_000}(new bytes(0));
+        emit Transfer(msg.sender, address(1337), 100 gwei);
+    }
+
+    function t5(address payable to, uint256 amount) public {
+        (bool success, ) = to.call{value: amount, gas: 30_000}(new bytes(0));
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/gakonst/foundry/issues/668

Notice emitted a and b values below:

Before:
```
# [PASS] testExpectEmit() (gas: 33730)
Traces:

  [146057] ContractTest::setUp()
    ├─ → new Contract@0xce71…c246
    │   └─ ← 552 bytes of code
    ├─ [0] VM::deal(0xce71065d4017f316ec606fe4422e11eb2c47c246, 100000000000000000000)
    │   └─ ← ()
    └─ ← ()
  [33730] ContractTest::testExpectEmit()
    ├─ [0] VM::expectEmit(true, false, false, true)
    │   └─ ← ()
    ├─ emit ZEvent(a: 42893283, b: 4223232, c: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84)
    ├─ [31091] Contract::testemit(10)
    │   ├─ [45] ContractTest::fallback{value: 1}()
    │   │   └─ ← ()
    │   ├─ emit ZEvent(a: 1, b: 2, c: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84)
    │   └─ ← ()
    └─ ← ()
```

--

After 
```
[FAIL. Reason: Expected an emit, but no logs were emitted afterward] testExpectEmit() (gas: 33737)
Traces:

  [146057] ContractTest::setUp()
    ├─ → new Contract@0xce71…c246
    │   └─ ← 552 bytes of code
    ├─ [0] VM::deal(0xce71065d4017f316ec606fe4422e11eb2c47c246, 100000000000000000000)
    │   └─ ← ()
    └─ ← ()
  [33737] ContractTest::testExpectEmit()
    ├─ [0] VM::expectEmit(true, false, false, true)
    │   └─ ← ()
    ├─ emit ZEvent(a: 42893283, b: 4223232, c: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84)
    ├─ [31091] Contract::testemit(10)
    │   ├─ [45] ContractTest::fallback{value: 1}()
    │   │   └─ ← ()
    │   ├─ emit ZEvent(a: 1, b: 2, c: 0xb4c79dab8f259c7aee6e5b2aa729821864227e84)
    │   └─ ← ()
    └─ ← "Log != expected log"
```
