### PR TITLE
REVM cheatcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3486,10 +3486,10 @@ version = "0.4.0"
 source = "git+https://github.com/onbjerg/revm?branch=onbjerg/blockhashes#ed4e9aeec068ba36b054fdfb807060f1555ec484"
 dependencies = [
  "bytes",
+ "k256",
  "num 0.4.0",
  "primitive-types",
  "ripemd",
- "secp256k1",
  "sha2 0.10.2",
  "sha3 0.10.1",
  "substrate-bn",
@@ -3716,24 +3716,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.2.0"
-source = "git+https://github.com/bluealloy/revm?branch=main#0f6c09ff19873b99aab98b4cefe20d0e5bfa9a8c"
+source = "git+https://github.com/onbjerg/revm?branch=onbjerg/blockhashes#ed4e9aeec068ba36b054fdfb807060f1555ec484"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "0.4.0"
-source = "git+https://github.com/bluealloy/revm?branch=main#0f6c09ff19873b99aab98b4cefe20d0e5bfa9a8c"
+source = "git+https://github.com/onbjerg/revm?branch=onbjerg/blockhashes#ed4e9aeec068ba36b054fdfb807060f1555ec484"
 dependencies = [
  "bytes",
  "num 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4933,8 +4933,3 @@ name = "zeroize"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
-
-[[patch.unused]]
-name = "evm"
-version = "0.33.1"
-source = "git+https://github.com/gakonst/evm?branch=bump-primitive-types#7df668d1e53a8ca212fe5fe5362eb9b74839363c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,6 @@ codegen-units = 1
 panic = "abort"
 debug = true
 
-## Patch sputnik with more recent primitive types
-# https://github.com/rust-blockchain/evm/pulls
-[patch."https://github.com/rust-blockchain/evm"]
-evm = { git = "https://github.com/gakonst/evm", branch = "bump-primitive-types" }
-
 ## Patch ethers-rs with a local checkout
 #[patch."https://github.com/gakonst/ethers-rs"]
 #ethers = { path = "../ethers-rs" }

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -5,12 +5,11 @@ use crate::{
 };
 use ansi_term::Colour;
 use clap::{AppSettings, Parser};
-use ethers::{
-    abi::RawLog,
-    contract::EthLogDecode,
-    solc::{ArtifactOutput, Project},
+use ethers::solc::{ArtifactOutput, Project};
+use forge::{
+    decode::decode_console_logs, executor::opts::EvmOpts, MultiContractRunnerBuilder, TestFilter,
+    TestResult,
 };
-use forge::{executor::opts::EvmOpts, MultiContractRunnerBuilder, TestFilter, TestResult};
 use foundry_config::{figment::Figment, Config};
 use regex::Regex;
 use std::{collections::BTreeMap, str::FromStr, sync::mpsc::channel, thread};
@@ -354,9 +353,7 @@ fn test<A: ArtifactOutput + 'static>(
                     let mut add_newline = false;
                     if verbosity > 1 {
                         // We only decode logs from Hardhat and DS-style console events
-                        let console_logs: Vec<String> =
-                            result.logs.iter().filter_map(decode_console_log).collect();
-
+                        let console_logs = decode_console_logs(&result.logs);
                         if !console_logs.is_empty() {
                             add_newline = true;
                             println!("Logs:");
@@ -449,42 +446,4 @@ fn test<A: ArtifactOutput + 'static>(
         }*/
         Ok(TestOutcome::new(results, allow_failure))
     }
-}
-
-fn decode_console_log(log: &RawLog) -> Option<String> {
-    use forge::abi::ConsoleEvents::{self, *};
-
-    let decoded = match ConsoleEvents::decode_log(log).ok()? {
-        LogsFilter(inner) => format!("{}", inner.0),
-        LogBytesFilter(inner) => format!("{}", inner.0),
-        LogNamedAddressFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
-        LogNamedBytes32Filter(inner) => {
-            format!("{}: 0x{}", inner.key, hex::encode(inner.val))
-        }
-        LogNamedDecimalIntFilter(inner) => {
-            let (sign, val) = inner.val.into_sign_and_abs();
-            format!(
-                "{}: {}{}",
-                inner.key,
-                sign,
-                ethers::utils::format_units(val, inner.decimals.as_u32()).unwrap()
-            )
-        }
-        LogNamedDecimalUintFilter(inner) => {
-            format!(
-                "{}: {}",
-                inner.key,
-                ethers::utils::format_units(inner.val, inner.decimals.as_u32()).unwrap()
-            )
-        }
-        LogNamedIntFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
-        LogNamedUintFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
-        LogNamedBytesFilter(inner) => {
-            format!("{}: 0x{}", inner.key, hex::encode(inner.val))
-        }
-        LogNamedStringFilter(inner) => format!("{}: {}", inner.key, inner.val),
-
-        e => e.to_string(),
-    };
-    Some(decoded)
 }

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -25,7 +25,7 @@ rlp = "0.5.1"
 
 bytes = "1.1.0"
 thiserror = "1.0.29"
-revm = { package = "revm", git = "https://github.com/bluealloy/revm", branch = "main" }
+revm = { package = "revm", git = "https://github.com/onbjerg/revm", branch = "onbjerg/blockhashes" }
 hashbrown = "0.12"
 once_cell = "1.9.0"
 

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -25,7 +25,7 @@ rlp = "0.5.1"
 
 bytes = "1.1.0"
 thiserror = "1.0.29"
-revm = { package = "revm", git = "https://github.com/onbjerg/revm", branch = "onbjerg/blockhashes" }
+revm = { package = "revm", git = "https://github.com/onbjerg/revm", branch = "onbjerg/blockhashes", default-features = false, features = ["std", "k256"] }
 hashbrown = "0.12"
 once_cell = "1.9.0"
 

--- a/forge/src/decode.rs
+++ b/forge/src/decode.rs
@@ -1,0 +1,48 @@
+//! Various utilities to decode test results
+use crate::abi::ConsoleEvents::{self, *};
+use ethers::{abi::RawLog, contract::EthLogDecode};
+
+/// Decode a set of logs, only returning logs from DSTest logging events and Hardhat's `console.log`
+pub fn decode_console_logs(logs: &[RawLog]) -> Vec<String> {
+    logs.iter().filter_map(decode_console_log).collect()
+}
+
+/// Decode a single log.
+///
+/// This function returns [None] if it is not a DSTest log or the result of a Hardhat
+/// `console.log`.
+pub fn decode_console_log(log: &RawLog) -> Option<String> {
+    let decoded = match ConsoleEvents::decode_log(log).ok()? {
+        LogsFilter(inner) => format!("{}", inner.0),
+        LogBytesFilter(inner) => format!("{}", inner.0),
+        LogNamedAddressFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
+        LogNamedBytes32Filter(inner) => {
+            format!("{}: 0x{}", inner.key, hex::encode(inner.val))
+        }
+        LogNamedDecimalIntFilter(inner) => {
+            let (sign, val) = inner.val.into_sign_and_abs();
+            format!(
+                "{}: {}{}",
+                inner.key,
+                sign,
+                ethers::utils::format_units(val, inner.decimals.as_u32()).unwrap()
+            )
+        }
+        LogNamedDecimalUintFilter(inner) => {
+            format!(
+                "{}: {}",
+                inner.key,
+                ethers::utils::format_units(inner.val, inner.decimals.as_u32()).unwrap()
+            )
+        }
+        LogNamedIntFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
+        LogNamedUintFilter(inner) => format!("{}: {:?}", inner.key, inner.val),
+        LogNamedBytesFilter(inner) => {
+            format!("{}: 0x{}", inner.key, hex::encode(inner.val))
+        }
+        LogNamedStringFilter(inner) => format!("{}: {}", inner.key, inner.val),
+
+        e => e.to_string(),
+    };
+    Some(decoded)
+}

--- a/forge/src/executor/abi.rs
+++ b/forge/src/executor/abi.rs
@@ -2,6 +2,47 @@ use ethers::types::{Address, Selector};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
+/// The cheatcode handler address.
+///
+/// This is the same address as the one used in DappTools's HEVM.
+pub static CHEATCODE_ADDRESS: Lazy<Address> = Lazy::new(|| {
+    Address::from_slice(&hex::decode("7109709ECfa91a80626fF3989D68f67F5b1DD12D").unwrap())
+});
+
+// Bindings for cheatcodes
+ethers::contract::abigen!(
+    HEVM,
+    r#"[
+            roll(uint256)
+            warp(uint256)
+            fee(uint256)
+            store(address,bytes32,bytes32)
+            load(address,bytes32)(bytes32)
+            ffi(string[])(bytes)
+            addr(uint256)(address)
+            sign(uint256,bytes32)(uint8,bytes32,bytes32)
+            prank(address)
+            startPrank(address)
+            prank(address,address)
+            startPrank(address,address)
+            stopPrank()
+            deal(address,uint256)
+            etch(address,bytes)
+            expectRevert(bytes)
+            expectRevert(bytes4)
+            record()
+            accesses(address)(bytes32[],bytes32[])
+            expectEmit(bool,bool,bool,bool)
+            mockCall(address,bytes,bytes)
+            clearMockedCalls()
+            expectCall(address,bytes)
+            getCode(string)
+            label(address,string)
+            assume(bool)
+    ]"#,
+);
+pub use hevm_mod::{HEVMCalls, HEVM_ABI};
+
 /// The Hardhat console address.
 ///
 /// See: https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/console.sol

--- a/forge/src/executor/builder.rs
+++ b/forge/src/executor/builder.rs
@@ -1,46 +1,44 @@
 use revm::{db::EmptyDB, Env, SpecId};
 
-use super::Executor;
+use super::{inspector::InspectorStackConfig, Executor};
 
 #[derive(Default)]
 pub struct ExecutorBuilder {
-    /// Whether or not cheatcodes are enabled
-    cheatcodes: bool,
-    /// Whether or not the FFI cheatcode is enabled
-    ffi: bool,
     /// The execution environment configuration.
-    config: Env,
+    env: Env,
+    /// The configuration used to build an [InspectorStack].
+    inspector_config: InspectorStackConfig,
 }
 
 impl ExecutorBuilder {
     #[must_use]
     pub fn new() -> Self {
-        Self { cheatcodes: false, ffi: false, config: Env::default() }
+        Default::default()
     }
 
     /// Enables cheatcodes on the executor.
     #[must_use]
     pub fn with_cheatcodes(mut self, ffi: bool) -> Self {
-        self.cheatcodes = true;
-        self.ffi = ffi;
+        self.inspector_config.cheatcodes = true;
+        self.inspector_config.ffi = ffi;
         self
     }
 
     pub fn with_spec(mut self, spec: SpecId) -> Self {
-        self.config.cfg.spec_id = spec;
+        self.env.cfg.spec_id = spec;
         self
     }
 
     /// Configure the execution environment (gas limit, chain spec, ...)
     #[must_use]
-    pub fn with_config(mut self, config: Env) -> Self {
-        self.config = config;
+    pub fn with_config(mut self, env: Env) -> Self {
+        self.env = env;
         self
     }
 
     /// Builds the executor as configured.
     pub fn build(self) -> Executor<EmptyDB> {
-        Executor::new(EmptyDB(), self.config)
+        Executor::new(EmptyDB(), self.env, self.inspector_config)
     }
 
     // TODO: add with_traces

--- a/forge/src/executor/inspector/cheatcodes/env.rs
+++ b/forge/src/executor/inspector/cheatcodes/env.rs
@@ -1,0 +1,171 @@
+use std::collections::BTreeMap;
+
+use super::Cheatcodes;
+use crate::abi::HEVMCalls;
+use bytes::Bytes;
+use ethers::{
+    abi::{AbiEncode, Token, Tokenize},
+    types::{Address, H256, U256},
+    utils::keccak256,
+};
+use revm::{Database, EVMData};
+
+#[derive(Clone, Debug, Default)]
+pub struct Prank {
+    /// Address of the contract that initiated the prank
+    pub prank_caller: Address,
+    /// Address of `tx.origin` when the prank was initiated
+    pub prank_origin: Address,
+    /// The address to assign to `msg.sender`
+    pub new_caller: Address,
+    /// The address to assign to `tx.origin`
+    pub new_origin: Option<Address>,
+    /// The depth at which the prank was called
+    pub depth: u64,
+    /// Whether or not the prank stops by itself after the next call
+    pub single_call: bool,
+}
+
+fn prank(
+    state: &mut Cheatcodes,
+    prank_caller: Address,
+    prank_origin: Address,
+    new_caller: Address,
+    new_origin: Option<Address>,
+    depth: u64,
+    single_call: bool,
+) -> Result<Bytes, Bytes> {
+    let prank = Prank {
+        prank_caller,
+        prank_origin,
+        new_caller,
+        new_origin,
+        // Note: When calling a cheatcode, the depth is not increased. Because of that, the depth
+        // we actually want to prank at is 1 level deeper.
+        depth: depth + 1,
+        single_call,
+    };
+
+    if state.prank.is_some() {
+        return Err("You have an active prank already.".to_string().encode().into())
+    }
+
+    state.prank = Some(prank);
+    Ok(Bytes::new())
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RecordAccess {
+    pub reads: BTreeMap<Address, Vec<U256>>,
+    pub writes: BTreeMap<Address, Vec<U256>>,
+}
+
+fn record(state: &mut Cheatcodes) {
+    state.accesses = Some(Default::default());
+}
+
+fn accesses(state: &mut Cheatcodes, address: Address) -> Bytes {
+    if let Some(storage_accesses) = &mut state.accesses {
+        ethers::abi::encode(&[
+            storage_accesses.reads.remove(&address).unwrap_or_default().into_tokens()[0].clone(),
+            storage_accesses.writes.remove(&address).unwrap_or_default().into_tokens()[0].clone(),
+        ])
+        .into()
+    } else {
+        ethers::abi::encode(&[Token::Array(vec![]), Token::Array(vec![])]).into()
+    }
+}
+
+pub fn apply<DB: Database>(
+    state: &mut Cheatcodes,
+    data: &mut EVMData<'_, DB>,
+    caller: Address,
+    call: &HEVMCalls,
+) -> Option<Result<Bytes, Bytes>> {
+    Some(match call {
+        HEVMCalls::Warp(inner) => {
+            data.env.block.timestamp = inner.0;
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Roll(inner) => {
+            data.env.block.number = inner.0;
+            // TODO: Set blockhash somehow
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Fee(inner) => {
+            data.env.block.basefee = inner.0;
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Store(inner) => {
+            // TODO: Does this increase gas usage?
+            data.subroutine.load_account(inner.0, data.db);
+            data.subroutine.sstore(inner.0, inner.1.into(), inner.2.into(), data.db);
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Load(inner) => {
+            // TODO: Does this increase gas usage?
+            data.subroutine.load_account(inner.0, data.db);
+            let (val, _) = data.subroutine.sload(inner.0, inner.1.into(), data.db);
+            Ok(val.encode().into())
+        }
+        HEVMCalls::Etch(inner) => {
+            let code = inner.1.clone();
+            let hash = H256::from_slice(&keccak256(&code));
+
+            // TODO: Does this increase gas usage?
+            data.subroutine.load_account(inner.0, data.db);
+            data.subroutine.set_code(inner.0, code.0, hash);
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Deal(inner) => {
+            let who = inner.0;
+            let value = inner.1;
+
+            // TODO: Does this increase gas usage?
+            data.subroutine.load_account(who, data.db);
+            let balance = data.subroutine.account(inner.0).info.balance;
+
+            // TODO: We should probably upstream a `set_balance` function
+            if balance < value {
+                data.subroutine.balance_add(who, value - balance);
+            } else {
+                data.subroutine.balance_sub(who, balance - value);
+            }
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Prank0(inner) => {
+            prank(state, caller, data.env.tx.caller, inner.0, None, data.subroutine.depth(), true)
+        }
+        HEVMCalls::Prank1(inner) => prank(
+            state,
+            caller,
+            data.env.tx.caller,
+            inner.0,
+            Some(inner.1),
+            data.subroutine.depth(),
+            true,
+        ),
+        HEVMCalls::StartPrank0(inner) => {
+            prank(state, caller, data.env.tx.caller, inner.0, None, data.subroutine.depth(), false)
+        }
+        HEVMCalls::StartPrank1(inner) => prank(
+            state,
+            caller,
+            data.env.tx.caller,
+            inner.0,
+            Some(inner.1),
+            data.subroutine.depth(),
+            false,
+        ),
+        HEVMCalls::StopPrank(_) => {
+            state.prank = None;
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Record(_) => {
+            record(state);
+            Ok(Bytes::new())
+        }
+        HEVMCalls::Accesses(inner) => Ok(accesses(state, inner.0)),
+        _ => return None,
+    })
+}

--- a/forge/src/executor/inspector/cheatcodes/env.rs
+++ b/forge/src/executor/inspector/cheatcodes/env.rs
@@ -60,7 +60,7 @@ pub struct RecordAccess {
     pub writes: BTreeMap<Address, Vec<U256>>,
 }
 
-fn record(state: &mut Cheatcodes) {
+fn start_record(state: &mut Cheatcodes) {
     state.accesses = Some(Default::default());
 }
 
@@ -162,7 +162,7 @@ pub fn apply<DB: Database>(
             Ok(Bytes::new())
         }
         HEVMCalls::Record(_) => {
-            record(state);
+            start_record(state);
             Ok(Bytes::new())
         }
         HEVMCalls::Accesses(inner) => Ok(accesses(state, inner.0)),

--- a/forge/src/executor/inspector/cheatcodes/env.rs
+++ b/forge/src/executor/inspector/cheatcodes/env.rs
@@ -89,7 +89,6 @@ pub fn apply<DB: Database>(
         }
         HEVMCalls::Roll(inner) => {
             data.env.block.number = inner.0;
-            // TODO: Set blockhash somehow
             Ok(Bytes::new())
         }
         HEVMCalls::Fee(inner) => {

--- a/forge/src/executor/inspector/cheatcodes/expect.rs
+++ b/forge/src/executor/inspector/cheatcodes/expect.rs
@@ -106,8 +106,11 @@ pub fn apply<DB: Database>(
         HEVMCalls::ExpectRevert1(inner) => {
             expect_revert(state, inner.0.to_vec().into(), data.subroutine.depth())
         }
-        /*HEVMCalls::ExpectEmit(_) => {}
-        HEVMCalls::ExpectCall(_) => {}*/
+        /* HEVMCalls::ExpectEmit(_) => {} */
+        HEVMCalls::ExpectCall(inner) => {
+            state.expected_calls.entry(inner.0).or_default().push(inner.1.to_vec().into());
+            Ok(Bytes::new())
+        }
         HEVMCalls::MockCall(inner) => {
             state
                 .mocked_calls

--- a/forge/src/executor/inspector/cheatcodes/expect.rs
+++ b/forge/src/executor/inspector/cheatcodes/expect.rs
@@ -1,0 +1,125 @@
+use super::Cheatcodes;
+use crate::abi::HEVMCalls;
+use bytes::Bytes;
+use ethers::{abi::AbiEncode, types::Address};
+use once_cell::sync::Lazy;
+use revm::{return_ok, Database, EVMData, Return};
+use std::str::FromStr;
+
+/// For some cheatcodes we may internally change the status of the call, i.e. in `expectRevert`.
+/// Solidity will see a successful call and attempt to decode the return data. Therefore, we need
+/// to populate the return with dummy bytes so the decode doesn't fail.
+static DUMMY_CALL_OUTPUT: [u8; 320] = [0u8; 320];
+
+/// Same reasoning as [DUMMY_CALL_OUTPUT], but for creates.
+static DUMMY_CREATE_ADDRESS: Lazy<Address> =
+    Lazy::new(|| Address::from_str("0000000000000000000000000000000000000001").unwrap());
+
+#[derive(Clone, Debug, Default)]
+pub struct ExpectedRevert {
+    /// The expected data returned by the revert
+    pub reason: Bytes,
+    /// The depth at which the revert is expected
+    pub depth: u64,
+}
+
+fn expect_revert(state: &mut Cheatcodes, reason: Bytes, depth: u64) -> Result<Bytes, Bytes> {
+    if state.expected_revert.is_some() {
+        Err("You must call another function prior to expecting a second revert."
+            .to_string()
+            .encode()
+            .into())
+    } else {
+        state.expected_revert = Some(ExpectedRevert { reason, depth });
+        Ok(Bytes::new())
+    }
+}
+
+pub fn handle_expect_revert(
+    is_create: bool,
+    expected_revert: &Bytes,
+    status: Return,
+    retdata: Bytes,
+) -> Result<(Option<Address>, Bytes), Bytes> {
+    if matches!(status, return_ok!()) {
+        return Err("Call did not revert as expected".to_string().encode().into())
+    }
+
+    if retdata.is_empty() {
+        return Err("Call reverted as expected, but without data".to_string().encode().into())
+    }
+
+    let (err, actual_revert): (_, Bytes) = match retdata {
+        _ if retdata.len() >= 4 && retdata[0..4] == [8, 195, 121, 160] => {
+            // It's a revert string, so we do some conversion to perform the check
+            let decoded_data: Bytes =
+                ethers::abi::decode(&[ethers::abi::ParamType::Bytes], &retdata[4..])
+                    .expect("String error code, but data is not a string")[0]
+                    .clone()
+                    .into_bytes()
+                    .expect("Cannot fail as this is bytes")
+                    .into();
+
+            (
+                format!(
+                    "Error != expected error: '{}' != '{}'",
+                    String::from_utf8_lossy(&decoded_data),
+                    String::from_utf8_lossy(expected_revert)
+                )
+                .encode()
+                .into(),
+                decoded_data,
+            )
+        }
+        _ => (
+            format!(
+                "Error != expected error: 0x{} != 0x{}",
+                hex::encode(&retdata),
+                hex::encode(&expected_revert)
+            )
+            .encode()
+            .into(),
+            retdata,
+        ),
+    };
+
+    if actual_revert == expected_revert {
+        Ok(if is_create {
+            (Some(*DUMMY_CREATE_ADDRESS), Bytes::new())
+        } else {
+            (None, DUMMY_CALL_OUTPUT.to_vec().into())
+        })
+    } else {
+        Err(err)
+    }
+}
+
+pub fn apply<DB: Database>(
+    state: &mut Cheatcodes,
+    data: &mut EVMData<'_, DB>,
+    call: &HEVMCalls,
+) -> Option<Result<Bytes, Bytes>> {
+    Some(match call {
+        HEVMCalls::ExpectRevert0(inner) => {
+            expect_revert(state, inner.0.to_vec().into(), data.subroutine.depth())
+        }
+        HEVMCalls::ExpectRevert1(inner) => {
+            expect_revert(state, inner.0.to_vec().into(), data.subroutine.depth())
+        }
+        /*HEVMCalls::ExpectEmit(_) => {}
+        HEVMCalls::ExpectCall(_) => {}*/
+        HEVMCalls::MockCall(inner) => {
+            state
+                .mocked_calls
+                .entry(inner.0)
+                .or_default()
+                .insert(inner.1.to_vec().into(), inner.2.to_vec().into());
+            Ok(Bytes::new())
+        }
+        HEVMCalls::ClearMockedCalls(_) => {
+            state.mocked_calls = Default::default();
+            Ok(Bytes::new())
+        }
+        _ => return None,
+    })
+}

--- a/forge/src/executor/inspector/cheatcodes/expect.rs
+++ b/forge/src/executor/inspector/cheatcodes/expect.rs
@@ -51,7 +51,7 @@ pub fn handle_expect_revert(
         return Err("Call did not revert as expected".to_string().encode().into())
     }
 
-    if retdata.is_empty() {
+    if !expected_revert.is_empty() && retdata.is_empty() {
         return Err("Call reverted as expected, but without data".to_string().encode().into())
     }
 

--- a/forge/src/executor/inspector/cheatcodes/expect.rs
+++ b/forge/src/executor/inspector/cheatcodes/expect.rs
@@ -12,6 +12,9 @@ use std::str::FromStr;
 /// For some cheatcodes we may internally change the status of the call, i.e. in `expectRevert`.
 /// Solidity will see a successful call and attempt to decode the return data. Therefore, we need
 /// to populate the return with dummy bytes so the decode doesn't fail.
+///
+/// 320 bytes was arbitrarily chosen because it is long enough for return values up to 10 words in
+/// size.
 static DUMMY_CALL_OUTPUT: [u8; 320] = [0u8; 320];
 
 /// Same reasoning as [DUMMY_CALL_OUTPUT], but for creates.

--- a/forge/src/executor/inspector/cheatcodes/ext.rs
+++ b/forge/src/executor/inspector/cheatcodes/ext.rs
@@ -1,0 +1,62 @@
+use crate::abi::HEVMCalls;
+use bytes::Bytes;
+use ethers::{
+    abi::{self, AbiEncode, Token},
+    prelude::{artifacts::CompactContractBytecode, ProjectPathsConfig},
+};
+use std::{fs::File, io::Read, path::Path, process::Command};
+
+fn ffi(args: &[String]) -> Result<Bytes, Bytes> {
+    let output = Command::new(&args[0])
+        .args(&args[1..])
+        .output()
+        .map_err(|err| err.to_string().encode())?
+        .stdout;
+    let output = unsafe { std::str::from_utf8_unchecked(&output) };
+    let decoded = hex::decode(&output.trim()[2..]).map_err(|err| err.to_string().encode())?;
+
+    Ok(abi::encode(&[Token::Bytes(decoded.to_vec())]).into())
+}
+
+fn get_code(path: &str) -> Result<Bytes, Bytes> {
+    let path = if path.ends_with(".json") {
+        Path::new(&path).to_path_buf()
+    } else {
+        let parts: Vec<&str> = path.split(':').collect();
+        let file = parts[0];
+        let contract_name =
+            if parts.len() == 1 { parts[0].replace(".sol", "") } else { parts[1].to_string() };
+
+        let out_dir = ProjectPathsConfig::find_artifacts_dir(Path::new("./"));
+        out_dir.join(format!("{}/{}.json", file, contract_name))
+    };
+
+    let mut buffer = String::new();
+    File::open(path)
+        .map_err(|err| err.to_string().encode())?
+        .read_to_string(&mut buffer)
+        .map_err(|err| err.to_string().encode())?;
+
+    let artifact = serde_json::from_str::<CompactContractBytecode>(&buffer)
+        .map_err(|err| err.to_string().encode())?;
+
+    if let Some(bin) = artifact.bytecode.and_then(|bytecode| bytecode.object.into_bytes()) {
+        Ok(abi::encode(&[Token::Bytes(bin.to_vec())]).into())
+    } else {
+        Err("No bytecode for contract. Is it abstract or unlinked?".to_string().encode().into())
+    }
+}
+
+pub fn apply(ffi_enabled: bool, call: &HEVMCalls) -> Option<Result<Bytes, Bytes>> {
+    Some(match call {
+        HEVMCalls::Ffi(inner) => {
+            if !ffi_enabled {
+                Err("FFI disabled: run again with `--ffi` if you want to allow tests to call external scripts.".to_string().encode().into())
+            } else {
+                ffi(&inner.0)
+            }
+        }
+        HEVMCalls::GetCode(inner) => get_code(&inner.0),
+        _ => return None,
+    })
+}

--- a/forge/src/executor/inspector/cheatcodes/fuzz.rs
+++ b/forge/src/executor/inspector/cheatcodes/fuzz.rs
@@ -1,0 +1,14 @@
+use crate::{abi::HEVMCalls, executor::fuzz::ASSUME_MAGIC_RETURN_CODE};
+use bytes::Bytes;
+use revm::{Database, EVMData};
+
+pub fn apply<DB: Database>(
+    _: &mut EVMData<'_, DB>,
+    call: &HEVMCalls,
+) -> Option<Result<Bytes, Bytes>> {
+    if let HEVMCalls::Assume(inner) = call {
+        Some(if inner.0 { Ok(Bytes::new()) } else { Err(ASSUME_MAGIC_RETURN_CODE.into()) })
+    } else {
+        None
+    }
+}

--- a/forge/src/executor/inspector/cheatcodes/mod.rs
+++ b/forge/src/executor/inspector/cheatcodes/mod.rs
@@ -1,0 +1,230 @@
+/// Cheatcodes related to the execution environment.
+mod env;
+pub use env::{Prank, RecordAccess};
+/// Assertion helpers (such as `expectEmit`)
+mod expect;
+pub use expect::ExpectedRevert;
+/// Cheatcodes that interact with the external environment (FFI etc.)
+mod ext;
+/// Cheatcodes that configure the fuzzer
+mod fuzz;
+/// Utility cheatcodes (`sign` etc.)
+mod util;
+
+use crate::{abi::HEVMCalls, executor::CHEATCODE_ADDRESS};
+use bytes::Bytes;
+use ethers::{
+    abi::{AbiDecode, AbiEncode},
+    types::Address,
+};
+use revm::{
+    opcode, CallInputs, CreateInputs, Database, EVMData, Gas, Inspector, Interpreter, Return,
+};
+use std::collections::BTreeMap;
+
+use self::expect::handle_expect_revert;
+
+/// An inspector that handles calls to various cheatcodes, each with their own behavior.
+///
+/// Cheatcodes can be called by contracts during execution to modify the VM environment, such as
+/// mocking addresses, signatures and altering call reverts.
+pub struct Cheatcodes {
+    /// Whether FFI is enabled or not
+    ffi: bool,
+
+    /// Address labels
+    pub labels: BTreeMap<Address, String>,
+
+    /// Prank information
+    pub prank: Option<Prank>,
+
+    /// Expected revert information
+    pub expected_revert: Option<ExpectedRevert>,
+
+    /// Recorded storage reads and writes
+    pub accesses: Option<RecordAccess>,
+
+    /// Mocked calls
+    pub mocked_calls: BTreeMap<Address, BTreeMap<Bytes, Bytes>>,
+}
+
+impl Cheatcodes {
+    pub fn new(ffi: bool) -> Self {
+        Self {
+            ffi,
+            labels: BTreeMap::new(),
+            prank: None,
+            expected_revert: None,
+            accesses: None,
+            mocked_calls: BTreeMap::new(),
+        }
+    }
+
+    fn apply_cheatcode<DB: Database>(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        caller: Address,
+        call: &CallInputs,
+    ) -> Result<Bytes, Bytes> {
+        // Decode the cheatcode call
+        let decoded = HEVMCalls::decode(&call.input).map_err(|err| err.to_string().encode())?;
+
+        // TODO: Log the opcode for the debugger
+        env::apply(self, data, caller, &decoded)
+            .or_else(|| util::apply(self, data, &decoded))
+            .or_else(|| expect::apply(self, data, &decoded))
+            .or_else(|| fuzz::apply(data, &decoded))
+            .or_else(|| ext::apply(self.ffi, &decoded))
+            .ok_or_else(|| "Cheatcode was unhandled. This is a bug.".to_string().encode())?
+    }
+}
+
+impl<DB> Inspector<DB> for Cheatcodes
+where
+    DB: Database,
+{
+    fn call(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &CallInputs,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        if call.contract == *CHEATCODE_ADDRESS {
+            match self.apply_cheatcode(data, call.context.caller, call) {
+                Ok(retdata) => (Return::Return, Gas::new(0), retdata),
+                Err(err) => (Return::Revert, Gas::new(0), err),
+            }
+        } else {
+            // Handle mocked calls
+            if let Some(mocks) = self.mocked_calls.get(&call.contract) {
+                if let Some(mock_retdata) = mocks.get(&call.input) {
+                    return (Return::Return, Gas::new(0), mock_retdata.clone())
+                } else if let Some((_, mock_retdata)) =
+                    mocks.iter().find(|(mock, _)| *mock == &call.input[..mock.len()])
+                {
+                    return (Return::Return, Gas::new(0), mock_retdata.clone())
+                }
+            }
+
+            (Return::Continue, Gas::new(0), Bytes::new())
+        }
+    }
+
+    fn initialize_interp(
+        &mut self,
+        interpreter: &mut Interpreter,
+        data: &mut EVMData<'_, DB>,
+        _: bool,
+    ) -> Return {
+        // Apply our prank
+        if let Some(prank) = &self.prank {
+            if data.subroutine.depth() >= prank.depth &&
+                interpreter.contract.caller == prank.prank_caller
+            {
+                // At the target depth we set `msg.sender`
+                if data.subroutine.depth() == prank.depth {
+                    interpreter.contract.caller = prank.new_caller;
+                }
+
+                // At the target depth, or deeper, we set `tx.origin`
+                if let Some(new_origin) = prank.new_origin {
+                    data.env.tx.caller = new_origin;
+                }
+            }
+        }
+
+        Return::Continue
+    }
+
+    fn step(&mut self, interpreter: &mut Interpreter, _: &mut EVMData<'_, DB>, _: bool) -> Return {
+        if let Some(storage_accesses) = &mut self.accesses {
+            match interpreter.contract.code[interpreter.program_counter()] {
+                opcode::SLOAD => {
+                    let key = try_or_continue!(interpreter.stack().peek(0));
+                    storage_accesses
+                        .reads
+                        .entry(interpreter.contract().address)
+                        .or_insert_with(Vec::new)
+                        .push(key);
+                }
+                opcode::SSTORE => {
+                    let key = try_or_continue!(interpreter.stack().peek(0));
+                    storage_accesses
+                        .writes
+                        .entry(interpreter.contract().address)
+                        .or_insert_with(Vec::new)
+                        .push(key);
+                }
+                _ => (),
+            }
+        }
+
+        Return::Continue
+    }
+
+    fn call_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &CallInputs,
+        remaining_gas: Gas,
+        status: Return,
+        retdata: Bytes,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        if call.contract == *CHEATCODE_ADDRESS {
+            return (status, remaining_gas, retdata)
+        }
+
+        // Clean up pranks
+        if let Some(prank) = &self.prank {
+            data.env.tx.caller = prank.prank_origin;
+            if prank.single_call {
+                std::mem::take(&mut self.prank);
+            }
+        }
+
+        // Handle expected reverts
+        if let Some(expected_revert) = &self.expected_revert {
+            if data.subroutine.depth() <= expected_revert.depth {
+                let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
+                return match handle_expect_revert(false, &expected_revert.reason, status, retdata) {
+                    Err(retdata) => (Return::Revert, remaining_gas, retdata),
+                    Ok((_, retdata)) => (Return::Return, remaining_gas, retdata),
+                }
+            }
+        }
+
+        (status, remaining_gas, retdata)
+    }
+
+    fn create_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        _: &CreateInputs,
+        status: Return,
+        address: Option<Address>,
+        remaining_gas: Gas,
+        retdata: Bytes,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        // Clean up pranks
+        if let Some(prank) = &self.prank {
+            data.env.tx.caller = prank.prank_origin;
+            if prank.single_call {
+                std::mem::take(&mut self.prank);
+            }
+        }
+
+        // Handle expected reverts
+        if let Some(expected_revert) = &self.expected_revert {
+            if data.subroutine.depth() <= expected_revert.depth {
+                let expected_revert = std::mem::take(&mut self.expected_revert).unwrap();
+                return match handle_expect_revert(true, &expected_revert.reason, status, retdata) {
+                    Err(retdata) => (Return::Revert, None, remaining_gas, retdata),
+                    Ok((address, retdata)) => (Return::Return, address, remaining_gas, retdata),
+                }
+            }
+        }
+
+        (status, address, remaining_gas, retdata)
+    }
+}

--- a/forge/src/executor/inspector/cheatcodes/mod.rs
+++ b/forge/src/executor/inspector/cheatcodes/mod.rs
@@ -90,8 +90,8 @@ where
     ) -> (Return, Gas, Bytes) {
         if call.contract == *CHEATCODE_ADDRESS {
             match self.apply_cheatcode(data, call.context.caller, call) {
-                Ok(retdata) => (Return::Return, Gas::new(0), retdata),
-                Err(err) => (Return::Revert, Gas::new(0), err),
+                Ok(retdata) => (Return::Return, Gas::new(call.gas_limit), retdata),
+                Err(err) => (Return::Revert, Gas::new(call.gas_limit), err),
             }
         } else {
             // Handle expected calls
@@ -106,15 +106,15 @@ where
             // Handle mocked calls
             if let Some(mocks) = self.mocked_calls.get(&call.contract) {
                 if let Some(mock_retdata) = mocks.get(&call.input) {
-                    return (Return::Return, Gas::new(0), mock_retdata.clone())
+                    return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone())
                 } else if let Some((_, mock_retdata)) =
                     mocks.iter().find(|(mock, _)| *mock == &call.input[..mock.len()])
                 {
-                    return (Return::Return, Gas::new(0), mock_retdata.clone())
+                    return (Return::Return, Gas::new(call.gas_limit), mock_retdata.clone())
                 }
             }
 
-            (Return::Continue, Gas::new(0), Bytes::new())
+            (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
         }
     }
 

--- a/forge/src/executor/inspector/cheatcodes/mod.rs
+++ b/forge/src/executor/inspector/cheatcodes/mod.rs
@@ -158,6 +158,13 @@ where
                 }
                 opcode::SSTORE => {
                     let key = try_or_continue!(interpreter.stack().peek(0));
+
+                    // An SSTORE does an SLOAD internally
+                    storage_accesses
+                        .reads
+                        .entry(interpreter.contract().address)
+                        .or_insert_with(Vec::new)
+                        .push(key);
                     storage_accesses
                         .writes
                         .entry(interpreter.contract().address)

--- a/forge/src/executor/inspector/cheatcodes/util.rs
+++ b/forge/src/executor/inspector/cheatcodes/util.rs
@@ -1,0 +1,65 @@
+use crate::abi::HEVMCalls;
+use bytes::Bytes;
+use ethers::{
+    abi::AbiEncode,
+    prelude::{k256::ecdsa::SigningKey, LocalWallet, Signer},
+    types::{H256, U256},
+    utils,
+};
+use revm::{Database, EVMData};
+
+use super::Cheatcodes;
+
+fn addr(private_key: U256) -> Result<Bytes, Bytes> {
+    if private_key.is_zero() {
+        return Err("Private key cannot be 0.".to_string().encode().into())
+    }
+
+    let mut bytes: [u8; 32] = [0; 32];
+    private_key.to_big_endian(&mut bytes);
+
+    let key = SigningKey::from_bytes(&bytes).map_err(|err| err.to_string().encode())?;
+    let addr = utils::secret_key_to_address(&key);
+    Ok(addr.encode().into())
+}
+
+fn sign(private_key: U256, digest: H256, chain_id: U256) -> Result<Bytes, Bytes> {
+    if private_key.is_zero() {
+        return Err("Private key cannot be 0.".to_string().encode().into())
+    }
+
+    let mut bytes: [u8; 32] = [0; 32];
+    private_key.to_big_endian(&mut bytes);
+
+    let key = SigningKey::from_bytes(&bytes).map_err(|err| err.to_string().encode())?;
+    let wallet = LocalWallet::from(key).with_chain_id(chain_id.as_u64());
+
+    // The `ecrecover` precompile does not use EIP-155
+    let sig = wallet.sign_hash(digest, false);
+    let recovered = sig.recover(digest).map_err(|err| err.to_string().encode())?;
+
+    assert_eq!(recovered, wallet.address());
+
+    let mut r_bytes = [0u8; 32];
+    let mut s_bytes = [0u8; 32];
+    sig.r.to_big_endian(&mut r_bytes);
+    sig.s.to_big_endian(&mut s_bytes);
+
+    Ok((sig.v, r_bytes, s_bytes).encode().into())
+}
+
+pub fn apply<DB: Database>(
+    state: &mut Cheatcodes,
+    data: &mut EVMData<'_, DB>,
+    call: &HEVMCalls,
+) -> Option<Result<Bytes, Bytes>> {
+    Some(match call {
+        HEVMCalls::Addr(inner) => addr(inner.0),
+        HEVMCalls::Sign(inner) => sign(inner.0, inner.1.into(), data.env.cfg.chain_id),
+        HEVMCalls::Label(inner) => {
+            state.labels.insert(inner.0, inner.1.clone());
+            Ok(Bytes::new())
+        }
+        _ => return None,
+    })
+}

--- a/forge/src/executor/inspector/logs.rs
+++ b/forge/src/executor/inspector/logs.rs
@@ -96,9 +96,9 @@ where
     ) -> (Return, Gas, Bytes) {
         if call.contract == *HARDHAT_CONSOLE_ADDRESS {
             let (status, reason) = self.hardhat_log(call.input.to_vec());
-            (status, Gas::new(0), reason)
+            (status, Gas::new(call.gas_limit), reason)
         } else {
-            (Return::Continue, Gas::new(0), Bytes::new())
+            (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
         }
     }
 }

--- a/forge/src/executor/inspector/macros.rs
+++ b/forge/src/executor/inspector/macros.rs
@@ -11,6 +11,19 @@ macro_rules! try_or_return {
     };
 }
 
+/// Returns [Return::Continue] on an error, discarding the error.
+///
+/// Useful for inspectors that read state that might be invalid, but do not want to emit
+/// appropriate errors themselves, instead opting to continue.
+macro_rules! try_or_continue {
+    ($e:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(_) => return Return::Continue,
+        }
+    };
+}
+
 /// Tries to convert a U256 to a usize and returns from the function on an error.
 ///
 /// This is useful for opcodes that deal with the stack where parameters might be invalid and you

--- a/forge/src/executor/inspector/mod.rs
+++ b/forge/src/executor/inspector/mod.rs
@@ -3,3 +3,27 @@ mod macros;
 
 mod logs;
 pub use logs::LogCollector;
+
+mod stack;
+use revm::Database;
+pub use stack::InspectorStack;
+
+#[derive(Default, Clone)]
+pub struct InspectorStackConfig {
+    /// Whether or not cheatcodes are enabled
+    pub cheatcodes: bool,
+    /// Whether or not the FFI cheatcode is enabled
+    pub ffi: bool,
+}
+
+impl InspectorStackConfig {
+    pub fn stack<DB>(&self) -> InspectorStack<DB>
+    where
+        DB: Database,
+    {
+        let mut stack = InspectorStack::new();
+
+        stack.insert(LogCollector::new());
+        stack
+    }
+}

--- a/forge/src/executor/inspector/mod.rs
+++ b/forge/src/executor/inspector/mod.rs
@@ -8,6 +8,9 @@ mod stack;
 use revm::Database;
 pub use stack::InspectorStack;
 
+mod cheatcodes;
+pub use cheatcodes::Cheatcodes;
+
 #[derive(Default, Clone)]
 pub struct InspectorStackConfig {
     /// Whether or not cheatcodes are enabled
@@ -24,6 +27,9 @@ impl InspectorStackConfig {
         let mut stack = InspectorStack::new();
 
         stack.insert(LogCollector::new());
+        if self.cheatcodes {
+            stack.insert(Cheatcodes::new(self.ffi));
+        }
         stack
     }
 }

--- a/forge/src/executor/inspector/mod.rs
+++ b/forge/src/executor/inspector/mod.rs
@@ -5,7 +5,6 @@ mod logs;
 pub use logs::LogCollector;
 
 mod stack;
-use revm::Database;
 pub use stack::InspectorStack;
 
 mod cheatcodes;
@@ -20,15 +19,12 @@ pub struct InspectorStackConfig {
 }
 
 impl InspectorStackConfig {
-    pub fn stack<DB>(&self) -> InspectorStack<DB>
-    where
-        DB: Database,
-    {
+    pub fn stack(&self) -> InspectorStack {
         let mut stack = InspectorStack::new();
 
-        stack.insert(LogCollector::new());
+        stack.logs = Some(LogCollector::new());
         if self.cheatcodes {
-            stack.insert(Cheatcodes::new(self.ffi));
+            stack.cheatcodes = Some(Cheatcodes::new(self.ffi));
         }
         stack
     }

--- a/forge/src/executor/inspector/stack.rs
+++ b/forge/src/executor/inspector/stack.rs
@@ -1,0 +1,232 @@
+use bytes::Bytes;
+use ethers::types::{Address, U256};
+use revm::{
+    db::Database, CallContext, CreateScheme, EVMData, Gas, Inspector, Machine, Return, Transfer,
+};
+use std::any::Any;
+
+/// A wrapper trait for [Inspector]s that allows for downcasting to a concrete type.
+pub trait DowncastableInspector<DB>: Inspector<DB> + Any
+where
+    DB: Database,
+{
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<DB, T> DowncastableInspector<DB> for T
+where
+    DB: Database,
+    T: Inspector<DB> + Any,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// An inspector that calls multiple inspectors in sequence.
+///
+/// The order in which inspectors are called match the order in which they were added to the stack.
+///
+/// If a call to an inspector returns a value other than [Return::Continue] (or equivalent) the
+/// remaining inspectors are not called.
+pub struct InspectorStack<DB> {
+    // We use a Vec because ordering matters
+    inspectors: Vec<Box<dyn DowncastableInspector<DB>>>,
+}
+
+impl<DB> InspectorStack<DB>
+where
+    DB: Database,
+{
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Add a new inspector to the stack.
+    pub fn insert<T: DowncastableInspector<DB> + 'static>(&mut self, inspector: T) {
+        self.inspectors.push(Box::new(inspector));
+    }
+
+    /// Get a reference to an inspector.
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        self.inspectors.iter().find_map(|inspector| inspector.as_ref().as_any().downcast_ref())
+    }
+}
+
+impl<DB> Default for InspectorStack<DB>
+where
+    DB: Database,
+{
+    fn default() -> Self {
+        Self { inspectors: Vec::new() }
+    }
+}
+
+impl<DB> Inspector<DB> for InspectorStack<DB>
+where
+    DB: Database,
+{
+    fn initialize(&mut self, data: &mut EVMData<'_, DB>) {
+        for inspector in &mut self.inspectors {
+            inspector.initialize(data)
+        }
+    }
+
+    fn initialize_machine(
+        &mut self,
+        machine: &mut Machine,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> Return {
+        for inspector in &mut self.inspectors {
+            let status = inspector.initialize_machine(machine, data, is_static);
+
+            // Allow inspectors to exit early
+            if status != Return::Continue {
+                return status
+            }
+        }
+
+        Return::Continue
+    }
+
+    fn step(
+        &mut self,
+        machine: &mut Machine,
+        data: &mut EVMData<'_, DB>,
+        is_static: bool,
+    ) -> Return {
+        for inspector in &mut self.inspectors {
+            let status = inspector.initialize_machine(machine, data, is_static);
+
+            // Allow inspectors to exit early
+            if status != Return::Continue {
+                return status
+            }
+        }
+
+        Return::Continue
+    }
+
+    fn step_end(&mut self, status: Return, machine: &mut Machine) -> Return {
+        for inspector in &mut self.inspectors {
+            let status = inspector.step_end(status, machine);
+
+            // Allow inspectors to exit early
+            if status != Return::Continue {
+                return status
+            }
+        }
+
+        Return::Continue
+    }
+
+    fn call(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        to: Address,
+        context: &CallContext,
+        transfer: &Transfer,
+        input: &Bytes,
+        gas_limit: u64,
+        is_static: bool,
+    ) -> (Return, Gas, Bytes) {
+        for inspector in &mut self.inspectors {
+            let (status, gas, retdata) =
+                inspector.call(data, to, context, transfer, input, gas_limit, is_static);
+
+            // Allow inspectors to exit early
+            if status != Return::Continue {
+                return (status, gas, retdata)
+            }
+        }
+
+        (Return::Continue, Gas::new(0), Bytes::new())
+    }
+
+    fn call_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        to: Address,
+        context: &CallContext,
+        transfer: &Transfer,
+        input: &Bytes,
+        gas_limit: u64,
+        remaining_gas: u64,
+        status: Return,
+        retdata: &Bytes,
+        is_static: bool,
+    ) {
+        for inspector in &mut self.inspectors {
+            inspector.call_end(
+                data,
+                to,
+                context,
+                transfer,
+                input,
+                gas_limit,
+                remaining_gas,
+                status,
+                retdata,
+                is_static,
+            );
+        }
+    }
+
+    fn create(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        to: Address,
+        scheme: &CreateScheme,
+        value: U256,
+        init_code: &Bytes,
+        gas_limit: u64,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        for inspector in &mut self.inspectors {
+            let (status, addr, gas, retdata) =
+                inspector.create(data, to, scheme, value, init_code, gas_limit);
+
+            // Allow inspectors to exit early
+            if status != Return::Continue {
+                return (status, addr, gas, retdata)
+            }
+        }
+
+        (Return::Continue, None, Gas::new(0), Bytes::new())
+    }
+
+    fn create_end(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        to: Address,
+        scheme: &CreateScheme,
+        value: U256,
+        init_code: &Bytes,
+        status: Return,
+        address: Option<Address>,
+        gas_limit: u64,
+        remaining_gas: u64,
+        retdata: &Bytes,
+    ) {
+        for inspector in &mut self.inspectors {
+            inspector.create_end(
+                data,
+                to,
+                scheme,
+                value,
+                init_code,
+                status,
+                address,
+                gas_limit,
+                remaining_gas,
+                retdata,
+            );
+        }
+    }
+
+    fn selfdestruct(&mut self) {
+        for inspector in &mut self.inspectors {
+            inspector.selfdestruct();
+        }
+    }
+}

--- a/forge/src/executor/inspector/stack.rs
+++ b/forge/src/executor/inspector/stack.rs
@@ -107,7 +107,7 @@ where
             }
         });
 
-        (Return::Continue, Gas::new(0), Bytes::new())
+        (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
     }
 
     fn call_end(
@@ -146,7 +146,7 @@ where
             }
         });
 
-        (Return::Continue, None, Gas::new(0), Bytes::new())
+        (Return::Continue, None, Gas::new(call.gas_limit), Bytes::new())
     }
 
     fn create_end(

--- a/forge/src/executor/mod.rs
+++ b/forge/src/executor/mod.rs
@@ -29,11 +29,13 @@ use ethers::{
 use eyre::Result;
 use foundry_utils::IntoFunction;
 use hashbrown::HashMap;
-use inspector::LogCollector;
+use inspector::{InspectorStack, LogCollector};
 use revm::{
     db::{CacheDB, DatabaseCommit, DatabaseRef, EmptyDB},
-    return_ok, Account, CreateScheme, Env, Return, TransactOut, TransactTo, TxEnv, EVM,
+    return_ok, Account, CreateScheme, Database, Env, Return, TransactOut, TransactTo, TxEnv, EVM,
 };
+
+use self::inspector::InspectorStackConfig;
 
 #[derive(thiserror::Error, Debug)]
 pub enum EvmError {
@@ -101,18 +103,15 @@ pub struct Executor<DB: DatabaseRef> {
     // we need to set `evm.env`.
     db: CacheDB<DB>,
     env: Env,
-    // TODO: Here we are going to store information about the enabled inspectors, or just the
-    // meta-inspector.
-    // NOTE: It is important that the inspector gets a new state every time.
-    //inspector: LogCollector,
+    inspector_config: InspectorStackConfig,
 }
 
 impl<DB> Executor<DB>
 where
     DB: DatabaseRef,
 {
-    pub fn new(inner_db: DB, env: Env) -> Self {
-        Executor { db: CacheDB::new(inner_db), env }
+    pub fn new(inner_db: DB, env: Env, inspector_config: InspectorStackConfig) -> Self {
+        Executor { db: CacheDB::new(inner_db), env, inspector_config }
     }
 
     /// Set the balance of an account.
@@ -197,14 +196,15 @@ where
         evm.database(&mut self.db);
 
         // Run the call
-        let mut inspector = LogCollector::new();
+        let mut inspector: InspectorStack<_> = self.inspector_config.stack();
         let (status, out, gas, _) = evm.inspect_commit(&mut inspector);
         let result = match out {
             TransactOut::Call(data) => data,
             _ => Bytes::default(),
         };
+        let (logs,) = collect_inspector_states(&inspector);
 
-        Ok(RawCallResult { status, result, gas, logs: inspector.logs, state_changeset: None })
+        Ok(RawCallResult { status, result, gas, logs, state_changeset: None })
     }
 
     /// Performs a call to an account on the current state of the VM.
@@ -251,18 +251,19 @@ where
         evm.database(&self.db);
 
         // Run the call
-        let mut inspector = LogCollector::new();
+        let mut inspector: InspectorStack<_> = self.inspector_config.stack();
         let (status, out, gas, state_changeset, _) = evm.inspect_ref(&mut inspector);
         let result = match out {
             TransactOut::Call(data) => data,
             _ => Bytes::default(),
         };
 
+        let (logs,) = collect_inspector_states(&inspector);
         Ok(RawCallResult {
             status,
             result,
             gas,
-            logs: inspector.logs,
+            logs: logs.to_vec(),
             state_changeset: Some(state_changeset),
         })
     }
@@ -278,7 +279,7 @@ where
         evm.env = self.build_env(from, TransactTo::Create(CreateScheme::Create), code, value);
         evm.database(&mut self.db);
 
-        let mut inspector = LogCollector::new();
+        let mut inspector: InspectorStack<_> = self.inspector_config.stack();
         let (status, out, gas, _) = evm.inspect_commit(&mut inspector);
         let addr = match out {
             TransactOut::Create(_, Some(addr)) => addr,
@@ -286,8 +287,9 @@ where
             // regarding deployments in general
             _ => eyre::bail!("deployment failed: {:?}", status),
         };
+        let (logs,) = collect_inspector_states(&inspector);
 
-        Ok((addr, status, gas, inspector.logs))
+        Ok((addr, status, gas, logs))
     }
 
     /// Check if a call to a test contract was successful
@@ -304,7 +306,7 @@ where
         let mut db = CacheDB::new(EmptyDB());
         db.insert_cache(address, self.db.basic(address));
         db.commit(state_changeset);
-        let executor = Executor::new(db, self.env.clone());
+        let executor = Executor::new(db, self.env.clone(), self.inspector_config.clone());
 
         if success {
             // Check if a DSTest assertion failed
@@ -332,4 +334,10 @@ where
             tx: TxEnv { caller, transact_to, data, value, ..self.env.tx.clone() },
         }
     }
+}
+
+fn collect_inspector_states<DB: Database>(stack: &InspectorStack<DB>) -> (Vec<RawLog>,) {
+    let LogCollector { logs } = stack.get().expect("should always have a log collector");
+
+    (logs.to_vec(),)
 }

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod decode;
+
 /// The Forge test runner
 mod runner;
 pub use runner::{ContractRunner, TestKind, TestKindGas, TestResult};


### PR DESCRIPTION
**In draft while I address the remaining items**

Ports all the cheatcodes to REVM in a cheatcode-specific inspector. The cheatcodes have been split up into different modules so we don't end up with a huge file like we had with Sputnik, because we can.

This PR also incldues an update to ethers, which we needed to bump `primitive-types` (needed by `revm`), but it also brought in a lot of other changes. I tried to resolve the breaking changes as best I could, but I'm sure it was changed differently on master.

Also adds `InspectorStack` which is an inspector that calls a bunch of underlying inspectors.

Using my branch of revm until https://github.com/bluealloy/revm/pull/69 is merged.

Remaining items:

- [x] `expectEmit`
- [x] `expectCall`
- [x] Block hashes for `roll`
- [x] Moving to static dispatch (probably?) for `InspectorStack` using an enum
- [ ] Porting over some Rust tests - I already tested all of these changes with https://github.com/onbjerg/foundry-test

Some questions:

- ~~In our `record`/`accesses` test we assert that 2 reads have taken place because "SSTORE does an SLOAD", but this is not reproduced in REVM. I couldn't find any docs that suggest this is supposed to be the case? If it is, or if we want to replicate the behavior, the change is small, but I'd like some thoughts on it~~ (we're now recording a read on every write)
- ~~The `getCode` cheatcode sort of works, but when I added more files to https://github.com/onbjerg/foundry-test the test started failing. As far as I can see, the bytecode does match except for some Solidity metadata at the end. I cannot figure out if this is an error on my part, or if it is because ethers was updated and that somehow changed the metadata that `solc` appends at the end of the bytecode?~~ (seems to work after rebase)

Closes #752 
Closes #755 
Closes #756 