### PR TITLE
fix(cli/cast): Typo in the description of abi-encode

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -281,7 +281,7 @@ pub enum Subcommands {
     },
     #[clap(name = "abi-encode")]
     #[clap(
-        about = "ABI encodes the given arguments with the function signature, excluidng the selector"
+        about = "ABI encodes the given arguments with the function signature, excluding the selector"
     )]
     AbiEncode {
         #[clap(help = "the function signature")]


### PR DESCRIPTION
Fixed typo in the description of abi-encode.
