### PR TITLE
Add `cast wallet vanity --nonce <nonce>` to generate wallet that deploys a contract address

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -15,6 +15,7 @@ use ethers::{
     providers::{Middleware, Provider},
     signers::{LocalWallet, Signer},
     types::{Address, Chain, NameOrAddress, Signature, U256, U64},
+    utils::get_contract_address,
 };
 use opts::{
     cast::{Opts, Subcommands, WalletSubcommands},
@@ -608,7 +609,7 @@ async fn main() -> eyre::Result<()> {
                     }
                 }
             }
-            WalletSubcommands::Vanity { starts_with, ends_with } => {
+            WalletSubcommands::Vanity { starts_with, ends_with, nonce } => {
                 let mut regexs = vec![];
                 if let Some(prefix) = starts_with {
                     let pad_width = prefix.len() + prefix.len() % 2;
@@ -629,20 +630,31 @@ async fn main() -> eyre::Result<()> {
                 );
 
                 let regex = RegexSet::new(regexs)?;
+                let match_contract = nonce.is_some();
 
                 println!("Starting to generate vanity address...");
                 let timer = Instant::now();
                 let wallet = std::iter::repeat_with(move || LocalWallet::new(&mut thread_rng()))
                     .par_bridge()
                     .find_any(|wallet| {
-                        let addr = hex::encode(wallet.address().to_fixed_bytes());
+                        let addr = if match_contract {
+                            // looking for contract address created by wallet with CREATE + nonce
+                            let contract_addr =
+                                get_contract_address(wallet.address(), nonce.unwrap());
+                            hex::encode(contract_addr.to_fixed_bytes())
+                        } else {
+                            // looking for wallet address
+                            hex::encode(wallet.address().to_fixed_bytes())
+                        };
                         regex.matches(&addr).into_iter().count() == regex.patterns().len()
                     })
                     .expect("failed to generate vanity wallet");
 
                 println!(
-                    "Successfully created new keypair in {} seconds.\nAddress: {}\nPrivate Key: {}",
+                    "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: 0x{}",
                     timer.elapsed().as_secs(),
+                    if match_contract {"\nContract address: "} else {""},
+                    if match_contract {SimpleCast::checksum_address(&Address::from(get_contract_address(wallet.address(), nonce.unwrap())))?} else {"".to_string()},
                     SimpleCast::checksum_address(&wallet.address())?,
                     hex::encode(wallet.signer().to_bytes()),
                 );

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -654,7 +654,7 @@ async fn main() -> eyre::Result<()> {
                     "Successfully found vanity address in {} seconds.{}{}\nAddress: {}\nPrivate Key: 0x{}",
                     timer.elapsed().as_secs(),
                     if match_contract {"\nContract address: "} else {""},
-                    if match_contract {SimpleCast::checksum_address(&Address::from(get_contract_address(wallet.address(), nonce.unwrap())))?} else {"".to_string()},
+                    if match_contract {SimpleCast::checksum_address(&get_contract_address(wallet.address(), nonce.unwrap()))?} else {"".to_string()},
                     SimpleCast::checksum_address(&wallet.address())?,
                     hex::encode(wallet.signer().to_bytes()),
                 );

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -523,6 +523,11 @@ pub enum WalletSubcommands {
         starts_with: Option<String>,
         #[clap(long, help = "Suffix for vanity address")]
         ends_with: Option<String>,
+        #[clap(
+            long,
+            help = "Generate a vanity contract address created by the generated account with specified nonce"
+        )]
+        nonce: Option<u64>, /* 2^64-1 is max possible nonce per https://eips.ethereum.org/EIPS/eip-2681 */
     },
     #[clap(name = "address", about = "Convert a private key to an address")]
     Address {


### PR DESCRIPTION
```sh
# Find wallet that, when it deploys a contract at nonce 0, results in a contract address 
# that starts and ends with `c`
$ cast wallet vanity --starts-with c --ends-with c --nonce 0
Starting to generate vanity address...
Successfully found vanity address in 0 seconds.
Contract address: 0xcba76A958E502fdCbBABdE7eE4a50Fe70d11eD7C
Address: 0x76A4A0dc5Cc658901A04c188e69de44d343B4D51
Private Key: 0xf6d3b4f5601b588436dbeb05d32038fc737f6a363a0bec7395213362750db1ab

# This functionality already existed
$ Find a wallet with an address that starts and ends with `c`
$ cast wallet vanity --starts-with c --ends-with c
Starting to generate vanity address...
Successfully found vanity address in 1 seconds.
Address: 0xc4365487aE7d796233E8d615743CD81ce1C8843c
Private Key: 0x15d53501bb1f2cbe0f6c6e5ec58cfc5b50ee8a4c87fdadc6354878959f3b65af
```

Also added the `0x` prefix to the printed private key, which previously was not included