### PR TITLE
feat(cast): add find-block command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ dependencies = [
  "foundry-cli-test-utils",
  "foundry-config",
  "foundry-utils",
+ "futures",
  "glob",
  "hex",
  "locate-cargo-manifest",

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -405,6 +405,10 @@ where
         Ok(datetime.format("%a %b %e %H:%M:%S %Y").to_string())
     }
 
+    pub async fn timestamp<T: Into<BlockId>>(&self, block: T) -> Result<U256> {
+        Ok(Cast::block_field_as_num(self, block, String::from("timestamp")).await?)
+    }
+
     pub async fn chain(&self) -> Result<&str> {
         let genesis_hash = Cast::block(
             self,
@@ -1219,7 +1223,6 @@ impl SimpleCast {
     /// #    Ok(())
     /// # }
     /// ```
-
     pub fn index(
         from_type: &str,
         to_type: &str,

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -50,7 +50,7 @@ where
     /// Makes a read-only call to the specified address
     ///
     /// ```no_run
-    /// 
+    ///
     /// use cast::Cast;
     /// use ethers_core::types::{Address, Chain};
     /// use ethers_providers::{Provider, Http};
@@ -406,7 +406,7 @@ where
     }
 
     pub async fn timestamp<T: Into<BlockId>>(&self, block: T) -> Result<U256> {
-        Ok(Cast::block_field_as_num(self, block, "timestamp".to_string()).await?)
+        Cast::block_field_as_num(self, block, "timestamp".to_string()).await
     }
 
     pub async fn chain(&self) -> Result<&str> {
@@ -1217,7 +1217,7 @@ impl SimpleCast {
     /// # use cast::SimpleCast as Cast;
     ///
     /// # fn main() -> eyre::Result<()> {
-    ///    
+    ///
     ///    assert_eq!(Cast::index("address", "uint256" ,"0xD0074F4E6490ae3f888d1d4f7E3E43326bD3f0f5" ,"2").unwrap().as_str(),"0x9525a448a9000053a4d151336329d6563b7e80b24f8e628e95527f218e8ab5fb");
     ///    assert_eq!(Cast::index("uint256", "uint256" ,"42" ,"6").unwrap().as_str(),"0xfc808b0f31a1e6b9cf25ff6289feae9b51017b392cc8e25620a94a38dcdafcc1");
     /// #    Ok(())

--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -406,7 +406,7 @@ where
     }
 
     pub async fn timestamp<T: Into<BlockId>>(&self, block: T) -> Result<U256> {
-        Ok(Cast::block_field_as_num(self, block, String::from("timestamp")).await?)
+        Ok(Cast::block_field_as_num(self, block, "timestamp".to_string()).await?)
     }
 
     pub async fn chain(&self) -> Result<&str> {

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,6 +44,7 @@ tracing = "0.1.26"
 hex = "0.4.3"
 rayon = "1.5.1"
 serde = "1.0.133"
+futures = "0.3.17"
 
 ## EVM Implementations
 # evm = { version = "0.30.1" }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -506,47 +506,46 @@ async fn main() -> eyre::Result<()> {
             let last_block_num = provider.get_block_number().await?;
             let cast_provider = Cast::new(provider);
             let ts_block = cast_provider.timestamp(last_block_num).await?;
-            let block_num = match ts_block.lt(&ts_target) {
+            let block_num = if ts_block.lt(&ts_target) {
                 // If the most recent block's timestamp is below the target, return it
-                true => last_block_num,
+                last_block_num
+            } else {
                 // Otherwise, find the block that is closest to the timestamp
-                false => {
-                    let mut low_block = U64::from(1); // block 0 has a timestamp of 0: https://github.com/ethereum/go-ethereum/issues/17042#issuecomment-559414137
-                    let mut high_block = last_block_num;
-                    let mut matching_block: Option<U64> = None;
-                    while high_block.gt(&low_block) && matching_block.is_none() {
-                        // Get timestamp of middle block (this approach approach to avoids overflow)
-                        let high_minus_low_over_2 = high_block
-                            .checked_sub(low_block)
-                            .unwrap()
-                            .checked_div(U64::from(2))
-                            .unwrap();
-                        let mid_block = high_block.checked_sub(high_minus_low_over_2).unwrap();
-                        let ts_mid_block = cast_provider.timestamp(mid_block).await?;
+                let mut low_block = U64::from(1); // block 0 has a timestamp of 0: https://github.com/ethereum/go-ethereum/issues/17042#issuecomment-559414137
+                let mut high_block = last_block_num;
+                let mut matching_block: Option<U64> = None;
+                while high_block.gt(&low_block) && matching_block.is_none() {
+                    // Get timestamp of middle block (this approach approach to avoids overflow)
+                    let high_minus_low_over_2 = high_block
+                        .checked_sub(low_block)
+                        .unwrap()
+                        .checked_div(U64::from(2))
+                        .unwrap();
+                    let mid_block = high_block.checked_sub(high_minus_low_over_2).unwrap();
+                    let ts_mid_block = cast_provider.timestamp(mid_block).await?;
 
-                        // Check if we've found a match or should keep searching
-                        if ts_mid_block.eq(&ts_target) {
-                            matching_block = Some(mid_block)
-                        } else if high_block.checked_sub(low_block).unwrap().eq(&U64::from(1)) {
-                            // The target timestamp is in between these blocks. This rounds to the
-                            // highest block if timestamp is equidistant between blocks
-                            let ts_high = cast_provider.timestamp(high_block).await?;
-                            let ts_low = cast_provider.timestamp(low_block).await?;
-                            let high_diff = ts_high.checked_sub(ts_target).unwrap();
-                            let low_diff = ts_target.checked_sub(ts_low).unwrap();
-                            let is_low = low_diff.lt(&high_diff);
-                            matching_block = if is_low { Some(low_block) } else { Some(high_block) }
-                        } else if ts_mid_block.lt(&ts_target) {
-                            low_block = mid_block;
-                        } else {
-                            high_block = mid_block;
-                        }
+                    // Check if we've found a match or should keep searching
+                    if ts_mid_block.eq(&ts_target) {
+                        matching_block = Some(mid_block)
+                    } else if high_block.checked_sub(low_block).unwrap().eq(&U64::from(1)) {
+                        // The target timestamp is in between these blocks. This rounds to the
+                        // highest block if timestamp is equidistant between blocks
+                        let ts_high = cast_provider.timestamp(high_block).await?;
+                        let ts_low = cast_provider.timestamp(low_block).await?;
+                        let high_diff = ts_high.checked_sub(ts_target).unwrap();
+                        let low_diff = ts_target.checked_sub(ts_low).unwrap();
+                        let is_low = low_diff.lt(&high_diff);
+                        matching_block = if is_low { Some(low_block) } else { Some(high_block) }
+                    } else if ts_mid_block.lt(&ts_target) {
+                        low_block = mid_block;
+                    } else {
+                        high_block = mid_block;
                     }
-                    if matching_block.is_none() {
-                        matching_block = Some(low_block);
-                    }
-                    matching_block.unwrap()
                 }
+                if matching_block.is_none() {
+                    matching_block = Some(low_block);
+                }
+                matching_block.unwrap()
             };
             println!("{}", block_num);
         }

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -506,9 +506,13 @@ async fn main() -> eyre::Result<()> {
             let last_block_num = provider.get_block_number().await?;
             let cast_provider = Cast::new(provider);
             let ts_block = cast_provider.timestamp(last_block_num).await?;
+            let ts_block1 = cast_provider.timestamp(1).await?;
             let block_num = if ts_block.lt(&ts_target) {
                 // If the most recent block's timestamp is below the target, return it
                 last_block_num
+            } else if ts_block1.gt(&ts_target) {
+                // If the target timestamp is below block 1's timestamp, return that
+                U64::from(1)
             } else {
                 // Otherwise, find the block that is closest to the timestamp
                 let mut low_block = U64::from(1); // block 0 has a timestamp of 0: https://github.com/ethereum/go-ethereum/issues/17042#issuecomment-559414137

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -466,6 +466,16 @@ pub enum Subcommands {
         #[clap(help = "The human-readable function signature, e.g. 'transfer(address,uint256)'")]
         sig: String,
     },
+    #[clap(
+        name = "find-block",
+        about = "Prints the block number closes to the provided timestamp"
+    )]
+    FindBlock {
+        #[clap(help = "The timestamp to search for")]
+        timestamp: u128,
+        #[clap(long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+    },
     #[clap(about = "Generate shell completions script")]
     Completions {
         #[clap(arg_enum)]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -471,8 +471,8 @@ pub enum Subcommands {
         about = "Prints the block number closes to the provided timestamp"
     )]
     FindBlock {
-        #[clap(help = "The timestamp to search for")]
-        timestamp: u128,
+        #[clap(help = "The UNIX timestamp to search for (in seconds)")]
+        timestamp: u64,
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },


### PR DESCRIPTION
## Motivation

It's often useful to find the block number that is closes to a given timestamp

## Solution

`cast find-block <timestamp>` now binary searches blocks to find the one closest to the provided timestamp

As a rust amateur, I'm almost certain there's ways this code can be improved or cleaned up, so feedback is welcome 🙂
