### PR TITLE
feat(forge): watch mode for forge build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +152,12 @@ checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "atomic-take"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f65e4fb35ff6a80b3298d1f028649f3a23da141fa3951e9b24dde1d515b67e"
 
 [[package]]
 name = "atty"
@@ -338,6 +376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +566,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "clearscreen"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ed49b0e894fe6264a58496c7ec4e9d3c46f66b59efae527cd5bee429d0a418"
+dependencies = [
+ "nix 0.22.3",
+ "terminfo",
+ "thiserror",
+ "which",
+ "winapi",
+]
+
+[[package]]
 name = "coins-bip32"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,7 +588,7 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.9.0",
- "getrandom",
+ "getrandom 0.2.4",
  "hmac 0.11.0",
  "k256",
  "lazy_static",
@@ -545,11 +605,11 @@ checksum = "8f473ea37dfc9d2cb94fdde50c3d41f28c3f384b367573d66386fea38d76d466"
 dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
- "getrandom",
+ "getrandom 0.2.4",
  "hex",
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
- "rand",
+ "rand 0.8.5",
  "sha2 0.9.9",
  "thiserror",
 ]
@@ -592,7 +652,7 @@ dependencies = [
  "libc",
  "log",
  "matches",
- "nix",
+ "nix 0.13.1",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -647,6 +707,18 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width",
+]
+
+[[package]]
+name = "command-group"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a8a86f409b4a59df3a3e4bee2de0b83f1755fdd2a25e3a9684c396fc4bed2c"
+dependencies = [
+ "async-trait",
+ "nix 0.22.3",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -829,7 +901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array 0.14.5",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
@@ -951,6 +1023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1040,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1007,7 +1100,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.5",
  "group",
- "rand_core",
+ "rand_core 0.6.3",
  "sec1",
  "subtle",
  "zeroize",
@@ -1075,7 +1168,7 @@ dependencies = [
  "hex",
  "hmac 0.12.0",
  "pbkdf2 0.10.0",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -1205,7 +1298,7 @@ dependencies = [
  "dunce",
  "ethers-core",
  "eyre",
- "getrandom",
+ "getrandom 0.2.4",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -1250,7 +1343,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "rlp-derive",
  "serde",
@@ -1345,7 +1438,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "rand",
+ "rand 0.8.5",
  "semver",
  "sha2 0.9.9",
  "thiserror",
@@ -1362,7 +1455,7 @@ dependencies = [
  "ethers-core",
  "fs_extra",
  "futures-util",
- "getrandom",
+ "getrandom 0.2.4",
  "glob",
  "hex",
  "home",
@@ -1496,7 +1589,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -1517,13 +1610,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1641,6 +1746,7 @@ dependencies = [
  "ui",
  "vergen",
  "walkdir",
+ "watchexec",
 ]
 
 [[package]]
@@ -1698,6 +1804,15 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -1821,6 +1936,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
@@ -1828,7 +1954,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1870,13 +1996,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "group"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -2086,6 +2225,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2319,26 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "instant"
@@ -2245,6 +2422,26 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
+name = "kqueue"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058a107a784f8be94c7d35c1300f4facced2e93d2fbe5b1452b44e905ddca4a9"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "lalrpop"
@@ -2405,10 +2602,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2adcfcced5d625bf90a958a82ae5b93231f57f3df1383fee28c9b5096d35ed"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "miette-derive"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c01a8b61312d367ce87956bb686731f87e4c6dd5dbc550e8f06e3c24fb1f67f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2477,6 +2702,58 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0-pre.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245d358380e2352c2d020e8ee62baac09b3420f1f6c012a31326cfced4ad487d"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "winapi",
 ]
 
 [[package]]
@@ -2733,7 +3010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e0b28ace46c5a396546bcf443bf422b57049617433d8854227352a4a9b24e7"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -2744,7 +3021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -2824,6 +3101,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
@@ -2834,13 +3120,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared 0.8.0",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2849,7 +3155,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.10.0",
  "phf_shared 0.10.0",
  "proc-macro-hack",
  "proc-macro2",
@@ -3042,8 +3348,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3091,13 +3397,37 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3107,7 +3437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -3116,7 +3455,25 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.4",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3125,7 +3482,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3168,7 +3525,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.4",
  "redox_syscall",
 ]
 
@@ -3742,7 +4099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3790,7 +4147,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
- "phf",
+ "phf 0.10.1",
  "unicode-xid",
 ]
 
@@ -3862,7 +4219,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
 ]
 
@@ -3887,7 +4244,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "semver",
  "serde",
@@ -3959,6 +4316,19 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
+dependencies = [
+ "dirs",
+ "fnv",
+ "nom 5.1.2",
+ "phf 0.8.0",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -4083,6 +4453,17 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4300,7 +4681,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "sha-1",
  "thiserror",
@@ -4420,7 +4801,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.4",
  "serde",
 ]
 
@@ -4494,6 +4875,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4583,6 +4970,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "watchexec"
+version = "2.0.0-pre.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c84127066dd06c8fb74ce978818ee2cd0040259bf35d28babdba1b24f2f69d"
+dependencies = [
+ "async-recursion",
+ "async-stream",
+ "atomic-take",
+ "clearscreen",
+ "command-group",
+ "dunce",
+ "futures",
+ "git2",
+ "globset",
+ "ignore",
+ "libc",
+ "miette",
+ "nom 7.1.0",
+ "notify",
+ "once_cell",
+ "regex",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4609,6 +5025,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,6 +58,7 @@ walkdir = "2.3.2"
 solang-parser = "0.1.2"
 similar = { version = "2.1.0", features = ["inline"] }
 console = "0.15.0"
+watchexec = "2.0.0-pre.6"
 
 [dev-dependencies]
 foundry-utils = { path = "./../utils", features = ["test"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,7 +58,7 @@ walkdir = "2.3.2"
 solang-parser = "0.1.2"
 similar = { version = "2.1.0", features = ["inline"] }
 console = "0.15.0"
-watchexec = "2.0.0-pre.6"
+watchexec = "2.0.0-pre.10"
 
 [dev-dependencies]
 foundry-utils = { path = "./../utils", features = ["test"] }

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::{cmd::Cmd, opts::forge::CompilerArgs};
 
+use crate::cmd::watch::WatchArgs;
 use clap::{Parser, ValueHint};
 use ethers::solc::remappings::Remapping;
 use foundry_config::{
@@ -149,6 +150,10 @@ pub struct BuildArgs {
 
     #[clap(help = "add linked libraries", long, env = "DAPP_LIBRARIES")]
     pub libraries: Vec<String>,
+
+    #[clap(flatten)]
+    #[serde(skip)]
+    pub watch: WatchArgs,
 }
 
 impl Cmd for BuildArgs {
@@ -168,6 +173,11 @@ impl BuildArgs {
     pub fn project(&self) -> eyre::Result<Project> {
         let config: Config = self.into();
         Ok(config.project()?)
+    }
+
+    /// Returns whether `BuildArgs` was configured with `--watch`
+    pub fn is_watch(&self) -> bool {
+        self.watch.watch.is_some()
     }
 
     /// Returns the remappings to add to the config

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -18,6 +18,7 @@ use foundry_config::{
     find_project_root_path, remappings_from_env_var, Config,
 };
 use serde::Serialize;
+use watchexec::config::{InitConfig, RuntimeConfig};
 
 // Loads project's figment and merges the build cli arguments into it
 impl<'a> From<&'a BuildArgs> for Figment {
@@ -178,6 +179,25 @@ impl BuildArgs {
     /// Returns whether `BuildArgs` was configured with `--watch`
     pub fn is_watch(&self) -> bool {
         self.watch.watch.is_some()
+    }
+
+    /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
+    /// bootstrap a new [`watchexe::Watchexec`] loop.
+    pub(crate) fn watchexec_config(&self) -> eyre::Result<(InitConfig, RuntimeConfig)> {
+        use crate::cmd::watch;
+        let init = watch::init()?;
+        let mut runtime = watch::runtime(&self.watch)?;
+
+        // contains all the arguments `--watch p1, p2, p3`
+        let has_paths =
+            self.watch.watch.as_ref().map(|paths| !paths.is_empty()).unwrap_or_default();
+
+        if !has_paths {
+            // listen for changes in the project's src dir
+            let config = Config::from(self);
+            runtime.pathset(Some(config.src));
+        }
+        Ok((init, runtime))
     }
 
     /// Returns the remappings to add to the config

--- a/cli/src/cmd/flatten.rs
+++ b/cli/src/cmd/flatten.rs
@@ -79,6 +79,7 @@ impl Cmd for FlattenArgs {
             force: false,
             hardhat,
             libraries: vec![],
+            watch: Default::default(),
         };
 
         let config = Config::from(&build_args);

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -50,6 +50,7 @@ pub mod run;
 pub mod snapshot;
 pub mod test;
 pub mod verify;
+pub mod watch;
 
 use crate::opts::forge::ContractInfo;
 use ethers::{

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -22,7 +22,7 @@ pub struct Filter {
         short = 'm',
         help = "only run test methods matching regex (deprecated, see --match-test)"
     )]
-    pattern: Option<regex::Regex>,
+    pub pattern: Option<regex::Regex>,
 
     #[clap(
         long = "match-test",
@@ -30,7 +30,7 @@ pub struct Filter {
         help = "only run test methods matching regex",
         conflicts_with = "pattern"
     )]
-    test_pattern: Option<regex::Regex>,
+    pub test_pattern: Option<regex::Regex>,
 
     #[clap(
         long = "no-match-test",
@@ -38,7 +38,7 @@ pub struct Filter {
         help = "only run test methods not matching regex",
         conflicts_with = "pattern"
     )]
-    test_pattern_inverse: Option<regex::Regex>,
+    pub test_pattern_inverse: Option<regex::Regex>,
 
     #[clap(
         long = "match-contract",
@@ -46,7 +46,7 @@ pub struct Filter {
         help = "only run test methods in contracts matching regex",
         conflicts_with = "pattern"
     )]
-    contract_pattern: Option<regex::Regex>,
+    pub contract_pattern: Option<regex::Regex>,
 
     #[clap(
         long = "no-match-contract",
@@ -62,7 +62,7 @@ pub struct Filter {
         help = "only run test methods in source files at path matching regex. Requires absolute path",
         conflicts_with = "pattern"
     )]
-    path_pattern: Option<regex::Regex>,
+    pub path_pattern: Option<regex::Regex>,
 
     #[clap(
         long = "no-match-path",
@@ -70,7 +70,7 @@ pub struct Filter {
         help = "only run test methods in source files at path not matching regex. Requires absolute path",
         conflicts_with = "pattern"
     )]
-    path_pattern_inverse: Option<regex::Regex>,
+    pub path_pattern_inverse: Option<regex::Regex>,
 }
 
 impl TestFilter for Filter {
@@ -145,6 +145,18 @@ pub struct TestArgs {
         env = "FORGE_ALLOW_FAILURE"
     )]
     allow_failure: bool,
+}
+
+impl TestArgs {
+    /// Returns the flattened [`BuildArgs`]
+    pub fn build_args(&self) -> &BuildArgs {
+        &self.opts
+    }
+
+    /// Returns the flattened [`Filter`] arguments
+    pub fn filter(&self) -> &Filter {
+        &self.filter
+    }
 }
 
 impl Cmd for TestArgs {

--- a/cli/src/cmd/watch.rs
+++ b/cli/src/cmd/watch.rs
@@ -47,6 +47,8 @@ pub async fn watch_test(args: TestArgs) -> eyre::Result<()> {
     // marker to check whether we can safely override the command
     let has_conflicting_pattern_args =
         args.filter().pattern.is_some() || args.filter().test_pattern.is_some();
+    || args.filter().path_pattern.is_some();
+
     on_action(
         args.build_args().watch.clone(),
         runtime,

--- a/cli/src/cmd/watch.rs
+++ b/cli/src/cmd/watch.rs
@@ -139,10 +139,6 @@ pub struct WatchArgs {
     #[clap(long = "no-restart")]
     pub no_restart: bool,
 
-    /// Show paths that changed
-    #[clap(long = "why")]
-    pub why: bool,
-
     /// Watch specific file(s) or folder(s)
     ///
     /// By default, the project's source dir is watched
@@ -196,17 +192,10 @@ fn on_action<F, T>(
     T: Clone + Send + 'static,
 {
     let on_busy = if args.no_restart { "do-nothing" } else { "restart" };
-    let print_events = args.why;
     let runtime = config.clone();
     let w = Arc::clone(&wx);
     config.on_action(move |action: Action| {
         let fut = async { Ok::<(), Infallible>(()) };
-        if print_events {
-            for (n, event) in action.events.iter().enumerate() {
-                eprintln!("[EVENT {}] {}", n, event);
-            }
-        }
-
         let signals: Vec<MainSignal> = action.events.iter().flat_map(|e| e.signals()).collect();
         let has_paths = action.events.iter().flat_map(|e| e.paths()).next().is_some();
 

--- a/cli/src/cmd/watch.rs
+++ b/cli/src/cmd/watch.rs
@@ -78,7 +78,7 @@ fn on_test(action: OnActionState<bool>) {
         .events
         .iter()
         .flat_map(|e| e.paths())
-        .filter(|(path, _)| path.extension() == Some(&OsStr::new("sol")))
+        .filter(|(path, _)| path.extension() == Some(OsStr::new("sol")))
         .filter_map(|(path, _)| path.to_str())
         .collect();
 

--- a/cli/src/cmd/watch.rs
+++ b/cli/src/cmd/watch.rs
@@ -1,0 +1,231 @@
+//! Watch mode support
+
+use clap::Parser;
+use std::{convert::Infallible, path::PathBuf};
+use watchexec::{
+    action::{Action, Outcome, PreSpawn},
+    command::Shell,
+    config::{InitConfig, RuntimeConfig},
+    event::ProcessEnd,
+    handler::SyncFnHandler,
+    paths::summarise_events_to_env,
+    signal::source::MainSignal,
+    Watchexec,
+};
+
+use crate::utils;
+
+pub fn watch(args: &WatchArgs) -> eyre::Result<()> {
+    let init = init()?;
+    let runtime = runtime(args)?;
+    // runtime.filterer(filterer::new(&args).await?);
+
+    let wx = Watchexec::new(init, runtime)?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct WatchArgs {
+    /// File updates debounce delay
+    ///
+    /// During this time, incoming change events are accumulated and
+    /// only once the delay has passed, is an action taken. Note that
+    /// this does not mean a command will be started: if --no-restart is
+    /// given and a command is already running, the outcome of the
+    /// action will be to do nothing.
+    ///
+    /// Defaults to 50ms. Parses as decimal seconds by default, but
+    /// using an integer with the `ms` suffix may be more convenient.
+    /// When using --poll mode, you'll want a larger duration, or risk
+    /// overloading disk I/O.
+    #[clap(short = 'd', long = "delay", forbid_empty_values = true)]
+    pub delay: Option<String>,
+
+    /// Shell to use for the command, or `none` for direct execution
+    #[cfg_attr(
+        windows,
+        doc = "Defaults to Powershell. Examples: --use-shell=cmd, --use-shell=gitbash.exe"
+    )]
+    #[cfg_attr(
+        not(windows),
+        doc = "Defaults to $SHELL. Examples: --use-shell=sh, --use-shell=fish"
+    )]
+    #[clap(long = "use-shell", value_name = "shell")]
+    pub shell: Option<String>,
+
+    /// Don’t restart command while it’s still running
+    #[clap(long = "no-restart")]
+    pub no_restart: bool,
+
+    /// Show paths that changed
+    #[clap(long = "why")]
+    pub why: bool,
+
+    /// Watch specific file(s) or folder(s)
+    ///
+    /// By default, the entire crate/workspace is watched.
+    #[clap(
+        short = 'w',
+        long = "watch",
+        value_name = "path",
+        // forbid_empty_values = true,
+        // min_values = 1
+    )]
+    pub watch: Vec<PathBuf>,
+}
+
+/// Returns the Initialisation configuration for [`Watchexec`].
+pub fn init() -> eyre::Result<InitConfig> {
+    let mut config = InitConfig::default();
+    config.on_error(SyncFnHandler::from(|data| -> std::result::Result<(), Infallible> {
+        eprintln!("[[{:?}]]", data);
+        Ok(())
+    }));
+
+    Ok(config)
+}
+
+/// Returns the Runtime configuration for [`Watchexec`].
+pub fn runtime(args: &WatchArgs) -> eyre::Result<RuntimeConfig> {
+    let mut config = RuntimeConfig::default();
+
+    config.pathset(&args.watch);
+
+    if let Some(delay) = &args.delay {
+        config.action_throttle(utils::parse_delay(delay)?);
+    }
+
+    config.command_shell(if let Some(s) = &args.shell {
+        if s.eq_ignore_ascii_case("powershell") {
+            Shell::Powershell
+        } else if s.eq_ignore_ascii_case("none") {
+            Shell::None
+        } else if s.eq_ignore_ascii_case("cmd") {
+            cmd_shell(s.into())
+        } else {
+            Shell::Unix(s.into())
+        }
+    } else {
+        default_shell()
+    });
+
+    let on_busy = if args.no_restart { "do-nothing" } else { "restart" };
+
+    let print_events = args.why;
+
+    config.on_action(move |action: Action| {
+        let fut = async { Ok::<(), Infallible>(()) };
+
+        if print_events {
+            for (n, event) in action.events.iter().enumerate() {
+                eprintln!("[EVENT {}] {}", n, event);
+            }
+        }
+
+        let signals: Vec<MainSignal> = action.events.iter().flat_map(|e| e.signals()).collect();
+        let has_paths = action.events.iter().flat_map(|e| e.paths()).next().is_some();
+
+        if signals.contains(&MainSignal::Terminate) {
+            action.outcome(Outcome::both(Outcome::Stop, Outcome::Exit));
+            return fut
+        }
+
+        if signals.contains(&MainSignal::Interrupt) {
+            action.outcome(Outcome::both(Outcome::Stop, Outcome::Exit));
+            return fut
+        }
+
+        if !has_paths {
+            if !signals.is_empty() {
+                let mut out = Outcome::DoNothing;
+                for sig in signals {
+                    out = Outcome::both(out, Outcome::Signal(sig.into()));
+                }
+
+                action.outcome(out);
+                return fut
+            }
+
+            let completion = action.events.iter().flat_map(|e| e.completions()).next();
+            if let Some(status) = completion {
+                let (msg, printit) = match status {
+                    Some(ProcessEnd::ExitError(code)) => {
+                        (format!("Command exited with {}", code), true)
+                    }
+                    Some(ProcessEnd::ExitSignal(sig)) => {
+                        (format!("Command killed by {:?}", sig), true)
+                    }
+                    Some(ProcessEnd::ExitStop(sig)) => {
+                        (format!("Command stopped by {:?}", sig), true)
+                    }
+                    Some(ProcessEnd::Continued) => ("Command continued".to_string(), true),
+                    Some(ProcessEnd::Exception(ex)) => {
+                        (format!("Command ended by exception {:#x}", ex), true)
+                    }
+                    Some(ProcessEnd::Success) => ("Command was successful".to_string(), false),
+                    None => ("Command completed".to_string(), false),
+                };
+
+                if printit {
+                    eprintln!("[[{}]]", msg);
+                }
+
+                action.outcome(Outcome::DoNothing);
+                return fut
+            }
+        }
+
+        // TODO make this configurable
+        let clear = true;
+        let when_running = match (clear, on_busy) {
+            (_, "do-nothing") => Outcome::DoNothing,
+            (true, "restart") => {
+                Outcome::both(Outcome::Stop, Outcome::both(Outcome::Clear, Outcome::Start))
+            }
+            (false, "restart") => Outcome::both(Outcome::Stop, Outcome::Start),
+            _ => Outcome::DoNothing,
+        };
+
+        let when_idle =
+            if clear { Outcome::both(Outcome::Clear, Outcome::Start) } else { Outcome::Start };
+
+        action.outcome(Outcome::if_running(when_running, when_idle));
+
+        fut
+    });
+
+    config.on_pre_spawn(move |prespawn: PreSpawn| async move {
+        let envs = summarise_events_to_env(prespawn.events.iter());
+        if let Some(mut command) = prespawn.command().await {
+            for (k, v) in envs {
+                command.env(format!("CARGO_WATCH_{}_PATH", k), v);
+            }
+        }
+
+        Ok::<(), Infallible>(())
+    });
+
+    Ok(config)
+}
+
+#[cfg(windows)]
+fn default_shell() -> Shell {
+    Shell::Powershell
+}
+
+#[cfg(not(windows))]
+fn default_shell() -> Shell {
+    Shell::default()
+}
+
+// because Shell::Cmd is only on windows
+#[cfg(windows)]
+fn cmd_shell(_: String) -> Shell {
+    Shell::Cmd
+}
+
+#[cfg(not(windows))]
+fn cmd_shell(s: String) -> Shell {
+    Shell::Unix(s)
+}

--- a/cli/src/cmd/watch.rs
+++ b/cli/src/cmd/watch.rs
@@ -119,8 +119,7 @@ pub fn init() -> eyre::Result<InitConfig> {
 pub fn runtime(args: &WatchArgs) -> eyre::Result<RuntimeConfig> {
     let mut config = RuntimeConfig::default();
 
-    // config.pathset(args.watch.clone().unwrap_or_default());
-    config.pathset(vec!["/Users/Matthias/git/rust/foundry/cli"]);
+    config.pathset(args.watch.clone().unwrap_or_default());
 
     if let Some(delay) = &args.delay {
         config.action_throttle(utils::parse_delay(delay)?);
@@ -223,8 +222,6 @@ pub fn runtime(args: &WatchArgs) -> eyre::Result<RuntimeConfig> {
 
         fut
     });
-
-    config.command(["ls"]);
 
     config.on_pre_spawn(move |prespawn: PreSpawn| async move {
         let envs = summarise_events_to_env(prespawn.events.iter());

--- a/cli/src/cmd/watch.rs
+++ b/cli/src/cmd/watch.rs
@@ -45,9 +45,9 @@ pub async fn watch_test(args: TestArgs) -> eyre::Result<()> {
     let wx = Watchexec::new(init, runtime.clone())?;
 
     // marker to check whether we can safely override the command
-    let has_conflicting_pattern_args =
-        args.filter().pattern.is_some() || args.filter().test_pattern.is_some();
-    || args.filter().path_pattern.is_some();
+    let has_conflicting_pattern_args = args.filter().pattern.is_some() ||
+        args.filter().test_pattern.is_some() ||
+        args.filter().path_pattern.is_some();
 
     on_action(
         args.build_args().watch.clone(),
@@ -159,7 +159,7 @@ pub struct WatchArgs {
 pub fn init() -> eyre::Result<InitConfig> {
     let mut config = InitConfig::default();
     config.on_error(SyncFnHandler::from(|data| -> std::result::Result<(), Infallible> {
-        eprintln!("[[{:?}]]", data);
+        tracing::trace!("[[{:?}]]", data);
         Ok(())
     }));
 
@@ -251,6 +251,7 @@ fn on_action<F, T>(
             other: other.clone(),
         });
 
+        // mattsse: could be made into flag to never clear the shell
         let clear = true;
         let when_running = match (clear, on_busy) {
             (_, "do-nothing") => Outcome::DoNothing,

--- a/cli/src/cmd/watch.rs
+++ b/cli/src/cmd/watch.rs
@@ -97,6 +97,7 @@ pub struct WatchArgs {
         short = 'w',
         long = "watch",
         value_name = "path",
+        min_values = 0,
         multiple_values = true,
         multiple_occurrences = false
     )]

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -26,7 +26,11 @@ fn main() -> eyre::Result<()> {
             cmd.run()?;
         }
         Subcommands::Build(cmd) => {
-            cmd.run()?;
+            if cmd.is_watch() {
+                utils::block_on(crate::cmd::watch::watch_build(cmd))?;
+            } else {
+                cmd.run()?;
+            }
         }
         Subcommands::Run(cmd) => {
             cmd.run()?;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -2,7 +2,7 @@ pub mod cmd;
 mod opts;
 mod utils;
 
-use crate::cmd::Cmd;
+use crate::cmd::{watch, Cmd};
 
 use ethers::solc::{self, report::BasicStdoutReporter, Project, ProjectPathsConfig};
 use opts::forge::{Dependency, Opts, Subcommands};
@@ -19,8 +19,12 @@ fn main() -> eyre::Result<()> {
     let opts = Opts::parse();
     match opts.sub {
         Subcommands::Test(cmd) => {
-            let outcome = cmd.run()?;
-            outcome.ensure_ok()?;
+            if cmd.build_args().is_watch() {
+                utils::block_on(watch::watch_test(cmd))?;
+            } else {
+                let outcome = cmd.run()?;
+                outcome.ensure_ok()?;
+            }
         }
         Subcommands::Bind(cmd) => {
             cmd.run()?;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -32,12 +32,10 @@ fn main() -> eyre::Result<()> {
             cmd.run()?;
         }
         Subcommands::VerifyContract(args) => {
-            let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
-            rt.block_on(cmd::verify::run_verify(&args))?;
+            utils::block_on(cmd::verify::run_verify(&args))?;
         }
         Subcommands::VerifyCheck(args) => {
-            let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
-            rt.block_on(cmd::verify::run_verify_check(&args))?;
+            utils::block_on(cmd::verify::run_verify_check(&args))?;
         }
         Subcommands::Create(cmd) => {
             cmd.run()?;

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 use ethers::{solc::EvmVersion, types::U256};
 #[cfg(feature = "sputnik-evm")]
@@ -73,6 +73,22 @@ pub fn get_contract_name(id: &str) -> &str {
 /// parse a hex str or decimal str as U256
 pub fn parse_u256(s: &str) -> eyre::Result<U256> {
     Ok(if s.starts_with("0x") { U256::from_str(s)? } else { U256::from_dec_str(s)? })
+}
+
+pub fn parse_delay(delay: &str) -> eyre::Result<Duration> {
+    let delay = if delay.ends_with("ms") {
+        let d: u64 = delay.trim_end_matches("ms").parse()?;
+        Duration::from_millis(d)
+    } else {
+        let d: f64 = delay.parse()?;
+        let delay = (d * 1000.0).round();
+        if delay.is_infinite() || delay.is_nan() || delay.is_sign_negative() {
+            eyre::bail!("delay must be finite and non-negative");
+        }
+
+        Duration::from_millis(delay as u64)
+    };
+    Ok(delay)
 }
 
 /// Conditionally print a message

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, time::Duration};
+use std::{future::Future, str::FromStr, time::Duration};
 
 use ethers::{solc::EvmVersion, types::U256};
 #[cfg(feature = "sputnik-evm")]
@@ -75,6 +75,7 @@ pub fn parse_u256(s: &str) -> eyre::Result<U256> {
     Ok(if s.starts_with("0x") { U256::from_str(s)? } else { U256::from_dec_str(s)? })
 }
 
+/// Parses a `Duration` from a &str
 pub fn parse_delay(delay: &str) -> eyre::Result<Duration> {
     let delay = if delay.ends_with("ms") {
         let d: u64 = delay.trim_end_matches("ms").parse()?;
@@ -89,6 +90,13 @@ pub fn parse_delay(delay: &str) -> eyre::Result<Duration> {
         Duration::from_millis(delay as u64)
     };
     Ok(delay)
+}
+
+/// Runs the `future` in a new [`tokio::runtime::Runtime`]
+#[allow(unused)]
+pub fn block_on<F: Future>(future: F) -> F::Output {
+    let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
+    rt.block_on(future)
 }
 
 /// Conditionally print a message


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Fixes #813
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
this adds a `forge build -w|--watch` flag which enters watch mode that runs forge build on changes.

`forge test -w` is slightly more complicated because ideally, we want to adjust the match argument. I think I've figured out how to implement this and will try to add this.

### Update
`forge test --watch` added, currently it's configured to only run those files/file that was changed, see `forge test --match-path`
This will benefit once we can limit the files we need to compile based on the tests we need to run.

The watchexec API is a bit clunky when it comes to reconfiguring the runtime, but it appears to work.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
