### PR TITLE
feat(cast): cast pretty-calldata

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -413,6 +413,7 @@ SUBCOMMANDS:
     4byte                    Fetches function signatures given the selector from 4byte.directory
     4byte-decode             Decodes transaction calldata by fetching the signature using 4byte.directory
     4byte-event              Takes a 32 byte topic and prints the response from querying 4byte.directory for that topic
+    pretty-calldata          Pretty prints calldata, if available gets signature from 4byte.directory
     abi-encode
     age                      Prints the timestamp of a block
     balance                  Print the balance of <account> in wei

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -368,12 +368,12 @@ async fn main() -> eyre::Result<()> {
             sigs.iter().for_each(|sig| println!("{}", sig.0));
         }
 
-        Subcommands::PrettyCalldata { calldata } => {
+        Subcommands::PrettyCalldata { calldata, offline } => {
             if !calldata.starts_with("0x") {
                 eprintln!("Expected calldata hex string, received \"{}\"", calldata);
                 std::process::exit(0)
             }
-            let pretty_data = foundry_utils::pretty_calldata(&calldata).await?;
+            let pretty_data = foundry_utils::pretty_calldata(&calldata, offline).await?;
             println!("{}", pretty_data);
         }
         Subcommands::Age { block, rpc_url } => {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -367,6 +367,15 @@ async fn main() -> eyre::Result<()> {
             let sigs = foundry_utils::fourbyte_event(&topic).await?;
             sigs.iter().for_each(|sig| println!("{}", sig.0));
         }
+
+        Subcommands::PrettyCalldata { calldata } => {
+            if !calldata.starts_with("0x") {
+                eprintln!("Expected calldata hex string, received \"{}\"", calldata);
+                std::process::exit(0)
+            }
+            let pretty_data = foundry_utils::pretty_calldata(calldata).await?;
+            println!("{}", pretty_data);
+        }
         Subcommands::Age { block, rpc_url } => {
             let provider = Provider::try_from(rpc_url)?;
             println!(

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -373,7 +373,7 @@ async fn main() -> eyre::Result<()> {
                 eprintln!("Expected calldata hex string, received \"{}\"", calldata);
                 std::process::exit(0)
             }
-            let pretty_data = foundry_utils::pretty_calldata(calldata).await?;
+            let pretty_data = foundry_utils::pretty_calldata(&calldata).await?;
             println!("{}", pretty_data);
         }
         Subcommands::Age { block, rpc_url } => {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -329,7 +329,7 @@ pub enum Subcommands {
         #[clap(help = "Hex encoded calldata")]
         calldata: String,
         #[clap(long, short, help = "Skip the 4byte directory lookup.")]
-        offline: bool
+        offline: bool,
     },
 
     #[clap(name = "age")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -328,6 +328,8 @@ pub enum Subcommands {
     PrettyCalldata {
         #[clap(help = "Hex encoded calldata")]
         calldata: String,
+        #[clap(long, short, help = "Skip the 4byte directory lookup.")]
+        offline: bool
     },
 
     #[clap(name = "age")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -323,6 +323,13 @@ pub enum Subcommands {
         #[clap(help = "the 32 byte topic")]
         topic: String,
     },
+    #[clap(name = "pretty-calldata")]
+    #[clap(about = "Pretty prints calldata, if available gets signature from 4byte.directory")]
+    PrettyCalldata {
+        #[clap(help = "Hex encoded calldata")]
+        calldata: String,
+    },
+
     #[clap(name = "age")]
     #[clap(about = "Prints the timestamp of a block")]
     Age {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 use std::{
     collections::{BTreeMap, HashSet},
     env::VarError,
+    fmt,
 };
 
 use tokio::runtime::{Handle, Runtime};
@@ -45,6 +46,42 @@ impl RuntimeOrHandle {
             RuntimeOrHandle::Runtime(runtime) => runtime.block_on(f),
             RuntimeOrHandle::Handle(handle) => tokio::task::block_in_place(|| handle.block_on(f)),
         }
+    }
+}
+
+pub enum SelectorOrSig {
+    Selector(String),
+    Sig(Vec<String>),
+}
+
+pub struct PossibleSigs {
+    method: SelectorOrSig,
+    data: Vec<String>,
+}
+impl PossibleSigs {
+    fn new() -> Self {
+        PossibleSigs { method: SelectorOrSig::Selector("0x00000000".to_string()), data: vec![] }
+    }
+}
+impl fmt::Display for PossibleSigs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.method {
+            SelectorOrSig::Selector(selector) => {
+                writeln!(f, "\n Method: {}", selector)?;
+            }
+            SelectorOrSig::Sig(sigs) => {
+                writeln!(f, "\n Possible methods:")?;
+                for sig in sigs {
+                    writeln!(f, " - {}", sig)?;
+                }
+            }
+        }
+
+        writeln!(f, " ------------")?;
+        for (i, row) in self.data.iter().enumerate() {
+            writeln!(f, " [{}]: {}", i, row)?;
+        }
+        Ok(())
     }
 }
 
@@ -503,6 +540,47 @@ pub async fn fourbyte_event(topic: &str) -> Result<Vec<(String, i32)>> {
         .into_iter()
         .map(|d| (d.text_signature, d.id))
         .collect::<Vec<(String, i32)>>())
+}
+
+/// Pretty print calldata and if available, fetch possible function signatures
+///
+/// ```no_run
+/// 
+/// use foundry_utils::pretty_calldata;
+///
+/// # async fn foo() -> eyre::Result<()> {
+///   let pretty_data = pretty_calldata("0x70a08231000000000000000000000000d0074f4e6490ae3f888d1d4f7e3e43326bd3f0f5".to_string()).await?;
+///   println!("{}",pretty_data);
+/// # Ok(())
+/// # }
+/// ```
+
+pub async fn pretty_calldata(calldata: String) -> Result<PossibleSigs> {
+    let mut possible_info = PossibleSigs::new();
+    let calldata = calldata.strip_prefix("0x").unwrap();
+
+    let selector =
+        calldata.get(..8).ok_or_else(|| eyre::eyre!("calldata cannot be less that 4 bytes"))?;
+
+    let sigs: Vec<String> = fourbyte(selector).await?.into_iter().map(|sig| sig.0).collect();
+    let (_, data) = calldata.split_at(8);
+
+    if data.len() % 64 != 0 {
+        eprintln!("\nInvalid calldata size");
+        std::process::exit(0)
+    }
+
+    let row_length = data.len() / 64;
+
+    for row in 0..row_length {
+        possible_info.data.push(data[64 * row..64 * (row + 1)].to_string());
+    }
+    if sigs.is_empty() {
+        possible_info.method = SelectorOrSig::Selector(selector.to_string());
+    } else {
+        possible_info.method = SelectorOrSig::Sig(sigs);
+    }
+    Ok(possible_info)
 }
 
 pub fn abi_decode(sig: &str, calldata: &str, input: bool) -> Result<Vec<Token>> {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -546,7 +546,7 @@ pub async fn fourbyte_event(topic: &str) -> Result<Vec<(String, i32)>> {
 /// Pretty print calldata and if available, fetch possible function signatures
 ///
 /// ```no_run
-///
+/// 
 /// use foundry_utils::pretty_calldata;
 ///
 /// # async fn foo() -> eyre::Result<()> {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -545,7 +545,7 @@ pub async fn fourbyte_event(topic: &str) -> Result<Vec<(String, i32)>> {
 /// Pretty print calldata and if available, fetch possible function signatures
 ///
 /// ```no_run
-/// 
+///
 /// use foundry_utils::pretty_calldata;
 ///
 /// # async fn foo() -> eyre::Result<()> {
@@ -555,14 +555,18 @@ pub async fn fourbyte_event(topic: &str) -> Result<Vec<(String, i32)>> {
 /// # }
 /// ```
 
-pub async fn pretty_calldata(calldata: impl AsRef<str>) -> Result<PossibleSigs> {
+pub async fn pretty_calldata(calldata: impl AsRef<str>, offline: bool) -> Result<PossibleSigs> {
     let mut possible_info = PossibleSigs::new();
     let calldata = calldata.as_ref().trim_start_matches("0x");
 
     let selector =
         calldata.get(..8).ok_or_else(|| eyre::eyre!("calldata cannot be less that 4 bytes"))?;
 
-    let sigs: Vec<String> = fourbyte(selector).await?.into_iter().map(|sig| sig.0).collect();
+    let sigs = if offline {
+        vec![]
+    } else {
+        fourbyte(selector).await?.into_iter().map(|sig| sig.0).collect();
+    };
     let (_, data) = calldata.split_at(8);
 
     if data.len() % 64 != 0 {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -555,9 +555,9 @@ pub async fn fourbyte_event(topic: &str) -> Result<Vec<(String, i32)>> {
 /// # }
 /// ```
 
-pub async fn pretty_calldata(calldata: String) -> Result<PossibleSigs> {
+pub async fn pretty_calldata(calldata: impl AsRef<str>) -> Result<PossibleSigs> {
     let mut possible_info = PossibleSigs::new();
-    let calldata = calldata.strip_prefix("0x").unwrap();
+    let calldata = calldata.as_ref().trim_start_matches("0x");
 
     let selector =
         calldata.get(..8).ok_or_else(|| eyre::eyre!("calldata cannot be less that 4 bytes"))?;
@@ -566,8 +566,7 @@ pub async fn pretty_calldata(calldata: String) -> Result<PossibleSigs> {
     let (_, data) = calldata.split_at(8);
 
     if data.len() % 64 != 0 {
-        eprintln!("\nInvalid calldata size");
-        std::process::exit(0)
+        eyre::bail!("\nInvalid calldata size")
     }
 
     let row_length = data.len() / 64;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -79,7 +79,8 @@ impl fmt::Display for PossibleSigs {
 
         writeln!(f, " ------------")?;
         for (i, row) in self.data.iter().enumerate() {
-            writeln!(f, " [{}]: {}", i, row)?;
+            let pad = if i < 10 { "  " } else { " " };
+            writeln!(f, " [{}]:{}{}", i, pad, row)?;
         }
         Ok(())
     }
@@ -565,7 +566,7 @@ pub async fn pretty_calldata(calldata: impl AsRef<str>, offline: bool) -> Result
     let sigs = if offline {
         vec![]
     } else {
-        fourbyte(selector).await?.into_iter().map(|sig| sig.0).collect();
+        fourbyte(selector).await?.into_iter().map(|sig| sig.0).collect()
     };
     let (_, data) = calldata.split_at(8);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Implementing `cast pretty-calldata` . Mentioned here #732 

### Note
- It will attempt to get signatures from 4byte.directory by default 
- Get's possibilities from 4byte and displays them using a helper struct

Let me know if need to make any changes or any Rust related feedback, thanks!


Example
![image](https://user-images.githubusercontent.com/22870103/154625342-e378a1ec-935c-4697-bf87-ecd88f273d19.png)
