### PR TITLE
fix(forge/inspect): Inconsistent Mode Matching

### DIFF
--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -59,29 +59,28 @@ impl FromStr for ContractArtifactFields {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "abi" => Ok(ContractArtifactFields::Abi),
-            "bytecode" => Ok(ContractArtifactFields::Bytecode),
             "deployedBytecode" | "deployed_bytecode" | "deployed-bytecode" | "deployed" |
             "deployedbytecode" => Ok(ContractArtifactFields::DeployedBytecode),
             "assembly" | "asm" => Ok(ContractArtifactFields::Assembly),
             "asmOptimized" | "assemblyOptimized" | "assemblyoptimized" | "assembly_optimized" |
-            "asmo" => Ok(ContractArtifactFields::AssemblyOptimized),
-            "methodIdentifiers" | "method_identifiers" | "method-identifiers" | "mi" => {
-                Ok(ContractArtifactFields::MethodIdentifiers)
-            }
+            "assembly-optimized" | "asmo" => Ok(ContractArtifactFields::AssemblyOptimized),
+            "methods" | "methodidentifiers" | "methodIdentifiers" | "method_identifiers" |
+            "method-identifiers" | "mi" => Ok(ContractArtifactFields::MethodIdentifiers),
             "gasEstimates" | "gas" | "gas_estimates" | "gas-estimates" | "gasestimates" => {
                 Ok(ContractArtifactFields::GasEstimates)
             }
             "storageLayout" | "storage_layout" | "storage-layout" | "storagelayout" | "storage" => {
                 Ok(ContractArtifactFields::StorageLayout)
             }
-            "devdoc" => Ok(ContractArtifactFields::DevDoc),
-            "ir" => Ok(ContractArtifactFields::Ir),
+            "devdoc" | "dev-doc" | "devDoc" => Ok(ContractArtifactFields::DevDoc),
+            "ir" | "iR" | "IR" => Ok(ContractArtifactFields::Ir),
             "ir-optimized" | "irOptimized" | "iroptimized" | "iro" => {
                 Ok(ContractArtifactFields::IrOptimized)
             }
             "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
-            "userdoc" => Ok(ContractArtifactFields::UserDoc),
-            "ewasm" => Ok(ContractArtifactFields::Ewasm),
+            "userdoc" | "userDoc" | "user-doc" => Ok(ContractArtifactFields::UserDoc),
+            "ewasm" | "e-wasm" => Ok(ContractArtifactFields::Ewasm),
+            // Don't need to match bytecode since this is covered by the default case here
             _ => Ok(ContractArtifactFields::Bytecode),
         }
     }

--- a/cli/src/cmd/inspect.rs
+++ b/cli/src/cmd/inspect.rs
@@ -63,7 +63,9 @@ impl FromStr for ContractArtifactFields {
             "deployedbytecode" => Ok(ContractArtifactFields::DeployedBytecode),
             "assembly" | "asm" => Ok(ContractArtifactFields::Assembly),
             "asmOptimized" | "assemblyOptimized" | "assemblyoptimized" | "assembly_optimized" |
-            "assembly-optimized" | "asmo" => Ok(ContractArtifactFields::AssemblyOptimized),
+            "asmopt" | "assembly-optimized" | "asmo" => {
+                Ok(ContractArtifactFields::AssemblyOptimized)
+            }
             "methods" | "methodidentifiers" | "methodIdentifiers" | "method_identifiers" |
             "method-identifiers" | "mi" => Ok(ContractArtifactFields::MethodIdentifiers),
             "gasEstimates" | "gas" | "gas_estimates" | "gas-estimates" | "gasestimates" => {
@@ -74,7 +76,7 @@ impl FromStr for ContractArtifactFields {
             }
             "devdoc" | "dev-doc" | "devDoc" => Ok(ContractArtifactFields::DevDoc),
             "ir" | "iR" | "IR" => Ok(ContractArtifactFields::Ir),
-            "ir-optimized" | "irOptimized" | "iroptimized" | "iro" => {
+            "ir-optimized" | "irOptimized" | "iroptimized" | "iro" | "iropt" => {
                 Ok(ContractArtifactFields::IrOptimized)
             }
             "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),


### PR DESCRIPTION
## Overview

The `forge inspect` command has inconsistent matching when parsing as a string.

## Motivation

As shown below, there is a mix between kebab-casings, snake-casings, camel-casings, etc etc.

![Screenshot from 2022-03-10 16-50-58](https://user-images.githubusercontent.com/21288394/157781668-ae6f3b7b-43df-40ea-9e53-e37f7c558c2e.png)


## Solution

Add verbose matching patterns.
