### PR TITLE
feat(forge): forge inspect subcommand

### DIFF
--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -1,15 +1,127 @@
-use std::path::PathBuf;
+use std::{
+  path::PathBuf,
+  str::FromStr,
+};
 
+use ethers::solc::remappings::Remapping;
+
+use crate::cmd::{build::BuildArgs, Cmd};
 use clap::{Parser, ValueHint};
+use foundry_config::Config;
+
+#[derive(Debug, Clone, Parser)]
+pub struct CoreInspectArgs {
+    #[clap(
+    help = "the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
+    long,
+    value_hint = ValueHint::DirPath
+    )]
+    pub root: Option<PathBuf>,
+
+    #[clap(
+    env = "DAPP_SRC",
+    help = "the directory relative to the root under which the smart contracts are",
+    long,
+    short,
+    value_hint = ValueHint::DirPath
+    )]
+    pub contracts: Option<PathBuf>,
+
+    #[clap(help = "the remappings", long, short)]
+    pub remappings: Vec<Remapping>,
+    #[clap(long = "remappings-env", env = "DAPP_REMAPPINGS")]
+    pub remappings_env: Option<String>,
+
+    #[clap(
+    help = "the paths where your libraries are installed",
+    long,
+    value_hint = ValueHint::DirPath
+    )]
+    pub lib_paths: Vec<PathBuf>,
+
+    #[clap(
+        help = "uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-paths node_modules`",
+        long,
+        conflicts_with = "contracts",
+        alias = "hh"
+    )]
+    pub hardhat: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum Mode {
+    IR,
+    Bytecode,
+}
+
+impl FromStr for Mode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ir" | "IR" | "ir-mode" | "-ir" => Ok(Mode::IR),
+            "bytecode" | "BYTECODE" | "-bytecode" => Ok(Mode::Bytecode),
+            _ => Err(format!("Unrecognized mode `{}`, must be one of [IR, Bytecode]", s)),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
-    #[clap(help = "the path to the contract to flatten", value_hint = ValueHint::FilePath)]
+    #[clap(help = "the path to the contract to inspect", value_hint = ValueHint::FilePath)]
     pub target_path: PathBuf,
 
-    #[clap(long, short, help = "output path for the flattened contract", value_hint = ValueHint::FilePath)]
-    pub output: Option<PathBuf>,
+    #[clap(long, short, help = "the mode to build the ", value_hint = ValueHint::FilePath)]
+    pub mode: Option<Mode>,
 
     #[clap(flatten)]
-    core_flatten_args: CoreFlattenArgs,
+    core_inspect_args: CoreInspectArgs,
+}
+
+impl Cmd for InspectArgs {
+    type Output = ();
+    fn run(self) -> eyre::Result<Self::Output> {
+        let InspectArgs { target_path, mode, core_inspect_args } = self;
+
+        // Reuse `BuildArgs` to get the config (following flatten convention)
+        let build_args = BuildArgs {
+            root: core_inspect_args.root,
+            contracts: core_inspect_args.contracts,
+            remappings: core_inspect_args.remappings,
+            remappings_env: core_inspect_args.remappings_env,
+            lib_paths: core_inspect_args.lib_paths,
+            out_path: None,
+            compiler: Default::default(),
+            names: false,
+            sizes: false,
+            ignored_error_codes: vec![],
+            no_auto_detect: false,
+            offline: false,
+            force: false,
+            hardhat: core_inspect_args.hardhat,
+            libraries: vec![],
+            watch: Default::default(),
+        };
+
+        let config = Config::from(&build_args);
+
+        // let paths = config.project_paths();
+        // let target_path = dunce::canonicalize(target_path)?;
+        // let flattened = paths
+        //     .flatten(&target_path)
+        //     .map_err(|err| eyre::Error::msg(format!("failed to flatten the file: {}", err)))?;
+
+        // TODO: fetch or generate the IR or bytecode
+
+        // IR by default
+        if let Some(Mode::Bytecode) = mode {
+          // TODO: output bytecode
+          println!("<bytecode>");
+        } else {
+          // TODO: output IR
+          println!("<IR>");
+        }
+
+        Ok(())
+    }
 }

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -159,7 +159,7 @@ impl Cmd for InspectArgs {
         let outcome = super::suppress_compile(&project)?;
 
         // Find the artifact
-        let found_artifact = outcome.find(contract.clone());
+        let found_artifact = outcome.find(&contract);
 
         // Unwrap the inner artifact
         let artifact = found_artifact.ok_or_else(|| {

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -191,10 +191,7 @@ impl Cmd for InspectArgs {
                 println!("{}", tval.get("object").unwrap_or(&tval).clone().as_str().unwrap());
             }
             ContractArtifactFields::Assembly | ContractArtifactFields::AssemblyOptimized => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.assembly).unwrap()).unwrap()
-                );
+                println!("{}", to_value(&artifact.assembly).unwrap().as_str().unwrap());
             }
             ContractArtifactFields::MethodIdentifiers => {
                 println!(
@@ -236,17 +233,10 @@ impl Cmd for InspectArgs {
                 );
             }
             ContractArtifactFields::Ir => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.ir).unwrap()).unwrap()
-                );
+                println!("{}", to_value(&artifact.ir).unwrap().as_str().unwrap());
             }
             ContractArtifactFields::IrOptimized => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.ir_optimized).unwrap())
-                        .unwrap()
-                );
+                println!("{}", to_value(&artifact.ir_optimized).unwrap().as_str().unwrap());
             }
             ContractArtifactFields::Ewasm => {
                 println!(

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -64,7 +64,7 @@ impl FromStr for ContractArtifactFields {
             "deployedbytecode" => Ok(ContractArtifactFields::DeployedBytecode),
             "assembly" | "asm" => Ok(ContractArtifactFields::Assembly),
             "asmOptimized" | "assemblyOptimized" | "assemblyoptimized" | "assembly_optimized" |
-            "amso" => Ok(ContractArtifactFields::AssemblyOptimized),
+            "asmo" => Ok(ContractArtifactFields::AssemblyOptimized),
             "methodIdentifiers" | "method_identifiers" | "method-identifiers" => {
                 Ok(ContractArtifactFields::MethodIdentifiers)
             }
@@ -239,10 +239,7 @@ impl Cmd for InspectArgs {
                 println!("{}", to_value(&artifact.ir_optimized).unwrap().as_str().unwrap());
             }
             ContractArtifactFields::Ewasm => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.ewasm).unwrap()).unwrap()
-                );
+                println!("{}", to_value(&artifact.ewasm).unwrap().as_str().unwrap());
             }
         };
 

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
+
+#[derive(Debug, Clone, Parser)]
+pub struct InspectArgs {
+    #[clap(help = "the path to the contract to flatten", value_hint = ValueHint::FilePath)]
+    pub target_path: PathBuf,
+
+    #[clap(long, short, help = "output path for the flattened contract", value_hint = ValueHint::FilePath)]
+    pub output: Option<PathBuf>,
+
+    #[clap(flatten)]
+    core_flatten_args: CoreFlattenArgs,
+}

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -2,6 +2,8 @@ use std::{fmt, str::FromStr};
 
 use crate::cmd::{build, Cmd};
 use clap::Parser;
+use serde_json::{Value, to_value};
+use tracing_subscriber::fmt::format::Json;
 
 /// Contract level output selection
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -106,25 +108,24 @@ impl Cmd for InspectArgs {
             .unwrap();
 
         // Match on ContractOutputSelection
-        match mode {
-            ContractArtifactFields::Abi => println!("{:?}", artifact.abi),
-            ContractArtifactFields::Bytecode => println!("{:?}", artifact.bytecode),
-            ContractArtifactFields::DeployedBytecode => {
-                println!("{:?}", artifact.deployed_bytecode)
-            }
-            ContractArtifactFields::Assembly => println!("{:?}", artifact.assembly),
-            ContractArtifactFields::MethodIdentifiers => {
-                println!("{:?}", artifact.method_identifiers)
-            }
-            ContractArtifactFields::GasEstimates => println!("{:?}", artifact.gas_estimates),
-            ContractArtifactFields::Metadata => println!("{:?}", artifact.metadata),
-            ContractArtifactFields::StorageLayout => println!("{:?}", artifact.storage_layout),
-            ContractArtifactFields::UserDoc => println!("{:?}", artifact.userdoc),
-            ContractArtifactFields::DevDoc => println!("{:?}", artifact.devdoc),
-            ContractArtifactFields::Ir => println!("{:?}", artifact.ir),
-            ContractArtifactFields::IrOptimized => println!("{:?}", artifact.ir_optimized),
-            ContractArtifactFields::Ewasm => println!("{:?}", artifact.ewasm),
-        }
+        let output: Value = match mode {
+            ContractArtifactFields::Abi => to_value(&artifact.abi).unwrap(),
+            ContractArtifactFields::Bytecode => to_value(&artifact.bytecode).unwrap(),
+            ContractArtifactFields::DeployedBytecode => to_value(&artifact.deployed_bytecode).unwrap(),
+            ContractArtifactFields::Assembly => to_value(&artifact.assembly).unwrap(),
+            ContractArtifactFields::MethodIdentifiers => to_value(&artifact.method_identifiers).unwrap(),
+            ContractArtifactFields::GasEstimates => to_value(&artifact.gas_estimates).unwrap(),
+            ContractArtifactFields::Metadata => to_value(&artifact.metadata).unwrap(),
+            ContractArtifactFields::StorageLayout => to_value(&artifact.storage_layout).unwrap(),
+            ContractArtifactFields::UserDoc => to_value(&artifact.userdoc).unwrap(),
+            ContractArtifactFields::DevDoc => to_value(&artifact.devdoc).unwrap(),
+            ContractArtifactFields::Ir => to_value(&artifact.ir).unwrap(),
+            ContractArtifactFields::IrOptimized => to_value(&artifact.ir_optimized).unwrap(),
+            ContractArtifactFields::Ewasm => to_value(&artifact.ewasm).unwrap(),
+        };
+
+        // Pretty print the output with serde_json
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
 
         Ok(())
     }

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -75,21 +75,21 @@ impl FromStr for ContractArtifactFields {
 
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
-    /// All build arguments are supported
-    #[clap(flatten)]
-    build: build::BuildArgs,
-
     #[clap(help = "the contract to inspect")]
     pub contract: String,
 
-    #[clap(long, short, help = "the contract artifact field to inspect")]
+    #[clap(help = "the contract artifact field to inspect")]
     pub mode: ContractArtifactFields,
+
+    /// All build arguments are supported
+    #[clap(flatten)]
+    build: build::BuildArgs,
 }
 
 impl Cmd for InspectArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let InspectArgs { build, contract, mode } = self;
+        let InspectArgs { contract, mode, build  } = self;
 
         // Build the project
         let project = build.project()?;

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -65,7 +65,7 @@ impl FromStr for ContractArtifactFields {
             "assembly" | "asm" => Ok(ContractArtifactFields::Assembly),
             "asmOptimized" | "assemblyOptimized" | "assemblyoptimized" | "assembly_optimized" |
             "asmo" => Ok(ContractArtifactFields::AssemblyOptimized),
-            "methodIdentifiers" | "method_identifiers" | "method-identifiers" => {
+            "methodIdentifiers" | "method_identifiers" | "method-identifiers" | "mi" => {
                 Ok(ContractArtifactFields::MethodIdentifiers)
             }
             "gasEstimates" | "gas" | "gas_estimates" | "gas-estimates" | "gasestimates" => {

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -8,9 +8,7 @@ use crate::{
     opts::forge::CompilerArgs,
 };
 use clap::Parser;
-use ethers::prelude::artifacts::output_selection::{
-    ContractOutputSelection, EvmOutputSelection, EwasmOutputSelection,
-};
+use ethers::prelude::artifacts::output_selection::{ContractOutputSelection, EvmOutputSelection};
 use serde_json::{to_value, Value};
 
 /// Contract level output selection
@@ -23,13 +21,14 @@ pub enum ContractArtifactFields {
     AssemblyOptimized,
     MethodIdentifiers,
     GasEstimates,
-    Metadata,
     StorageLayout,
-    UserDoc,
     DevDoc,
     Ir,
     IrOptimized,
-    Ewasm,
+    // TODO: Add once these commands aren't broken at compiler-level
+    // Metadata,
+    // UserDoc,
+    // Ewasm,
 }
 
 impl fmt::Display for ContractArtifactFields {
@@ -42,13 +41,14 @@ impl fmt::Display for ContractArtifactFields {
             ContractArtifactFields::AssemblyOptimized => f.write_str("assemblyOptimized"),
             ContractArtifactFields::MethodIdentifiers => f.write_str("methodIdentifiers"),
             ContractArtifactFields::GasEstimates => f.write_str("gasEstimates"),
-            ContractArtifactFields::Metadata => f.write_str("metadata"),
             ContractArtifactFields::StorageLayout => f.write_str("storageLayout"),
-            ContractArtifactFields::UserDoc => f.write_str("userdoc"),
             ContractArtifactFields::DevDoc => f.write_str("devdoc"),
             ContractArtifactFields::Ir => f.write_str("ir"),
             ContractArtifactFields::IrOptimized => f.write_str("irOptimized"),
-            ContractArtifactFields::Ewasm => f.write_str("ewasm"),
+            // TODO: Add once these commands aren't broken at compiler-level
+            // ContractArtifactFields::Metadata => f.write_str("metadata"),
+            // ContractArtifactFields::UserDoc => f.write_str("userdoc"),
+            // ContractArtifactFields::Ewasm => f.write_str("ewasm"),
         }
     }
 }
@@ -71,17 +71,18 @@ impl FromStr for ContractArtifactFields {
             "gasEstimates" | "gas" | "gas_estimates" | "gas-estimates" | "gasestimates" => {
                 Ok(ContractArtifactFields::GasEstimates)
             }
-            "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
             "storageLayout" | "storage_layout" | "storage-layout" | "storagelayout" | "storage" => {
                 Ok(ContractArtifactFields::StorageLayout)
             }
-            "userdoc" => Ok(ContractArtifactFields::UserDoc),
             "devdoc" => Ok(ContractArtifactFields::DevDoc),
             "ir" => Ok(ContractArtifactFields::Ir),
             "ir-optimized" | "irOptimized" | "iroptimized" | "iro" => {
                 Ok(ContractArtifactFields::IrOptimized)
             }
-            "ewasm" => Ok(ContractArtifactFields::Ewasm),
+            // TODO: Add once these commands aren't broken at compiler-level
+            // "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
+            // "userdoc" => Ok(ContractArtifactFields::UserDoc),
+            // "ewasm" => Ok(ContractArtifactFields::Ewasm),
             _ => Ok(ContractArtifactFields::Bytecode),
         }
     }
@@ -121,19 +122,21 @@ impl Cmd for InspectArgs {
                 ContractArtifactFields::GasEstimates => {
                     cos.push(ContractOutputSelection::Evm(EvmOutputSelection::GasEstimates))
                 }
-                ContractArtifactFields::Metadata => cos.push(ContractOutputSelection::Metadata),
                 ContractArtifactFields::StorageLayout => {
                     cos.push(ContractOutputSelection::StorageLayout)
                 }
-                ContractArtifactFields::UserDoc => cos.push(ContractOutputSelection::UserDoc),
                 ContractArtifactFields::DevDoc => cos.push(ContractOutputSelection::DevDoc),
                 ContractArtifactFields::Ir => cos.push(ContractOutputSelection::Ir),
                 ContractArtifactFields::IrOptimized => {
                     cos.push(ContractOutputSelection::IrOptimized)
-                }
-                ContractArtifactFields::Ewasm => {
-                    cos.push(ContractOutputSelection::Ewasm(EwasmOutputSelection::All))
-                }
+                } /* TODO: Add once these commands aren't broken at compiler-level
+                   * ContractArtifactFields::Metadata =>
+                   * cos.push(ContractOutputSelection::Metadata),
+                   * ContractArtifactFields::UserDoc =>
+                   * cos.push(ContractOutputSelection::UserDoc),
+                   * ContractArtifactFields::Ewasm => {
+                   *     cos.push(ContractOutputSelection::Ewasm(EwasmOutputSelection::All))
+                   * } */
             }
         }
 
@@ -207,23 +210,11 @@ impl Cmd for InspectArgs {
                         .unwrap()
                 );
             }
-            ContractArtifactFields::Metadata => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.metadata).unwrap()).unwrap()
-                );
-            }
             ContractArtifactFields::StorageLayout => {
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&to_value(&artifact.storage_layout).unwrap())
                         .unwrap()
-                );
-            }
-            ContractArtifactFields::UserDoc => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.userdoc).unwrap()).unwrap()
                 );
             }
             ContractArtifactFields::DevDoc => {
@@ -237,10 +228,22 @@ impl Cmd for InspectArgs {
             }
             ContractArtifactFields::IrOptimized => {
                 println!("{}", to_value(&artifact.ir_optimized).unwrap().as_str().unwrap());
-            }
-            ContractArtifactFields::Ewasm => {
-                println!("{}", to_value(&artifact.ewasm).unwrap().as_str().unwrap());
-            }
+            } /* TODO: Add once these commands aren't broken at compiler-level
+               * ContractArtifactFields::Metadata => {
+               *     println!(
+               *         "{}",
+               *         serde_json::to_string_pretty(&to_value(&artifact.metadata).unwrap()).
+               * unwrap()     );
+               * }
+               * ContractArtifactFields::UserDoc => {
+               *     println!(
+               *         "{}",
+               *         serde_json::to_string_pretty(&to_value(&artifact.userdoc).unwrap()).
+               * unwrap()     );
+               * }
+               * ContractArtifactFields::Ewasm => {
+               *     println!("{}", to_value(&artifact.ewasm).unwrap().as_str().unwrap());
+               * } */
         };
 
         Ok(())

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -1,6 +1,77 @@
+use std::{fmt, str::FromStr};
+
 use crate::cmd::{build, Cmd};
-use clap::{Parser};
-use ethers::prelude::artifacts::output_selection::ContractOutputSelection;
+use clap::Parser;
+
+/// Contract level output selection
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ContractArtifactFields {
+    Abi,
+    Bytecode,
+    DeployedBytecode,
+    Assembly,
+    MethodIdentifiers,
+    GasEstimates,
+    Metadata,
+    StorageLayout,
+    UserDoc,
+    DevDoc,
+    Ir,
+    IrOptimized,
+    Ewasm,
+}
+
+impl fmt::Display for ContractArtifactFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ContractArtifactFields::Abi => f.write_str("abi"),
+            ContractArtifactFields::Bytecode => f.write_str("bytecode"),
+            ContractArtifactFields::DeployedBytecode => f.write_str("deployedBytecode"),
+            ContractArtifactFields::Assembly => f.write_str("assembly"),
+            ContractArtifactFields::MethodIdentifiers => f.write_str("methodIdentifiers"),
+            ContractArtifactFields::GasEstimates => f.write_str("gasEstimates"),
+            ContractArtifactFields::Metadata => f.write_str("metadata"),
+            ContractArtifactFields::StorageLayout => f.write_str("storageLayout"),
+            ContractArtifactFields::UserDoc => f.write_str("userdoc"),
+            ContractArtifactFields::DevDoc => f.write_str("devdoc"),
+            ContractArtifactFields::Ir => f.write_str("ir"),
+            ContractArtifactFields::IrOptimized => f.write_str("irOptimized"),
+            ContractArtifactFields::Ewasm => f.write_str("ewasm"),
+        }
+    }
+}
+
+impl FromStr for ContractArtifactFields {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "abi" => Ok(ContractArtifactFields::Abi),
+            "bytecode" => Ok(ContractArtifactFields::Bytecode),
+            "deployedBytecode" | "deployed_bytecode" | "deployed-bytecode" | "deployed" |
+            "deployedbytecode" => Ok(ContractArtifactFields::DeployedBytecode),
+            "assembly" | "asm" => Ok(ContractArtifactFields::Assembly),
+            "methodIdentifiers" | "method_identifiers" | "method-identifiers" => {
+                Ok(ContractArtifactFields::MethodIdentifiers)
+            }
+            "gasEstimates" | "gas_estimates" | "gas-estimates" | "gasestimates" => {
+                Ok(ContractArtifactFields::GasEstimates)
+            }
+            "metadata" => Ok(ContractArtifactFields::Metadata),
+            "storageLayout" | "storage_layout" | "storage-layout" | "storagelayout" => {
+                Ok(ContractArtifactFields::StorageLayout)
+            }
+            "userdoc" => Ok(ContractArtifactFields::UserDoc),
+            "devdoc" => Ok(ContractArtifactFields::DevDoc),
+            "ir" => Ok(ContractArtifactFields::Ir),
+            "ir-optimized" | "irOptimized" | "iroptimized" => {
+                Ok(ContractArtifactFields::IrOptimized)
+            }
+            "ewasm" => Ok(ContractArtifactFields::Ewasm),
+            _ => Ok(ContractArtifactFields::Bytecode),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
@@ -11,8 +82,8 @@ pub struct InspectArgs {
     #[clap(help = "the contract to inspect")]
     pub contract: String,
 
-    #[clap(long, short, help = "the contract output selection")]
-    pub mode: Option<ContractOutputSelection>,
+    #[clap(long, short, help = "the contract artifact field to inspect")]
+    pub mode: ContractArtifactFields,
 }
 
 impl Cmd for InspectArgs {
@@ -22,43 +93,37 @@ impl Cmd for InspectArgs {
 
         // Build the project
         let project = build.project()?;
-        let outcome =  super::compile(
-          &project,
-          build.names,
-          build.sizes
-        )?;
+        let outcome = super::compile(&project, build.names, build.sizes)?;
 
         // For the compiled artifacts, find the contract
         let artifacts = outcome.compiled_artifacts().find(contract.clone());
 
         // Unwrap the inner artifact
-        let artifact = match artifacts {
-          Some(a) => a,
-          None => {
-            eyre::eyre!(
-              "Could not find artifact `{}` in the compiled artifacts",
-              contract
-            );
-            return Ok(());
-          }
-        };
+        let artifact = artifacts
+            .ok_or_else(|| {
+                eyre::eyre!("Could not find artifact `{}` in the compiled artifacts", contract);
+            })
+            .unwrap();
 
         // Match on ContractOutputSelection
-        if let Some(m) = mode {
-          match m {
-            ContractOutputSelection::Abi => println!("{:?}", artifact.abi),
-            ContractOutputSelection::DevDoc => println!("{:?}", artifact.devdoc),
-            ContractOutputSelection::UserDoc => println!("{:?}", artifact.userdoc),
-            ContractOutputSelection::Metadata => println!("{:?}", artifact.metadata),
-            ContractOutputSelection::Ir => println!("{:?}", artifact.ir),
-            ContractOutputSelection::IrOptimized => println!("{:?}", artifact.ir_optimized),
-            ContractOutputSelection::StorageLayout => println!("{:?}", artifact.storage_layout),
-            ContractOutputSelection::Evm(e) => println!("{:?}", artifact.bytecode),
-            ContractOutputSelection::Ewasm(e) => println!("{:?}", artifact.ewasm),
-          }
-        } else {
-          // Otherwise, by default, print the bytecode
-          println!("{:?}", artifact.bytecode);
+        match mode {
+            ContractArtifactFields::Abi => println!("{:?}", artifact.abi),
+            ContractArtifactFields::Bytecode => println!("{:?}", artifact.bytecode),
+            ContractArtifactFields::DeployedBytecode => {
+                println!("{:?}", artifact.deployed_bytecode)
+            }
+            ContractArtifactFields::Assembly => println!("{:?}", artifact.assembly),
+            ContractArtifactFields::MethodIdentifiers => {
+                println!("{:?}", artifact.method_identifiers)
+            }
+            ContractArtifactFields::GasEstimates => println!("{:?}", artifact.gas_estimates),
+            ContractArtifactFields::Metadata => println!("{:?}", artifact.metadata),
+            ContractArtifactFields::StorageLayout => println!("{:?}", artifact.storage_layout),
+            ContractArtifactFields::UserDoc => println!("{:?}", artifact.userdoc),
+            ContractArtifactFields::DevDoc => println!("{:?}", artifact.devdoc),
+            ContractArtifactFields::Ir => println!("{:?}", artifact.ir),
+            ContractArtifactFields::IrOptimized => println!("{:?}", artifact.ir_optimized),
+            ContractArtifactFields::Ewasm => println!("{:?}", artifact.ewasm),
         }
 
         Ok(())

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -1,9 +1,17 @@
 use std::{fmt, str::FromStr};
 
-use crate::{cmd::{build::{self, BuildArgs}, Cmd}, opts::forge::CompilerArgs};
+use crate::{
+    cmd::{
+        build::{self, BuildArgs},
+        Cmd,
+    },
+    opts::forge::CompilerArgs,
+};
 use clap::Parser;
-use ethers::prelude::artifacts::output_selection::{ContractOutputSelection, EvmOutputSelection, EwasmOutputSelection};
-use serde_json::{Value, to_value};
+use ethers::prelude::artifacts::output_selection::{
+    ContractOutputSelection, EvmOutputSelection, EwasmOutputSelection,
+};
+use serde_json::{to_value, Value};
 
 /// Contract level output selection
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -91,47 +99,55 @@ pub struct InspectArgs {
 impl Cmd for InspectArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let InspectArgs { contract, mode, build  } = self;
+        let InspectArgs { contract, mode, build } = self;
 
         // Map mode to ContractOutputSelection
         let mut cos = if let Some(v) = build.compiler.extra_output { v } else { vec![] };
-        let selection: Vec<_> = cos.iter().map(|s| s.to_string()).collect();
-        if !selection.contains(&mode.to_string()) {
-          match mode {
-            ContractArtifactFields::Abi => cos.push(ContractOutputSelection::Abi),
-            ContractArtifactFields::Bytecode => { /* Auto Generated */ },
-            ContractArtifactFields::DeployedBytecode => { /* Auto Generated */ },
-            ContractArtifactFields::Assembly => cos.push(ContractOutputSelection::Evm(EvmOutputSelection::Assembly)),
-            ContractArtifactFields::MethodIdentifiers => cos.push(ContractOutputSelection::Evm(EvmOutputSelection::MethodIdentifiers)),
-            ContractArtifactFields::GasEstimates => cos.push(ContractOutputSelection::Evm(EvmOutputSelection::GasEstimates)),
-            ContractArtifactFields::Metadata => cos.push(ContractOutputSelection::Metadata),
-            ContractArtifactFields::StorageLayout => cos.push(ContractOutputSelection::StorageLayout),
-            ContractArtifactFields::UserDoc => cos.push(ContractOutputSelection::UserDoc),
-            ContractArtifactFields::DevDoc => cos.push(ContractOutputSelection::DevDoc),
-            ContractArtifactFields::Ir => cos.push(ContractOutputSelection::Ir),
-            ContractArtifactFields::IrOptimized => cos.push(ContractOutputSelection::IrOptimized),
-            ContractArtifactFields::Ewasm => cos.push(ContractOutputSelection::Ewasm(EwasmOutputSelection::All)),
-          }
+        if !cos.iter().any(|&i| i.to_string()==mode.to_string()) {
+            match mode {
+                ContractArtifactFields::Abi => cos.push(ContractOutputSelection::Abi),
+                ContractArtifactFields::Bytecode => { /* Auto Generated */ }
+                ContractArtifactFields::DeployedBytecode => { /* Auto Generated */ }
+                ContractArtifactFields::Assembly => {
+                    cos.push(ContractOutputSelection::Evm(EvmOutputSelection::Assembly))
+                }
+                ContractArtifactFields::MethodIdentifiers => {
+                    cos.push(ContractOutputSelection::Evm(EvmOutputSelection::MethodIdentifiers))
+                }
+                ContractArtifactFields::GasEstimates => {
+                    cos.push(ContractOutputSelection::Evm(EvmOutputSelection::GasEstimates))
+                }
+                ContractArtifactFields::Metadata => cos.push(ContractOutputSelection::Metadata),
+                ContractArtifactFields::StorageLayout => {
+                    cos.push(ContractOutputSelection::StorageLayout)
+                }
+                ContractArtifactFields::UserDoc => cos.push(ContractOutputSelection::UserDoc),
+                ContractArtifactFields::DevDoc => cos.push(ContractOutputSelection::DevDoc),
+                ContractArtifactFields::Ir => cos.push(ContractOutputSelection::Ir),
+                ContractArtifactFields::IrOptimized => {
+                    cos.push(ContractOutputSelection::IrOptimized)
+                }
+                ContractArtifactFields::Ewasm => {
+                    cos.push(ContractOutputSelection::Ewasm(EwasmOutputSelection::All))
+                }
+            }
         }
 
         // Build modified Args
         let modified_build_args = BuildArgs {
-          compiler: CompilerArgs {
-            extra_output: Some(cos),
-            ..build.compiler
-          },
-          ..build
+            compiler: CompilerArgs { extra_output: Some(cos), ..build.compiler },
+            ..build
         };
 
         // Build the project
         let project = modified_build_args.project()?;
-        let outcome = super::compile(&project, build.names, build.sizes)?;
+        let outcome = super::suppress_compile(&project)?;
 
         // If the project is unchanged, used cached artifacts
         let artifacts = if outcome.is_unchanged() {
-          outcome.cached_artifacts()
+            outcome.cached_artifacts()
         } else {
-          outcome.compiled_artifacts()
+            outcome.compiled_artifacts()
         };
 
         // For the compiled artifacts, find the contract
@@ -139,52 +155,89 @@ impl Cmd for InspectArgs {
 
         // Unwrap the inner artifact
         let artifact = found_artifact.unwrap_or_else(|| {
-          eyre::eyre!("Could not find artifact `{}` in the compiled artifacts", contract);
-          panic!("Could not find artifact `{}` in the compiled artifacts", contract)
+            eyre::eyre!("Could not find artifact `{}` in the compiled artifacts", contract);
+            panic!("Could not find artifact `{}` in the compiled artifacts", contract)
         });
 
         // Match on ContractArtifactFields and Pretty Print
         match mode {
             ContractArtifactFields::Abi => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.abi).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.abi).unwrap()).unwrap()
+                );
             }
             ContractArtifactFields::Bytecode => {
-              let tval: Value = to_value(&artifact.bytecode).unwrap();
-              println!("{}", tval.get("object").unwrap_or_else(|| &tval).clone().as_str().unwrap());
+                let tval: Value = to_value(&artifact.bytecode).unwrap();
+                println!("{}", tval.get("object").unwrap_or(&tval).clone().as_str().unwrap());
             }
             ContractArtifactFields::DeployedBytecode => {
-              let tval: Value = to_value(&artifact.deployed_bytecode).unwrap();
-              println!("{}", tval.get("object").unwrap_or_else(|| &tval).clone().as_str().unwrap());
+                let tval: Value = to_value(&artifact.deployed_bytecode).unwrap();
+                println!("{}", tval.get("object").unwrap_or(&tval).clone().as_str().unwrap());
             }
             ContractArtifactFields::Assembly => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.assembly).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.assembly).unwrap()).unwrap()
+                );
             }
             ContractArtifactFields::MethodIdentifiers => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.method_identifiers).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.method_identifiers).unwrap())
+                        .unwrap()
+                );
             }
             ContractArtifactFields::GasEstimates => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.gas_estimates).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.gas_estimates).unwrap())
+                        .unwrap()
+                );
             }
             ContractArtifactFields::Metadata => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.metadata).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.metadata).unwrap()).unwrap()
+                );
             }
             ContractArtifactFields::StorageLayout => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.storage_layout).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.storage_layout).unwrap())
+                        .unwrap()
+                );
             }
             ContractArtifactFields::UserDoc => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.userdoc).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.userdoc).unwrap()).unwrap()
+                );
             }
             ContractArtifactFields::DevDoc => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.devdoc).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.devdoc).unwrap()).unwrap()
+                );
             }
             ContractArtifactFields::Ir => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.ir).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.ir).unwrap()).unwrap()
+                );
             }
             ContractArtifactFields::IrOptimized => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.ir_optimized).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.ir_optimized).unwrap())
+                        .unwrap()
+                );
             }
             ContractArtifactFields::Ewasm => {
-              println!("{}", serde_json::to_string_pretty(&to_value(&artifact.ewasm).unwrap()).unwrap());
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&to_value(&artifact.ewasm).unwrap()).unwrap()
+                );
             }
         };
 

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -8,7 +8,9 @@ use crate::{
     opts::forge::CompilerArgs,
 };
 use clap::Parser;
-use ethers::prelude::artifacts::output_selection::{ContractOutputSelection, EvmOutputSelection};
+use ethers::prelude::artifacts::output_selection::{
+    ContractOutputSelection, EvmOutputSelection, EwasmOutputSelection,
+};
 use serde_json::{to_value, Value};
 
 /// Contract level output selection
@@ -25,10 +27,9 @@ pub enum ContractArtifactFields {
     DevDoc,
     Ir,
     IrOptimized,
-    // TODO: Add once these commands aren't broken at compiler-level
-    // Metadata,
-    // UserDoc,
-    // Ewasm,
+    Metadata,
+    UserDoc,
+    Ewasm,
 }
 
 impl fmt::Display for ContractArtifactFields {
@@ -45,10 +46,9 @@ impl fmt::Display for ContractArtifactFields {
             ContractArtifactFields::DevDoc => f.write_str("devdoc"),
             ContractArtifactFields::Ir => f.write_str("ir"),
             ContractArtifactFields::IrOptimized => f.write_str("irOptimized"),
-            // TODO: Add once these commands aren't broken at compiler-level
-            // ContractArtifactFields::Metadata => f.write_str("metadata"),
-            // ContractArtifactFields::UserDoc => f.write_str("userdoc"),
-            // ContractArtifactFields::Ewasm => f.write_str("ewasm"),
+            ContractArtifactFields::Metadata => f.write_str("metadata"),
+            ContractArtifactFields::UserDoc => f.write_str("userdoc"),
+            ContractArtifactFields::Ewasm => f.write_str("ewasm"),
         }
     }
 }
@@ -79,10 +79,9 @@ impl FromStr for ContractArtifactFields {
             "ir-optimized" | "irOptimized" | "iroptimized" | "iro" => {
                 Ok(ContractArtifactFields::IrOptimized)
             }
-            // TODO: Add once these commands aren't broken at compiler-level
-            // "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
-            // "userdoc" => Ok(ContractArtifactFields::UserDoc),
-            // "ewasm" => Ok(ContractArtifactFields::Ewasm),
+            "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
+            "userdoc" => Ok(ContractArtifactFields::UserDoc),
+            "ewasm" => Ok(ContractArtifactFields::Ewasm),
             _ => Ok(ContractArtifactFields::Bytecode),
         }
     }
@@ -107,7 +106,7 @@ impl Cmd for InspectArgs {
         let InspectArgs { contract, mode, build } = self;
 
         // Map mode to ContractOutputSelection
-        let mut cos = if let Some(v) = build.compiler.extra_output { v } else { vec![] };
+        let mut cos = build.compiler.extra_output.unwrap_or_default();
         if !cos.iter().any(|&i| i.to_string() == mode.to_string()) {
             match mode {
                 ContractArtifactFields::Abi => cos.push(ContractOutputSelection::Abi),
@@ -129,14 +128,12 @@ impl Cmd for InspectArgs {
                 ContractArtifactFields::Ir => cos.push(ContractOutputSelection::Ir),
                 ContractArtifactFields::IrOptimized => {
                     cos.push(ContractOutputSelection::IrOptimized)
-                } /* TODO: Add once these commands aren't broken at compiler-level
-                   * ContractArtifactFields::Metadata =>
-                   * cos.push(ContractOutputSelection::Metadata),
-                   * ContractArtifactFields::UserDoc =>
-                   * cos.push(ContractOutputSelection::UserDoc),
-                   * ContractArtifactFields::Ewasm => {
-                   *     cos.push(ContractOutputSelection::Ewasm(EwasmOutputSelection::All))
-                   * } */
+                }
+                ContractArtifactFields::Metadata => cos.push(ContractOutputSelection::Metadata),
+                ContractArtifactFields::UserDoc => cos.push(ContractOutputSelection::UserDoc),
+                ContractArtifactFields::Ewasm => {
+                    cos.push(ContractOutputSelection::Ewasm(EwasmOutputSelection::All))
+                }
             }
         }
 
@@ -161,89 +158,90 @@ impl Cmd for InspectArgs {
         let project = modified_build_args.project()?;
         let outcome = super::suppress_compile(&project)?;
 
-        // If the project is unchanged, used cached artifacts
-        let artifacts = if outcome.is_unchanged() {
-            outcome.cached_artifacts()
-        } else {
-            outcome.compiled_artifacts()
-        };
-
-        // For the compiled artifacts, find the contract
-        let found_artifact = artifacts.find(contract.clone());
+        // Find the artifact
+        let found_artifact = outcome.find(contract.clone());
 
         // Unwrap the inner artifact
-        let artifact = found_artifact.unwrap_or_else(|| {
-            eyre::eyre!("Could not find artifact `{}` in the compiled artifacts", contract);
-            panic!("Could not find artifact `{}` in the compiled artifacts", contract)
-        });
+        let artifact = found_artifact.ok_or_else(|| {
+            eyre::eyre!("Could not find artifact `{}` in the compiled artifacts", contract)
+        })?;
 
         // Match on ContractArtifactFields and Pretty Print
         match mode {
             ContractArtifactFields::Abi => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.abi).unwrap()).unwrap()
-                );
+                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.abi)?)?);
             }
             ContractArtifactFields::Bytecode => {
-                let tval: Value = to_value(&artifact.bytecode).unwrap();
-                println!("{}", tval.get("object").unwrap_or(&tval).clone().as_str().unwrap());
+                let tval: Value = to_value(&artifact.bytecode)?;
+                println!(
+                    "{}",
+                    tval.get("object").unwrap_or(&tval).clone().as_str().ok_or_else(
+                        || eyre::eyre!("Failed to extract artifact bytecode as a string")
+                    )?
+                );
             }
             ContractArtifactFields::DeployedBytecode => {
-                let tval: Value = to_value(&artifact.deployed_bytecode).unwrap();
-                println!("{}", tval.get("object").unwrap_or(&tval).clone().as_str().unwrap());
+                let tval: Value = to_value(&artifact.deployed_bytecode)?;
+                println!(
+                    "{}",
+                    tval.get("object").unwrap_or(&tval).clone().as_str().ok_or_else(
+                        || eyre::eyre!("Failed to extract artifact deployed bytecode as a string")
+                    )?
+                );
             }
             ContractArtifactFields::Assembly | ContractArtifactFields::AssemblyOptimized => {
-                println!("{}", to_value(&artifact.assembly).unwrap().as_str().unwrap());
+                println!(
+                    "{}",
+                    to_value(&artifact.assembly)?.as_str().ok_or_else(|| eyre::eyre!(
+                        "Failed to extract artifact assembly as a string"
+                    ))?
+                );
             }
             ContractArtifactFields::MethodIdentifiers => {
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.method_identifiers).unwrap())
-                        .unwrap()
+                    serde_json::to_string_pretty(&to_value(&artifact.method_identifiers)?)?
                 );
             }
             ContractArtifactFields::GasEstimates => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.gas_estimates).unwrap())
-                        .unwrap()
-                );
+                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.gas_estimates)?)?);
             }
             ContractArtifactFields::StorageLayout => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.storage_layout).unwrap())
-                        .unwrap()
-                );
+                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.storage_layout)?)?);
             }
             ContractArtifactFields::DevDoc => {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&to_value(&artifact.devdoc).unwrap()).unwrap()
-                );
+                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.devdoc)?)?);
             }
             ContractArtifactFields::Ir => {
-                println!("{}", to_value(&artifact.ir).unwrap().as_str().unwrap());
+                println!(
+                    "{}",
+                    to_value(&artifact.ir)?
+                        .as_str()
+                        .ok_or_else(|| eyre::eyre!("Failed to extract artifact ir as a string"))?
+                );
             }
             ContractArtifactFields::IrOptimized => {
-                println!("{}", to_value(&artifact.ir_optimized).unwrap().as_str().unwrap());
-            } /* TODO: Add once these commands aren't broken at compiler-level
-               * ContractArtifactFields::Metadata => {
-               *     println!(
-               *         "{}",
-               *         serde_json::to_string_pretty(&to_value(&artifact.metadata).unwrap()).
-               * unwrap()     );
-               * }
-               * ContractArtifactFields::UserDoc => {
-               *     println!(
-               *         "{}",
-               *         serde_json::to_string_pretty(&to_value(&artifact.userdoc).unwrap()).
-               * unwrap()     );
-               * }
-               * ContractArtifactFields::Ewasm => {
-               *     println!("{}", to_value(&artifact.ewasm).unwrap().as_str().unwrap());
-               * } */
+                println!(
+                    "{}",
+                    to_value(&artifact.ir_optimized)?.as_str().ok_or_else(|| eyre::eyre!(
+                        "Failed to extract artifact optimized ir as a string"
+                    ))?
+                );
+            }
+            ContractArtifactFields::Metadata => {
+                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.metadata)?)?);
+            }
+            ContractArtifactFields::UserDoc => {
+                println!("{}", serde_json::to_string_pretty(&to_value(&artifact.userdoc)?)?);
+            }
+            ContractArtifactFields::Ewasm => {
+                println!(
+                    "{}",
+                    to_value(&artifact.ewasm)?.as_str().ok_or_else(|| eyre::eyre!(
+                        "Failed to extract artifact ewasm as a string"
+                    ))?
+                );
+            }
         };
 
         Ok(())

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -3,50 +3,9 @@ use std::{
   str::FromStr,
 };
 
-use ethers::solc::remappings::Remapping;
-
-use crate::cmd::{build::BuildArgs, Cmd};
+use crate::cmd::{build, Cmd};
 use clap::{Parser, ValueHint};
 use foundry_config::Config;
-
-#[derive(Debug, Clone, Parser)]
-pub struct CoreInspectArgs {
-    #[clap(
-    help = "the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
-    long,
-    value_hint = ValueHint::DirPath
-    )]
-    pub root: Option<PathBuf>,
-
-    #[clap(
-    env = "DAPP_SRC",
-    help = "the directory relative to the root under which the smart contracts are",
-    long,
-    short,
-    value_hint = ValueHint::DirPath
-    )]
-    pub contracts: Option<PathBuf>,
-
-    #[clap(help = "the remappings", long, short)]
-    pub remappings: Vec<Remapping>,
-    #[clap(long = "remappings-env", env = "DAPP_REMAPPINGS")]
-    pub remappings_env: Option<String>,
-
-    #[clap(
-    help = "the paths where your libraries are installed",
-    long,
-    value_hint = ValueHint::DirPath
-    )]
-    pub lib_paths: Vec<PathBuf>,
-
-    #[clap(
-        help = "uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-paths node_modules`",
-        long,
-        conflicts_with = "contracts",
-        alias = "hh"
-    )]
-    pub hardhat: bool,
-}
 
 #[derive(Debug, Clone)]
 pub enum Mode {
@@ -68,42 +27,34 @@ impl FromStr for Mode {
 
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
-    #[clap(help = "the path to the contract to inspect", value_hint = ValueHint::FilePath)]
-    pub target_path: PathBuf,
-
-    #[clap(long, short, help = "the mode to build the ", value_hint = ValueHint::FilePath)]
-    pub mode: Option<Mode>,
-
+    /// All build arguments are supported
     #[clap(flatten)]
-    core_inspect_args: CoreInspectArgs,
+    build: build::BuildArgs,
+
+    #[clap(help = "the contract to inspect")]
+    pub contract: String,
+
+    #[clap(long, short, help = "the mode to build the ")]
+    pub mode: Option<Mode>,
 }
 
 impl Cmd for InspectArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let InspectArgs { target_path, mode, core_inspect_args } = self;
+        let InspectArgs { build, contract, mode } = self;
 
-        // Reuse `BuildArgs` to get the config (following flatten convention)
-        let build_args = BuildArgs {
-            root: core_inspect_args.root,
-            contracts: core_inspect_args.contracts,
-            remappings: core_inspect_args.remappings,
-            remappings_env: core_inspect_args.remappings_env,
-            lib_paths: core_inspect_args.lib_paths,
-            out_path: None,
-            compiler: Default::default(),
-            names: false,
-            sizes: false,
-            ignored_error_codes: vec![],
-            no_auto_detect: false,
-            offline: false,
-            force: false,
-            hardhat: core_inspect_args.hardhat,
-            libraries: vec![],
-            watch: Default::default(),
-        };
+        // Build the project
+        let project = build.project()?;
+        let outcome =  super::compile(
+          &project,
+          build.names,
+          build.sizes
+        )?;
 
-        let config = Config::from(&build_args);
+        // For the compiled artifacts, find the contract
+        let artifacts = outcome.compiled_artifacts().find(contract);
+
+        println!("ConfigurableContractArtifact: {:?}", artifacts);
 
         // let paths = config.project_paths();
         // let target_path = dunce::canonicalize(target_path)?;

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -44,6 +44,7 @@ pub mod create;
 pub mod flatten;
 pub mod fmt;
 pub mod init;
+pub mod inspect;
 pub mod install;
 pub mod remappings;
 pub mod run;
@@ -51,7 +52,6 @@ pub mod snapshot;
 pub mod test;
 pub mod verify;
 pub mod watch;
-pub mod inspect;
 
 use crate::opts::forge::ContractInfo;
 use ethers::{

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -144,6 +144,29 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
     Ok(output)
 }
 
+/// Compiles the provided [`Project`], throws if there's any compiler error and logs whether
+/// compilation was successful or if there was a cache hit.
+/// Doesn't print anything to stdout, thus is "suppressed".
+pub fn suppress_compile(project: &Project) -> eyre::Result<ProjectCompileOutput> {
+    if !project.paths.sources.exists() {
+        eyre::bail!(
+            r#"no contracts to compile, contracts folder "{}" does not exist.
+Check the configured workspace settings:
+{}
+If you are in a subdirectory in a Git repository, try adding `--root .`"#,
+            project.paths.sources.display(),
+            project.paths
+        );
+    }
+
+    let output = project.compile()?;
+    if output.has_compiler_errors() {
+        eyre::bail!(output.to_string())
+    }
+
+    Ok(output)
+}
+
 /// Compile a set of files not necessarily included in the `project`'s source dir
 pub fn compile_files(project: &Project, files: Vec<PathBuf>) -> eyre::Result<ProjectCompileOutput> {
     println!("Compiling...");

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -51,6 +51,7 @@ pub mod snapshot;
 pub mod test;
 pub mod verify;
 pub mod watch;
+pub mod inspect;
 
 use crate::opts::forge::ContractInfo;
 use ethers::{

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -94,6 +94,9 @@ fn main() -> eyre::Result<()> {
         Subcommands::Flatten(cmd) => {
             cmd.run()?;
         }
+        Subcommands::Inspect(cmd) => {
+            cmd.run()?;
+        }
     }
 
     Ok(())

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -10,12 +10,12 @@ use crate::cmd::{
     create::CreateArgs,
     flatten,
     init::InitArgs,
+    inspect,
     install::InstallArgs,
     remappings::RemappingArgs,
     run::RunArgs,
     snapshot, test,
     verify::{VerifyArgs, VerifyCheckArgs},
-    inspect
 };
 use serde::Serialize;
 
@@ -117,7 +117,6 @@ pub enum Subcommands {
     Flatten(flatten::FlattenArgs),
     // #[clap(about = "formats Solidity source files")]
     // Fmt(FmtArgs),
-
     #[clap(about = "Outputs a contract in a specified format (ir, assembly, ...)")]
     Inspect(inspect::InspectArgs),
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -15,6 +15,7 @@ use crate::cmd::{
     run::RunArgs,
     snapshot, test,
     verify::{VerifyArgs, VerifyCheckArgs},
+    inspect::InspectArgs
 };
 use serde::Serialize;
 
@@ -116,6 +117,9 @@ pub enum Subcommands {
     Flatten(flatten::FlattenArgs),
     // #[clap(about = "formats Solidity source files")]
     // Fmt(FmtArgs),
+
+    #[clap(about = "Outputs a contract in a specified format (ir, assembly, ...)")]
+    Inspect(inspect::InspectArgs),
 }
 
 // A set of solc compiler settings that can be set via command line arguments, which are intended

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -15,7 +15,7 @@ use crate::cmd::{
     run::RunArgs,
     snapshot, test,
     verify::{VerifyArgs, VerifyCheckArgs},
-    inspect::InspectArgs
+    inspect
 };
 use serde::Serialize;
 

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -462,7 +462,7 @@ forgetest!(can_execute_inspect_command, |prj: TestProject, mut cmd: TestCommand|
             r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
-contract Demo {
+contract Foo {
     event log_string(string);
     function run() external {
         emit log_string("script ran");
@@ -472,12 +472,17 @@ contract Demo {
         )
         .unwrap();
 
+    // Remove the ipfs hash from the metadata
+    let mut dynamic_bytecode = "0x608060405234801561001057600080fd5b5060c08061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063c040622614602d575b600080fd5b60336035565b005b7f0b2e13ff20ac7b474198655583edf70dedd2c1dc980e329c4fbb2fc0748b796b6040516080906020808252600a908201526939b1b934b83a103930b760b11b604082015260600190565b60405180910390a156fea264697066735822122065c066d19101ad1707272b9a884891af8ab0cf5a0e0bba70c4650594492c14be64736f6c634300080a0033\n".to_string();
+    let ipfs_start = dynamic_bytecode.len() - (24 + 64);
+    let ipfs_end = ipfs_start + 65;
+    dynamic_bytecode.replace_range(ipfs_start..ipfs_end, "");
     cmd.arg("inspect").arg(contract_name).arg("bytecode");
-    let output = cmd.stdout_lossy();
-    assert_eq!(
-        "0x608060405234801561001057600080fd5b5060d38061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063c040622614602d575b600080fd5b60336035565b005b7f0b2e13ff20ac7b474198655583edf70dedd2c1dc980e329c4fbb2fc0748b796b6040516093906020808252600a908201527f7363726970742072616e00000000000000000000000000000000000000000000604082015260600190565b60405180910390a156fea2646970667358221220087a3c832c1188b944b1abac5b07149f47b0cd023b8f53bbbfa0590e5e89bb2064736f6c634300080c0033",
-        output
-    );
+    let mut output = cmd.stdout_lossy();
+    output.replace_range(ipfs_start..ipfs_end, "");
+
+    // Compare the static bytecode
+    assert_eq!(dynamic_bytecode, output);
 });
 
 forgetest_init!(can_parse_dapp_libraries, |prj: TestProject, mut cmd: TestCommand| {

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -452,6 +452,44 @@ script ran
     );
 });
 
+// tests that the `inspect` command works correctly
+forgetest!(can_execute_inspect_command, |prj: TestProject, mut cmd: TestCommand| {
+    let contract_name = "Foo";
+    let script = prj
+        .inner()
+        .add_source(
+            contract_name,
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+contract Demo {
+    event log_string(string);
+    function run() external {
+        emit log_string("script ran");
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.arg("inspect").arg("bytecode").arg(contract_name);
+    let output = cmd.stdout_lossy();
+    assert_eq!(
+        format!(
+            "Compiling...
+Compiling 1 files with 0.8.10
+Compiler run successful
+{}
+Gas Used: 1751
+== Logs ==
+script ran
+",
+            Colour::Green.paint("Script ran successfully.")
+        ),
+        output
+    );
+});
+
 forgetest_init!(can_parse_dapp_libraries, |prj: TestProject, mut cmd: TestCommand| {
     cmd.set_current_dir(prj.root());
     cmd.set_env(

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -455,7 +455,7 @@ script ran
 // tests that the `inspect` command works correctly
 forgetest!(can_execute_inspect_command, |prj: TestProject, mut cmd: TestCommand| {
     let contract_name = "Foo";
-    let script = prj
+    let _ = prj
         .inner()
         .add_source(
             contract_name,
@@ -468,24 +468,14 @@ contract Demo {
         emit log_string("script ran");
     }
 }
-   "#,
+    "#,
         )
         .unwrap();
 
-    cmd.arg("inspect").arg("bytecode").arg(contract_name);
+    cmd.arg("inspect").arg(contract_name).arg("bytecode");
     let output = cmd.stdout_lossy();
     assert_eq!(
-        format!(
-            "Compiling...
-Compiling 1 files with 0.8.10
-Compiler run successful
-{}
-Gas Used: 1751
-== Logs ==
-script ran
-",
-            Colour::Green.paint("Script ran successfully.")
-        ),
+        "0x608060405234801561001057600080fd5b5060d38061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063c040622614602d575b600080fd5b60336035565b005b7f0b2e13ff20ac7b474198655583edf70dedd2c1dc980e329c4fbb2fc0748b796b6040516093906020808252600a908201527f7363726970742072616e00000000000000000000000000000000000000000000604082015260600190565b60405180910390a156fea2646970667358221220087a3c832c1188b944b1abac5b07149f47b0cd023b8f53bbbfa0590e5e89bb2064736f6c634300080c0033",
         output
     );
 });


### PR DESCRIPTION
## Overview

Introduces an `inspect` subcommand for `forge` that outputs one of `{ir, bytecode}` for a given contract as specified by #859 

## TODO

Implement the following modes for `forge inspect <CONTRACT> <MODE>`

- [x] `ContractArtifactFields::Abi`
- [x] `ContractArtifactFields::Bytecode` 
- [x] `ContractArtifactFields::DeployedBytecode` 
- [x] `ContractArtifactFields::Assembly` 
- [x] `ContractArtifactFields::AssemblyOptimized`
- [x] `ContractArtifactFields::MethodIdentifiers` 
- [x] `ContractArtifactFields::GasEstimates` 
- [x] `ContractArtifactFields::StorageLayout` 
- [x] `ContractArtifactFields::DevDoc` 
- [x] `ContractArtifactFields::Ir` 
- [x] `ContractArtifactFields::IrOptimized` 
- [x] `ContractArtifactFields::Metadata`
- [x] `ContractArtifactFields::UserDoc`
- [x] `ContractArtifactFields::Ewasm`

Compilation Suppression
- [x] Suppress compilation output to allow clean redirecting or piping from `inspect`

Example compilation output:
![Screenshot from 2022-03-09 12-02-58](https://user-images.githubusercontent.com/21288394/157524870-9112bfdf-9229-4ee7-b4dc-0c065c1f9a88.png)

Override Compiler Optimization for certain `ContractArtifactFields` variants
- [x] `ContractArtifactFields::AssemblyOptimized`

Extra Output Fixes
- [x] Merge #897 [fix](https://github.com/gakonst/ethers-rs/pull/1004) into ether-rs h/t @mattsse  
