### PR TITLE
fix(forge): verify-contract only needs subset of BuildArgs options

### DIFF
--- a/cli/src/cmd/flatten.rs
+++ b/cli/src/cmd/flatten.rs
@@ -7,26 +7,20 @@ use clap::{Parser, ValueHint};
 use foundry_config::Config;
 
 #[derive(Debug, Clone, Parser)]
-pub struct FlattenArgs {
-    #[clap(help = "the path to the contract to flatten", value_hint = ValueHint::FilePath)]
-    pub target_path: PathBuf,
-
-    #[clap(long, short, help = "output path for the flattened contract", value_hint = ValueHint::FilePath)]
-    pub output: Option<PathBuf>,
-
+pub struct CoreFlattenArgs {
     #[clap(
-        help = "the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
-        long,
-        value_hint = ValueHint::DirPath
+    help = "the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
+    long,
+    value_hint = ValueHint::DirPath
     )]
     pub root: Option<PathBuf>,
 
     #[clap(
-        env = "DAPP_SRC",
-        help = "the directory relative to the root under which the smart contracts are",
-        long,
-        short,
-        value_hint = ValueHint::DirPath
+    env = "DAPP_SRC",
+    help = "the directory relative to the root under which the smart contracts are",
+    long,
+    short,
+    value_hint = ValueHint::DirPath
     )]
     pub contracts: Option<PathBuf>,
 
@@ -36,9 +30,9 @@ pub struct FlattenArgs {
     pub remappings_env: Option<String>,
 
     #[clap(
-        help = "the paths where your libraries are installed",
-        long,
-        value_hint = ValueHint::DirPath
+    help = "the paths where your libraries are installed",
+    long,
+    value_hint = ValueHint::DirPath
     )]
     pub lib_paths: Vec<PathBuf>,
 
@@ -51,26 +45,30 @@ pub struct FlattenArgs {
     pub hardhat: bool,
 }
 
+#[derive(Debug, Clone, Parser)]
+pub struct FlattenArgs {
+    #[clap(help = "the path to the contract to flatten", value_hint = ValueHint::FilePath)]
+    pub target_path: PathBuf,
+
+    #[clap(long, short, help = "output path for the flattened contract", value_hint = ValueHint::FilePath)]
+    pub output: Option<PathBuf>,
+
+    #[clap(flatten)]
+    core_flatten_args: CoreFlattenArgs,
+}
+
 impl Cmd for FlattenArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let FlattenArgs {
-            target_path,
-            output,
-            root,
-            contracts,
-            remappings,
-            remappings_env,
-            lib_paths,
-            hardhat,
-        } = self;
+        let FlattenArgs { target_path, output, core_flatten_args } = self;
+
         // flatten is a subset of `BuildArgs` so we can reuse that to get the config
         let build_args = BuildArgs {
-            root,
-            contracts,
-            remappings,
-            remappings_env,
-            lib_paths,
+            root: core_flatten_args.root,
+            contracts: core_flatten_args.contracts,
+            remappings: core_flatten_args.remappings,
+            remappings_env: core_flatten_args.remappings_env,
+            lib_paths: core_flatten_args.lib_paths,
             out_path: None,
             compiler: Default::default(),
             names: false,
@@ -79,7 +77,7 @@ impl Cmd for FlattenArgs {
             no_auto_detect: false,
             offline: false,
             force: false,
-            hardhat,
+            hardhat: core_flatten_args.hardhat,
             libraries: vec![],
         };
 


### PR DESCRIPTION
## Motivation

Unless you read the foundry book, It's easy to accidentally specify `--optimize --optimize-runs=200` in `forge verify-contract` because that's what you use in `forge create`. The actual option is `--num-of-optimizations`. 

## Solution

AFAIK, most of the options from `BuildArgs` displayed in `forge verify-contract` are not actually used because we're only flattening the contract code. We don't need to display them.

`forge flatten` establishes a precedent of using a subset of `BuildArgs` to flatten the project. We follow that pattern by using the subset of `FlattenArgs`, which is used to establish `BuildArgs`, in `forge verify-contract` 

I have manually tested the `forge create` -> `forge verify-contract` -> `forge verify-check` flow multiple times in this branch and confirmed it works.

---

Current options displayed for `forge verify-contract`:

```
forge-verify-contract
Verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set.

USAGE:
    forge verify-contract [OPTIONS] --compiler-version <COMPILER_VERSION> <ADDRESS> <CONTRACT> <ETHERSCAN_KEY>

ARGS:
    <ADDRESS>          the target contract address
    <CONTRACT>         the contract source info `<path>:<contractname>`
    <ETHERSCAN_KEY>    your etherscan api key [env: ETHERSCAN_API_KEY=]

OPTIONS:
    -c, --contracts <CONTRACTS>                          the directory relative to the root under which the smart contracts are [env: DAPP_SRC=]
        --chain-id <CHAIN_ID>                            the chain id of the network you are verifying for [default: 1]
        --compiler-version <COMPILER_VERSION>            the compiler version used during build
        --constructor-args <CONSTRUCTOR_ARGS>            the encoded constructor arguments
        --evm-version <EVM_VERSION>                      Choose the evm version
        --extra-output <EXTRA_OUTPUT>                    Extra output types to include in the contract's json artifact [evm.assembly, ewasm, ir, irOptimized, metadata] eg: `--extra-output
                                                         evm.assembly`
        --extra-output-files <EXTRA_OUTPUT_FILES>        Extra output types to write to a separate file [metadata, ir, irOptimized, ewasm] eg: `--extra-output-files metadata`
        --force                                          force recompilation of the project, deletes the cache and artifacts folders
    -h, --help                                           Print help information
        --hardhat                                        uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-paths node_modules`
        --ignored-error-codes <IGNORED_ERROR_CODES>      ignore warnings with specific error codes
        --lib-paths <LIB_PATHS>                          the paths where your libraries are installed
        --libraries <LIBRARIES>                          add linked libraries [env: DAPP_LIBRARIES=]
        --no-auto-detect                                 if set to true, skips auto-detecting solc and uses what is in the user's $PATH
        --num-of-optimizations <NUM_OF_OPTIMIZATIONS>    the number of optimization runs used
    -o, --out <OUT_PATH>                                 path to where the contract artifacts are stored
        --offline                                        if set to true, runs without accessing the network (missing solc versions will not be installed)
        --optimize                                       Activate the solidity optimizer
        --optimize-runs <OPTIMIZE_RUNS>                  Optimizer parameter runs
    -r, --remappings <REMAPPINGS>                        the remappings
        --remappings-env <REMAPPINGS_ENV>                the env var that holds remappings
        --root <ROOT>                                    the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is
                                                         not part of a Git repository
```

After: 

```
forge-verify-contract
Verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set.

USAGE:
    forge verify-contract [OPTIONS] --compiler-version <COMPILER_VERSION> <ADDRESS> <CONTRACT> <ETHERSCAN_KEY>

ARGS:
    <ADDRESS>          the target contract address
    <CONTRACT>         the contract source info `<path>:<contractname>`
    <ETHERSCAN_KEY>    your etherscan api key [env: ETHERSCAN_API_KEY=]

OPTIONS:
    -c, --contracts <CONTRACTS>                          the directory relative to the root under which the smart contracts are [env: DAPP_SRC=]
        --chain-id <CHAIN_ID>                            the chain id of the network you are verifying for [default: 1]
        --compiler-version <COMPILER_VERSION>            the compiler version used during build
        --constructor-args <CONSTRUCTOR_ARGS>            the encoded constructor arguments
    -h, --help                                           Print help information
        --hardhat                                        uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-paths node_modules`
        --lib-paths <LIB_PATHS>                          the paths where your libraries are installed
        --num-of-optimizations <NUM_OF_OPTIMIZATIONS>    the number of optimization runs used
    -r, --remappings <REMAPPINGS>                        the remappings
        --remappings-env <REMAPPINGS_ENV>                [env: DAPP_REMAPPINGS=]
        --root <ROOT>                                    the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is
                                                         not part of a Git repository
```

