### PR TITLE
fix(cast): allow using `--from` and `ETH_FROM` with `cast send`

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -224,7 +224,7 @@ async fn main() -> eyre::Result<()> {
             let chain_id = Cast::new(&provider).chain_id().await?;
             let sig = sig.unwrap_or_default();
 
-            if let Some(signer) = eth.signer_with(chain_id, provider.clone()).await? {
+            if let Ok(Some(signer)) = eth.signer_with(chain_id, provider.clone()).await {
                 match signer {
                     WalletType::Ledger(signer) => {
                         cast_send(
@@ -284,8 +284,7 @@ async fn main() -> eyre::Result<()> {
                         .await?;
                     }
                 }
-            } else {
-                let from = eth.from.expect("No ETH_FROM or signer specified");
+            } else if let Some(from) = eth.from {
                 cast_send(
                     provider,
                     from,
@@ -303,6 +302,8 @@ async fn main() -> eyre::Result<()> {
                     to_json,
                 )
                 .await?;
+            } else {
+                eyre::bail!("No wallet or sender address provided.")
             }
         }
         Subcommands::PublishTx { eth, raw_tx, cast_async } => {

--- a/cli/src/cmd/fmt.rs
+++ b/cli/src/cmd/fmt.rs
@@ -3,6 +3,7 @@ use std::{fmt::Write, path::PathBuf};
 use clap::Parser;
 use console::{style, Style};
 use ethers::solc::ProjectPathsConfig;
+
 use rayon::prelude::*;
 use similar::{ChangeTag, TextDiff};
 

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -143,7 +143,7 @@ impl EthereumOpts {
         if self.flashbots {
             Ok(FLASHBOTS_URL)
         } else {
-            self.rpc_url.as_deref().ok_or_else(|| eyre::Error::msg("no Ethereum RPC provided, maybe you forgot to set the --rpc-url or the ETH_RPC_URL parameter? Alternatively, consider using the --flashbots flag to get frontrunning protection"))
+            Ok(self.rpc_url.as_deref().unwrap_or("http://localhost:8545"))
         }
     }
 }


### PR DESCRIPTION
Fixes #838 

(driveby: default RPC url to http://localhost:8545, cc @tynes)