### PR TITLE
install: respect unix file-hierarchy

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -3,14 +3,14 @@ set -e
 
 echo Installing foundryup...
 
-FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.foundry"}
+FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.local"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 
 FOUNDRYUP='#!/usr/bin/env bash
 set -e
 
-FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.foundry"}
+FOUNDRY_DIR=${FOUNDRY_DIR-"$HOME/.local"}
 FOUNDRY_BIN_DIR="$FOUNDRY_DIR/bin"
 FOUNDRY_MAN_DIR="$FOUNDRY_DIR/share/man/man1"
 


### PR DESCRIPTION
## Motivation
Instead of clobbering a users home directory with top-level directories respect unix file hierarchy
by installing user binaries in the ~/.local/bin directory. This has the benefit of not appending yet another directory to the system
PATH environment variable.

For more details see:
https://www.linux.org/docs/man7/file-hierarchy.html

## Solution
Install foundry binaries in the standard `~/.local/bin`
directory on unix systems.
Especially on Linux man pages are automatically read from
`~/.local/share/man/man1` directory without manually including that
path in the `MANPATH` environment variable.
