### PR TITLE
chore(docs): add link to foundryup in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ cargo +nightly clippy --all --all-features -- -D warnings
 
 If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other contributors are not duplicating work.
 
+If you would like to test the binaries built from your change, see [foundryup](https://github.com/gakonst/foundry/tree/master/foundryup).
+
 #### Adding tests
 
 If the change being proposed alters code, it is either adding new functionality to Foundry, or fixing existing, broken functionality.


### PR DESCRIPTION
## Motivation

While working on https://github.com/gakonst/foundry/pull/791, I wasn't sure how to test the behavior of `cast wallet` after my change.

## Solution

Add a link to `foundryup` README inside the CONTRIBUTING.md page