### PR TITLE
Ab/compute address

### DIFF
--- a/cast/src/lib.rs
+++ b/cast/src/lib.rs
@@ -8,7 +8,7 @@ use ethers_core::{
         Abi, AbiParser, Token,
     },
     types::{transaction::eip2718::TypedTransaction, Chain, *},
-    utils::{self, keccak256, parse_units},
+    utils::{self, keccak256, parse_units, get_contract_address},
 };
 
 use ethers_etherscan::Client;
@@ -497,6 +497,36 @@ where
         block: Option<BlockId>,
     ) -> Result<U256> {
         Ok(self.provider.get_transaction_count(who, block).await?)
+    }
+
+    /// ```no_run
+    /// use cast::Cast;
+    /// use ethers_providers::{Provider, Http};
+    /// use ethers_core::types::Address;
+    /// use std::{str::FromStr, convert::TryFrom};
+    ///
+    /// # async fn foo() -> eyre::Result<()> {
+    /// let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// let cast = Cast::new(provider);
+    /// let addr = Address::from_str("0x7eD52863829AB99354F3a0503A622e82AcD5F7d3")?;
+    /// let nonce = cast.nonce(addr, None).await? + 5;
+    /// let computed_address = cast.compute_address(addr, Some(nonce)).await?;
+    /// println!("Computed address for address {} with nonce {}: {}", addr, nonce, computed_address);
+    /// let computed_address_no_nonce = cast.compute_address(addr, None).await?;
+    /// println!("Computed address for address {} with nonce {}: {}", addr, nonce, computed_address_no_nonce);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn compute_address<T: Into<Address> + Copy + Send + Sync>(
+        &self,
+        address: T,
+        nonce: Option<U256>
+    ) -> Result<Address> {
+        let unpacked = if let Some(n) = nonce { n } else {
+            self.provider.get_transaction_count(address.into(), None).await?
+        };
+
+        Ok(get_contract_address(address, unpacked))
     }
 
     /// ```no_run

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -189,6 +189,11 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", provider.client_version().await?);
         }
+        Subcommands::ComputeAddress { rpc_url, address, nonce } => {
+            let provider = Provider::try_from(rpc_url)?;
+            let addr =  Cast::new(&provider).compute_address(address, nonce)?;
+            println!("Computed Address: {}", addr);
+        }
         Subcommands::Code { block, who, rpc_url } => {
             let provider = Provider::try_from(rpc_url)?;
             println!("{}", Cast::new(provider).code(who, block).await?);

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -190,8 +190,9 @@ async fn main() -> eyre::Result<()> {
             println!("{}", provider.client_version().await?);
         }
         Subcommands::ComputeAddress { rpc_url, address, nonce } => {
+            let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
             let provider = Provider::try_from(rpc_url)?;
-            let addr =  Cast::new(&provider).compute_address(address, nonce)?;
+            let addr =  Cast::new(&provider).compute_address(pubkey, nonce).await?;
             println!("Computed Address: {}", addr);
         }
         Subcommands::Code { block, who, rpc_url } => {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -163,6 +163,16 @@ pub enum Subcommands {
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },
+    #[clap(name = "compute-address")]
+    #[clap(about = "Returns the computed address from a given address and nonce pair")]
+    ComputeAddress {
+        #[clap(long, env = "ETH_RPC_URL")]
+        rpc_url: String,
+        #[clap(help = "the address to create from", parse(try_from_str = parse_name_or_address))]
+        address: NameOrAddress,
+        #[clap(long, help = "address nonce", parse(try_from_str = parse_u256))]
+        nonce: Option<U256>,
+    },
     #[clap(name = "namehash")]
     #[clap(about = "Returns ENS namehash of provided name")]
     Namehash { name: String },

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -168,8 +168,8 @@ pub enum Subcommands {
     ComputeAddress {
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
-        #[clap(help = "the address to create from", parse(try_from_str = parse_name_or_address))]
-        address: NameOrAddress,
+        #[clap(help = "the address to create from")]
+        address: String,
         #[clap(long, help = "address nonce", parse(try_from_str = parse_u256))]
         nonce: Option<U256>,
     },

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -231,7 +231,8 @@ impl Wallet {
 
     fn private_key(&self) -> Result<Option<LocalWallet>> {
         Ok(if let Some(ref private_key) = self.private_key {
-            Some(LocalWallet::from_str(private_key)?)
+            let privk = &private_key.strip_prefix("0x").unwrap_or(private_key);
+            Some(LocalWallet::from_str(privk)?)
         } else {
             None
         })


### PR DESCRIPTION
Closes #861 

## Motivation & Solution

Adds a `cast` subcommand that computes a new contract address given an input of an address and an optional nonce.
