### PR TITLE
feat(etherscan directory output)

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -531,11 +531,25 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).nonce(who, block).await?);
         }
-        Subcommands::EtherscanSource { chain, address, etherscan_api_key } => {
-            println!(
-                "{}",
-                SimpleCast::etherscan_source(chain.inner, address, etherscan_api_key).await?
-            );
+        Subcommands::EtherscanSource { chain, address, directory, etherscan_api_key } => {
+            match directory {
+                Some(dir) => {
+                    SimpleCast::expand_etherscan_source_to_directory(
+                        chain.inner,
+                        address,
+                        etherscan_api_key,
+                        dir,
+                    )
+                    .await?
+                }
+                None => {
+                    println!(
+                        "{}",
+                        SimpleCast::etherscan_source(chain.inner, address, etherscan_api_key)
+                            .await?
+                    );
+                }
+            }
         }
         Subcommands::Sig { sig } => {
             let contract = BaseContract::from(parse_abi(&[&sig]).unwrap());

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -473,6 +473,8 @@ pub enum Subcommands {
         chain: ClapChain,
         #[clap(help = "the contract address")]
         address: String,
+        #[clap(short, help = "output directory to expand source tree")]
+        directory: Option<PathBuf>,
         #[clap(long, env = "ETHERSCAN_API_KEY")]
         etherscan_api_key: String,
     },


### PR DESCRIPTION
* Inspired by etherscan.deth.net, this feature will expand a verified contract's
  source code paths to a directory for easy consumption with your favorite
  editor / IDE.

* Tested via the following examples that test a few of the edge cases.
> cargo run --bin cast -- etherscan-source 0x8d04a8c79cEB0889Bdd12acdF3Fa9D207eD3Ff63 -d blitmap
This results in a directory tree with all the source files of the contract.

> cargo run --bin cast -- etherscan-source 0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413 -d thedao
This results in a single file output.

> cargo run --bin cast -- etherscan-source 0xb5c31a0e22cae98ac08233e512bd627885aa24e5 -d unverified
This returns an error since the following contract is not verified yet on Etherscan

## Motivation

When learning about smart contracts it is a nice improvement to able the browse the contract code in your normal developer environment.

## Solution

This feature parses the etherscan API source structure and writes it to directory.  
