### PR TITLE
refactor(forge): use new ethers-solc functions in forge run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1235,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#5b2c1fa6f8758945aceab895c6ed5f3f3868cec2"
+source = "git+https://github.com/gakonst/ethers-rs#3effda28049e9a1c67c5406e5612ddda74185879"
 dependencies = [
  "colored",
  "dunce",

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -1,4 +1,4 @@
-use crate::cmd::{build::BuildArgs, compile, manual_compile, Cmd};
+use crate::cmd::{build::BuildArgs, compile_files, Cmd};
 use clap::{Parser, ValueHint};
 use evm_adapters::sputnik::cheatcodes::{CONSOLE_ABI, HEVMCONSOLE_ABI, HEVM_ABI};
 
@@ -275,32 +275,8 @@ impl RunArgs {
     /// Compiles the file with auto-detection and compiler params.
     pub fn build(&self, config: Config, evm_opts: &EvmOpts) -> eyre::Result<BuildOutput> {
         let target_contract = dunce::canonicalize(&self.path)?;
-        let (project, output) = if let Ok(mut project) = config.project() {
-            // TODO: caching causes no output until https://github.com/gakonst/ethers-rs/issues/727
-            // is fixed
-            project.cached = false;
-            project.no_artifacts = true;
-
-            // target contract may not be in the compilation path, add it and manually compile
-            match manual_compile(&project, vec![target_contract]) {
-                Ok(output) => (project, output),
-                Err(e) => {
-                    println!("No extra contracts compiled {:?}", e);
-                    let mut target_project = config.ephemeral_no_artifacts_project()?;
-                    target_project.cached = false;
-                    target_project.no_artifacts = true;
-                    let res = compile(&target_project)?;
-                    (target_project, res)
-                }
-            }
-        } else {
-            let mut target_project = config.ephemeral_no_artifacts_project()?;
-            target_project.cached = false;
-            target_project.no_artifacts = true;
-            let res = compile(&target_project)?;
-            (target_project, res)
-        };
-        println!("success.");
+        let project = config.ephemeral_no_artifacts_project()?;
+        let output = compile_files(&project, vec![target_contract])?;
 
         let (sources, all_contracts) = output.output().split();
 

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -247,7 +247,7 @@ impl Cmd for RunArgs {
             }
 
             println!("Gas Used: {}", result.gas_used);
-            println!("== Logs == ");
+            println!("== Logs ==");
             result.logs.iter().for_each(|log| println!("{}", log));
         }
 

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -1,4 +1,5 @@
 //! Contains various tests for checking forge's commands
+use ansi_term::Colour;
 use ethers::solc::{artifacts::Metadata, ConfigurableContractArtifact};
 use evm_adapters::evm_opts::{EvmOpts, EvmType};
 use foundry_cli_test_utils::{
@@ -313,6 +314,45 @@ Compiler run successful
 success.
 ",
         cmd.stdout_lossy()
+    );
+});
+
+// tests that the `run` command works correctly
+forgetest!(can_execute_run_command, |prj: TestProject, mut cmd: TestCommand| {
+    let script = prj
+        .inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+contract Demo {
+    event log_string(string);
+    function run() external {
+        emit log_string("script ran");
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.arg("run").arg(script);
+    let output = cmd.stdout_lossy();
+
+    assert_eq!(
+        format!(
+            "compiling...
+Compiling 1 files with 0.8.10
+Compilation finished successfully
+success.
+{}
+Gas Used: 1751
+== Logs ==
+script ran
+",
+            Colour::Green.paint("Script ran successfully.")
+        ),
+        output
     );
 });
 

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -338,7 +338,6 @@ contract Demo {
 
     cmd.arg("run").arg(script);
     let output = cmd.stdout_lossy();
-
     assert_eq!(
         format!(
             "compiling...


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Use new ethers-solc functions introduced in https://github.com/gakonst/ethers-rs/pull/931 to compile individual files
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
replace custom compile functions in forge run
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
