### PR TITLE
fix: print compiler warnings on success

### DIFF
--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -94,9 +94,12 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
     } else if output.is_unchanged() {
         println!("No files changed, compilation skipped");
     } else {
+        // print the compiler output / warnings
+        println!("{}", output);
+
+        // print any sizes or names
         if print_names {
             let compiled_contracts = output.compiled_contracts_by_compiler_version();
-            println!("compiled contracts:");
             for (version, contracts) in compiled_contracts.into_iter() {
                 println!(
                     "  compiler version: {}.{}.{}",
@@ -134,9 +137,6 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
             println!("-----------------------------");
             println!("{}", to_table(json));
         }
-
-        println!("{}", output);
-        println!("Success");
     }
 
     Ok(output)
@@ -149,7 +149,7 @@ pub fn compile_files(project: &Project, files: Vec<PathBuf>) -> eyre::Result<Pro
     if output.has_compiler_errors() {
         eyre::bail!(output.to_string())
     }
-    println!("Success");
+    println!("{}", output);
     Ok(output)
 }
 

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -284,9 +284,7 @@ contract Greeter {}
     assert!(cmd.stdout_lossy().ends_with(
         "Compiling...
 Compiling 1 files with 0.8.10
-Compilation finished successfully
 Compiler run successful
-Success
 ",
     ));
 });
@@ -337,9 +335,7 @@ library FooLib {
     assert_eq!(
         "Compiling...
 Compiling 2 files with 0.8.10
-Compilation finished successfully
 Compiler run successful
-Success
 ",
         cmd.stdout_lossy()
     );
@@ -382,9 +378,7 @@ contract Foo {
     assert!(cmd.stdout_lossy().ends_with(
         "Compiling...
 Compiling 1 files with 0.8.10
-Compilation finished successfully
 Compiler run successful
-Success
 ",
     ));
 });

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -289,6 +289,38 @@ Compiler run successful
     ));
 });
 
+forgetest!(can_print_warnings, |prj: TestProject, mut cmd: TestCommand| {
+    prj.inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >0.8.9;
+contract Greeter {
+    function foo(uint256 a) public {
+        uint256 x = 1;
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    // explicitly set to run with 0.8.10
+    let config = Config { solc_version: Some("0.8.10".parse().unwrap()), ..Default::default() };
+    prj.write_config(config);
+
+    cmd.arg("build");
+
+    let output = cmd.stdout_lossy();
+    assert!(output.contains(
+        "Compiling...
+Compiling 1 files with 0.8.10
+Compiler run successful (with warnings)
+Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
+",
+    ));
+});
+
 // tests that direct import paths are handled correctly
 forgetest!(can_handle_direct_imports_into_src, |prj: TestProject, mut cmd: TestCommand| {
     prj.inner()

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -52,7 +52,7 @@ impl MultiContractRunnerBuilder {
         } else if output.is_unchanged() {
             println!("No files changed, compilation skipped");
         } else {
-            println!("Success");
+            println!("{}", output);
         }
 
         // This is just the contracts compiled, but we need to merge this with the read cached


### PR DESCRIPTION
Sometimes we wouldn't print compiler warnings. This PR addresses it by always printing the compiler output in the else branch, and removing any ad-hoc prints or `println!("success")`

fixes #810
fixes #687