### PR TITLE
feat: make artifact type configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -1088,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "16.0.0"
-source = "git+https://github.com/rust-ethereum/ethabi?branch=master#321a651e767d7dbe81e8606cbf42f08dedf58c2b"
+source = "git+https://github.com/rust-ethereum/ethabi?branch=master#e161e688f1f567b25e829f62df053cf9bff1303a"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1354,8 +1354,8 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#f97a8ca5410331145cb742d40ebfe4a816dd3190"
+version = "0.3.0"
+source = "git+https://github.com/gakonst/ethers-rs#19d2fd115529ec18652f2ce544a9e52d70047883"
 dependencies = [
  "colored",
  "dunce",

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -1,6 +1,6 @@
 //! build command
 
-use ethers::solc::{MinimalCombinedArtifacts, Project, ProjectCompileOutput};
+use ethers::solc::{ConfigurableArtifacts, Project, ProjectCompileOutput};
 use std::path::PathBuf;
 
 use crate::{cmd::Cmd, opts::forge::CompilerArgs};
@@ -152,7 +152,7 @@ pub struct BuildArgs {
 }
 
 impl Cmd for BuildArgs {
-    type Output = ProjectCompileOutput<MinimalCombinedArtifacts>;
+    type Output = ProjectCompileOutput<ConfigurableArtifacts>;
     fn run(self) -> eyre::Result<Self::Output> {
         let project = self.project()?;
         super::compile(&project)
@@ -220,8 +220,14 @@ impl Provider for BuildArgs {
             dict.insert("optimizer".to_string(), self.compiler.optimize.into());
         }
 
-        if let Some(extra) = &self.compiler.extra_output {
-            dict.insert("extra_output".to_string(), extra.clone().into());
+        if let Some(ref extra) = self.compiler.extra_output {
+            let selection: Vec<_> = extra.into_iter().map(|s| s.to_string()).collect();
+            dict.insert("extra_output".to_string(), selection.into());
+        }
+
+        if let Some(ref extra) = self.compiler.extra_output_files {
+            let selection: Vec<_> = extra.into_iter().map(|s| s.to_string()).collect();
+            dict.insert("extra_output_files".to_string(), selection.into());
         }
 
         Ok(Map::from([(Config::selected_profile(), dict)]))

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -1,6 +1,6 @@
 //! build command
 
-use ethers::solc::{ConfigurableArtifacts, Project, ProjectCompileOutput};
+use ethers::solc::{Project, ProjectCompileOutput};
 use std::path::PathBuf;
 
 use crate::{cmd::Cmd, opts::forge::CompilerArgs};
@@ -152,7 +152,7 @@ pub struct BuildArgs {
 }
 
 impl Cmd for BuildArgs {
-    type Output = ProjectCompileOutput<ConfigurableArtifacts>;
+    type Output = ProjectCompileOutput;
     fn run(self) -> eyre::Result<Self::Output> {
         let project = self.project()?;
         super::compile(&project)
@@ -221,12 +221,12 @@ impl Provider for BuildArgs {
         }
 
         if let Some(ref extra) = self.compiler.extra_output {
-            let selection: Vec<_> = extra.into_iter().map(|s| s.to_string()).collect();
+            let selection: Vec<_> = extra.iter().map(|s| s.to_string()).collect();
             dict.insert("extra_output".to_string(), selection.into());
         }
 
         if let Some(ref extra) = self.compiler.extra_output_files {
-            let selection: Vec<_> = extra.into_iter().map(|s| s.to_string()).collect();
+            let selection: Vec<_> = extra.iter().map(|s| s.to_string()).collect();
             dict.insert("extra_output_files".to_string(), selection.into());
         }
 

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -68,13 +68,11 @@ pub trait Cmd: clap::Parser + Sized {
     fn run(self) -> eyre::Result<Self::Output>;
 }
 
-use ethers::solc::{
-    artifacts::CompactContractBytecode, ConfigurableArtifacts, Project, ProjectCompileOutput,
-};
+use ethers::solc::{artifacts::CompactContractBytecode, Project, ProjectCompileOutput};
 
 /// Compiles the provided [`Project`], throws if there's any compiler error and logs whether
 /// compilation was successful or if there was a cache hit.
-pub fn compile(project: &Project) -> eyre::Result<ProjectCompileOutput<ConfigurableArtifacts>> {
+pub fn compile(project: &Project) -> eyre::Result<ProjectCompileOutput> {
     if !project.paths.sources.exists() {
         eyre::bail!(
             r#"no contracts to compile, contracts folder "{}" does not exist.
@@ -103,7 +101,7 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
 pub fn manual_compile(
     project: &Project,
     added_sources: Vec<PathBuf>,
-) -> eyre::Result<ProjectCompileOutput<ConfigurableArtifacts>> {
+) -> eyre::Result<ProjectCompileOutput> {
     let mut sources = project.paths.read_input_files()?;
     sources.extend(Source::read_all_files(added_sources)?);
     println!("compiling...");
@@ -135,7 +133,7 @@ pub fn manual_compile(
 /// Runtime Bytecode of the given contract.
 pub fn read_artifact(
     project: &Project,
-    compiled: ProjectCompileOutput<ConfigurableArtifacts>,
+    compiled: ProjectCompileOutput,
     contract: ContractInfo,
 ) -> eyre::Result<(Abi, CompactBytecode, CompactDeployedBytecode)> {
     Ok(match contract.path {
@@ -149,7 +147,7 @@ pub fn read_artifact(
 // contract name?
 fn get_artifact_from_name(
     contract: ContractInfo,
-    compiled: ProjectCompileOutput<ConfigurableArtifacts>,
+    compiled: ProjectCompileOutput,
 ) -> eyre::Result<(Abi, CompactBytecode, CompactDeployedBytecode)> {
     let mut has_found_contract = false;
     let mut contract_artifact = None;

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -69,12 +69,12 @@ pub trait Cmd: clap::Parser + Sized {
 }
 
 use ethers::solc::{
-    artifacts::CompactContractBytecode, MinimalCombinedArtifacts, Project, ProjectCompileOutput,
+    artifacts::CompactContractBytecode, ConfigurableArtifacts, Project, ProjectCompileOutput,
 };
 
 /// Compiles the provided [`Project`], throws if there's any compiler error and logs whether
 /// compilation was successful or if there was a cache hit.
-pub fn compile(project: &Project) -> eyre::Result<ProjectCompileOutput<MinimalCombinedArtifacts>> {
+pub fn compile(project: &Project) -> eyre::Result<ProjectCompileOutput<ConfigurableArtifacts>> {
     if !project.paths.sources.exists() {
         eyre::bail!(
             r#"no contracts to compile, contracts folder "{}" does not exist.
@@ -101,9 +101,9 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
 
 /// Manually compile a project with added sources
 pub fn manual_compile(
-    project: &Project<MinimalCombinedArtifacts>,
+    project: &Project,
     added_sources: Vec<PathBuf>,
-) -> eyre::Result<ProjectCompileOutput<MinimalCombinedArtifacts>> {
+) -> eyre::Result<ProjectCompileOutput<ConfigurableArtifacts>> {
     let mut sources = project.paths.read_input_files()?;
     sources.extend(Source::read_all_files(added_sources)?);
     println!("compiling...");
@@ -135,7 +135,7 @@ pub fn manual_compile(
 /// Runtime Bytecode of the given contract.
 pub fn read_artifact(
     project: &Project,
-    compiled: ProjectCompileOutput<MinimalCombinedArtifacts>,
+    compiled: ProjectCompileOutput<ConfigurableArtifacts>,
     contract: ContractInfo,
 ) -> eyre::Result<(Abi, CompactBytecode, CompactDeployedBytecode)> {
     Ok(match contract.path {
@@ -149,7 +149,7 @@ pub fn read_artifact(
 // contract name?
 fn get_artifact_from_name(
     contract: ContractInfo,
-    compiled: ProjectCompileOutput<MinimalCombinedArtifacts>,
+    compiled: ProjectCompileOutput<ConfigurableArtifacts>,
 ) -> eyre::Result<(Abi, CompactBytecode, CompactDeployedBytecode)> {
     let mut has_found_contract = false;
     let mut contract_artifact = None;

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -7,7 +7,7 @@ use foundry_utils::IntoFunction;
 use std::{collections::BTreeMap, path::PathBuf};
 use ui::{TUIExitReason, Tui, Ui};
 
-use ethers::solc::{ConfigurableArtifacts, Project};
+use ethers::solc::Project;
 
 use crate::opts::evm::EvmArgs;
 use ansi_term::Colour;
@@ -264,7 +264,7 @@ struct ExtraLinkingInfo<'a> {
 }
 
 pub struct BuildOutput {
-    pub project: Project<ConfigurableArtifacts>,
+    pub project: Project,
     pub contract: CompactContractBytecode,
     pub highlevel_known_contracts: BTreeMap<String, ContractBytecodeSome>,
     pub sources: BTreeMap<u32, String>,

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -7,7 +7,7 @@ use foundry_utils::IntoFunction;
 use std::{collections::BTreeMap, path::PathBuf};
 use ui::{TUIExitReason, Tui, Ui};
 
-use ethers::solc::{MinimalCombinedArtifacts, Project};
+use ethers::solc::{ConfigurableArtifacts, Project};
 
 use crate::opts::evm::EvmArgs;
 use ansi_term::Colour;
@@ -264,7 +264,7 @@ struct ExtraLinkingInfo<'a> {
 }
 
 pub struct BuildOutput {
-    pub project: Project<MinimalCombinedArtifacts>,
+    pub project: Project<ConfigurableArtifacts>,
     pub contract: CompactContractBytecode,
     pub highlevel_known_contracts: BTreeMap<String, ContractBytecodeSome>,
     pub sources: BTreeMap<u32, String>,

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand, ValueHint};
 
-use ethers::solc::EvmVersion;
+use ethers::solc::{artifacts::output_selection::ContractOutputSelection, EvmVersion};
 use std::{path::PathBuf, str::FromStr};
 
 use crate::cmd::{
@@ -138,11 +138,18 @@ pub struct CompilerArgs {
     pub optimize_runs: Option<usize>,
 
     #[clap(
-        help = "Extra output types [evm.assembly, ewasm, ir, irOptimized] eg: `--extra-output evm.assembly`",
+        help = "Extra output types to include in the contract's json artifact [evm.assembly, ewasm, ir, irOptimized, metadata] eg: `--extra-output evm.assembly`",
         long
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extra_output: Option<Vec<String>>,
+    pub extra_output: Option<Vec<ContractOutputSelection>>,
+
+    #[clap(
+        help = "Extra output types to write to a separate file [metadata, ir, irOptimized, ewasm] eg: `--extra-output-files metadata`",
+        long
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_output_files: Option<Vec<ContractOutputSelection>>,
 }
 
 /// Represents the common dapp argument pattern for `<path>:<contractname>` where `<path>:` is

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -1,4 +1,8 @@
-use ethers_solc::{cache::SolFilesCache, project_util::{copy_dir, TempProject}, ArtifactOutput, PathStyle, ProjectPathsConfig, ConfigurableArtifacts};
+use ethers_solc::{
+    cache::SolFilesCache,
+    project_util::{copy_dir, TempProject},
+    ArtifactOutput, ConfigurableArtifacts, PathStyle, ProjectPathsConfig,
+};
 use foundry_config::Config;
 use once_cell::sync::Lazy;
 use std::{

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -267,6 +267,11 @@ impl TestCommand {
         self
     }
 
+    /// Resets the command
+    pub fn fuse(&mut self)  -> &mut TestCommand {
+        self.set_cmd(self.project.bin())
+    }
+
     /// Sets the current working directory
     pub fn set_current_dir(&mut self, p: impl AsRef<Path>) {
         drop(self.current_dir_lock.take());

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -1,8 +1,4 @@
-use ethers_solc::{
-    cache::SolFilesCache,
-    project_util::{copy_dir, TempProject},
-    ArtifactOutput, MinimalCombinedArtifacts, PathStyle, ProjectPathsConfig,
-};
+use ethers_solc::{cache::SolFilesCache, project_util::{copy_dir, TempProject}, ArtifactOutput, PathStyle, ProjectPathsConfig, ConfigurableArtifacts};
 use foundry_config::Config;
 use once_cell::sync::Lazy;
 use std::{
@@ -75,7 +71,7 @@ pub fn setup_project(test: TestProject) -> (TestProject, TestCommand) {
 ///
 /// Test projects are created from a global atomic counter to avoid duplicates.
 #[derive(Clone, Debug)]
-pub struct TestProject<T: ArtifactOutput = MinimalCombinedArtifacts> {
+pub struct TestProject<T: ArtifactOutput = ConfigurableArtifacts> {
     /// The directory in which this test executable is running.
     root: PathBuf,
     /// The project in which the test should run.

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -268,7 +268,7 @@ impl TestCommand {
     }
 
     /// Resets the command
-    pub fn fuse(&mut self)  -> &mut TestCommand {
+    pub fn fuse(&mut self) -> &mut TestCommand {
         self.set_cmd(self.project.bin())
     }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -167,9 +167,9 @@ pub struct Config {
     // "#
     #[serde(default)]
     pub extra_output: Vec<ContractOutputSelection>,
-    /// If set , a separate `json` file will be emitted for every contract depending on the selection,
-    /// eg. `extra_output_files = ["metadata"]` will create a `metadata.json` for each contract in the project.
-    /// See [Contract Metadata](https://docs.soliditylang.org/en/latest/metadata.html)
+    /// If set , a separate `json` file will be emitted for every contract depending on the
+    /// selection, eg. `extra_output_files = ["metadata"]` will create a `metadata.json` for
+    /// each contract in the project. See [Contract Metadata](https://docs.soliditylang.org/en/latest/metadata.html)
     ///
     /// The difference between `extra_output = ["metadata"]` and
     /// `extra_output_files = ["metadata]` is that the former will include the

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -167,7 +167,8 @@ pub struct Config {
     // "#
     #[serde(default)]
     pub extra_output: Vec<ContractOutputSelection>,
-    /// If set to `true`, a separate `metadata.json` will be emitted for every contract.
+    /// If set , a separate `json` file will be emitted for every contract depending on the selection,
+    /// eg. `extra_output_files = ["metadata"]` will create a `metadata.json` for each contract in the project.
     /// See [Contract Metadata](https://docs.soliditylang.org/en/latest/metadata.html)
     ///
     /// The difference between `extra_output = ["metadata"]` and


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

~~**BLOCKED BY** https://github.com/gakonst/ethers-rs/pull/907~~

## Motivation
Close #705
Close #765
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
add additional config and cli options to add additional items to the contract artifact and/or emit them as additional file like metadata

`--extra-output <metadata|ir|ir-optimized|...>` will add the provided selection to the contract's json artifact.

`--extra-output-files <metadata|ir|ir-optimized|...>` will emit the provided selection as additional file, eg. `forge build --extra-output-files metadata` will put the `Contract.sol` metadata in `Contract.metadata.json` next to the artifact `Contract.json`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
