### PR TITLE
feat(forge/create): opts for specifying gas price and priority fee

### DIFF
--- a/cli/src/cmd/create.rs
+++ b/cli/src/cmd/create.rs
@@ -59,6 +59,9 @@ pub struct CreateArgs {
 
     #[clap(long = "priority-fee", help = "gas priority fee for EIP1559 txs", env = "ETH_GAS_PRIORITY_FEE", parse(try_from_str = parse_u256))]
     priority_fee: Option<U256>,
+
+    #[clap(long = "value", help = "value to send with the contract creation tx", env = "ETH_VALUE", parse(try_from_str = parse_u256))]
+    value: Option<U256>,
 }
 
 impl Cmd for CreateArgs {
@@ -163,6 +166,11 @@ impl CreateArgs {
                 ),
                 _ => deployer.tx,
             };
+        }
+
+        // set tx value if specified
+        if let Some(value) = self.value {
+            deployer.tx.set_value(value);
         }
 
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently there is no way to specify gas prices when deploying contract with `forge create` nor does `cast send` supports `--create`. Adding `--gas-price` and `--priority-fee` option to `forge create` which users can use to specify the gas prices. Can be relevant when deploying on mainnet and want control over the cost.

Closes https://github.com/gakonst/foundry/issues/836

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adding the options and setting the gas price and priority fee before sending the deploy tx.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
