### PR TITLE
docs(forge readme, forge cli) Add more explicit notes around logging

### DIFF
--- a/cli/src/opts/evm.rs
+++ b/cli/src/opts/evm.rs
@@ -71,6 +71,7 @@ pub struct EvmArgs {
 
     #[clap(
         help = r#"Verbosity mode of EVM output as number of occurences of the `v` flag (-v, -vv, -vvv, etc.)
+    2: print test logs for all tests
     3: print test trace for failing tests
     4: always print test trace, print setup for failing tests
     5: always print test trace and setup

--- a/forge/README.md
+++ b/forge/README.md
@@ -305,6 +305,16 @@ console.log(someValue);
 
 ```
 
+Note: to make logs visible in `stdout`, you must use at least level 2 verbosity.
+```bash
+$> forge test -vv
+[PASS] test1() (gas: 7683)
+...
+Logs:
+  <your log string or event>
+  ...
+```
+
 ## Remappings
 If you are working in a repo with NPM-style imports, like
 ```


### PR DESCRIPTION
## Motivation
The documentation around test logging is a bit sparse for newcomers to both solidity development and forge. In a basic `forge test` call, neither log events nor console logs are visible. The documentation is not clear that 2nd level verbosity is required to view the logs in stdout.

## Solution
Add some simple documentation in the `Console.log` section of the `forge` README.
Update the help message text for the `--verbosity` flag in forge cli. 
