### PR TITLE
fix: add missing watch arg to verify BuildArgs

### DIFF
--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -78,6 +78,7 @@ pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
         force: false,
         hardhat,
         libraries: vec![],
+        watch: Default::default(),
     };
 
     let project = build_args.project()?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
`master` branch build was failing, likely due to changes in [cc13c40](https://github.com/gakonst/foundry/commit/cc13c4095ff38bd6adb1f5d853758768f7f6a2de).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added the missing BuildArg to the `verify` options.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
