### PR TITLE
feat(forge): Add `cache-path` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5016,9 +5016,9 @@ dependencies = [
 
 [[package]]
 name = "watchexec"
-version = "2.0.0-pre.10"
+version = "2.0.0-pre.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c84127066dd06c8fb74ce978818ee2cd0040259bf35d28babdba1b24f2f69d"
+checksum = "3115ed7db83103ab13d6ada8892372bf596eca52cf2ae06571b906fd7dcba4c6"
 dependencies = [
  "async-recursion",
  "async-stream",

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -95,6 +95,13 @@ pub struct BuildArgs {
     pub remappings_env: Option<String>,
 
     #[clap(
+        help = "the path where cached compiled contracts are stored",
+        long = "cache-path",
+        value_hint = ValueHint::DirPath
+    )]
+    pub cache_path: Option<PathBuf>,
+
+    #[clap(
         help = "the paths where your libraries are installed",
         long,
         value_hint = ValueHint::DirPath

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -99,6 +99,7 @@ pub struct BuildArgs {
         long = "cache-path",
         value_hint = ValueHint::DirPath
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_path: Option<PathBuf>,
 
     #[clap(

--- a/cli/src/cmd/flatten.rs
+++ b/cli/src/cmd/flatten.rs
@@ -30,6 +30,13 @@ pub struct CoreFlattenArgs {
     pub remappings_env: Option<String>,
 
     #[clap(
+        help = "the path where cached compiled contracts are stored",
+        long = "cache-path",
+        value_hint = ValueHint::DirPath
+    )]
+    pub cache_path: Option<PathBuf>,
+
+    #[clap(
     help = "the paths where your libraries are installed",
     long,
     value_hint = ValueHint::DirPath
@@ -68,6 +75,7 @@ impl Cmd for FlattenArgs {
             contracts: core_flatten_args.contracts,
             remappings: core_flatten_args.remappings,
             remappings_env: core_flatten_args.remappings_env,
+            cache_path: core_flatten_args.cache_path,
             lib_paths: core_flatten_args.lib_paths,
             out_path: None,
             compiler: Default::default(),

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -59,7 +59,7 @@ pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
         eyre::bail!("Contract info must be provided in the format <path>:<name>")
     }
 
-    let CoreFlattenArgs { root, contracts, remappings, remappings_env, lib_paths, hardhat } =
+    let CoreFlattenArgs { root, contracts, remappings, remappings_env, cache_path, lib_paths, hardhat } =
         args.opts.clone();
 
     let build_args = BuildArgs {
@@ -67,6 +67,7 @@ pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
         contracts,
         remappings,
         remappings_env,
+        cache_path,
         lib_paths,
         out_path: None,
         compiler: Default::default(),

--- a/cli/src/cmd/verify.rs
+++ b/cli/src/cmd/verify.rs
@@ -59,8 +59,15 @@ pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
         eyre::bail!("Contract info must be provided in the format <path>:<name>")
     }
 
-    let CoreFlattenArgs { root, contracts, remappings, remappings_env, cache_path, lib_paths, hardhat } =
-        args.opts.clone();
+    let CoreFlattenArgs {
+        root,
+        contracts,
+        remappings,
+        remappings_env,
+        cache_path,
+        lib_paths,
+        hardhat,
+    } = args.opts.clone();
 
     let build_args = BuildArgs {
         root,

--- a/config/README.md
+++ b/config/README.md
@@ -68,6 +68,7 @@ libs = ['lib']
 remappings = []
 libraries = []
 cache = true
+cache_path 'cache'
 force = false
 evm_version = 'london'
 gas_reports = ['*']

--- a/config/README.md
+++ b/config/README.md
@@ -68,7 +68,7 @@ libs = ['lib']
 remappings = []
 libraries = []
 cache = true
-cache_path 'cache'
+cache_path = 'cache'
 force = false
 evm_version = 'london'
 gas_reports = ['*']

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -18,10 +18,10 @@ use ethers_core::types::{Address, U256};
 pub use ethers_solc::artifacts::OptimizerDetails;
 use ethers_solc::{
     artifacts::{output_selection::ContractOutputSelection, Optimizer, Settings},
+    cache::SOLIDITY_FILES_CACHE_FILENAME,
     error::SolcError,
     remappings::{RelativeRemapping, Remapping},
     ConfigurableArtifacts, EvmVersion, Project, ProjectPathsConfig, Solc, SolcConfig,
-    cache::SOLIDITY_FILES_CACHE_FILENAME,
 };
 use figment::{providers::Data, value::Value};
 use inflector::Inflector;
@@ -332,7 +332,7 @@ impl Config {
 
         self.remappings =
             self.remappings.into_iter().map(|r| RelativeRemapping::new(r.into(), &root)).collect();
-        
+
         self.cache_path = p(&root, &self.cache_path);
 
         self

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -21,6 +21,7 @@ use ethers_solc::{
     error::SolcError,
     remappings::{RelativeRemapping, Remapping},
     ConfigurableArtifacts, EvmVersion, Project, ProjectPathsConfig, Solc, SolcConfig,
+    cache::SOLIDITY_FILES_CACHE_FILENAME,
 };
 use figment::{providers::Data, value::Value};
 use inflector::Inflector;
@@ -443,7 +444,7 @@ impl Config {
     /// ```
     pub fn project_paths(&self) -> ProjectPathsConfig {
         ProjectPathsConfig::builder()
-            .cache(&self.cache_path)
+            .cache(&self.cache_path.join(SOLIDITY_FILES_CACHE_FILENAME))
             .sources(&self.src)
             .artifacts(&self.out)
             .libs(self.libs.clone())

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -87,6 +87,8 @@ pub struct Config {
     pub libraries: Vec<String>,
     /// whether to enable cache
     pub cache: bool,
+    /// where the cache is stored if enabled
+    pub cache_path: PathBuf,
     /// whether to force a `project.clean()`
     pub force: bool,
     /// evm version to use
@@ -439,6 +441,7 @@ impl Config {
     /// ```
     pub fn project_paths(&self) -> ProjectPathsConfig {
         ProjectPathsConfig::builder()
+            .cache(&self.cache_path)
             .sources(&self.src)
             .artifacts(&self.out)
             .libs(self.libs.clone())
@@ -793,6 +796,7 @@ impl Default for Config {
             out: "out".into(),
             libs: vec!["lib".into()],
             cache: true,
+            cache_path: "cache".into(),
             force: false,
             evm_version: Default::default(),
             gas_reports: vec!["*".to_string()],

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -331,6 +331,8 @@ impl Config {
 
         self.remappings =
             self.remappings.into_iter().map(|r| RelativeRemapping::new(r.into(), &root)).collect();
+        
+        self.cache_path = p(&root, &self.cache_path);
 
         self
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
As mentioned in #750 , a user may want to store the cached output from compiling contracts in a different directory.  
`ethers-solc` has an option for this already, so the change is fairly straightforward.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
I've added an additional option:`cache_path` to the `BuildArgs` so users can specify the path of the cache.  
I also updated the default config and the docs to reflect this change.
I did not add any new tests. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
