### PR TITLE
chore(lib): remove 0x prefix stripping

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -371,13 +371,6 @@ pub fn parse_tokens<'a, I: IntoIterator<Item = (&'a ParamType, &'a str)>>(
     params
         .into_iter()
         .map(|(param, value)| {
-            let value = match param {
-                // allow addresses and bytes to be passed with "0x"
-                ParamType::Address => value.strip_prefix("0x").unwrap_or(value),
-                ParamType::Bytes => value.strip_prefix("0x").unwrap_or(value),
-                ParamType::FixedBytes(_size) => value.strip_prefix("0x").unwrap_or(value),
-                _ => value,
-            };
             if lenient {
                 LenientTokenizer::tokenize(param, value)
             } else {


### PR DESCRIPTION
since it is now handled in ethabi
