### PR TITLE
fix(cast): compute-address ouput not debugged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5016,9 +5016,9 @@ dependencies = [
 
 [[package]]
 name = "watchexec"
-version = "2.0.0-pre.10"
+version = "2.0.0-pre.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c84127066dd06c8fb74ce978818ee2cd0040259bf35d28babdba1b24f2f69d"
+checksum = "3115ed7db83103ab13d6ada8892372bf596eca52cf2ae06571b906fd7dcba4c6"
 dependencies = [
  "async-recursion",
  "async-stream",

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -193,7 +193,7 @@ async fn main() -> eyre::Result<()> {
             let pubkey = Address::from_str(&address).expect("invalid pubkey provided");
             let provider = Provider::try_from(rpc_url)?;
             let addr = Cast::new(&provider).compute_address(pubkey, nonce).await?;
-            println!("Computed Address: {}", addr);
+            println!("Computed Address: {:?}", addr);
         }
         Subcommands::Code { block, who, rpc_url } => {
             let provider = Provider::try_from(rpc_url)?;


### PR DESCRIPTION
This PR addresses an issue with the `cast compute-address` subcommand where the computed address is truncated.
 
## Motivation & Solution

Since the computed address from a `cast compute-address` call is printed to console, we need to use debugging format to print the full H160 rather than a truncated `0xXXX...XXX`.

Solution: change the output template string from `{}` to `{:?}`.
