### PR TITLE
fix(cheats): getCode compatibility with hardhat-style artifac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1274,7 +1274,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1285,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#1446f410ab9d853c8716ba1d7961cb346f6cf14d"
+source = "git+https://github.com/gakonst/ethers-rs#b05136e173f83f3c59280501a3fd4b04f7356e6f"
 dependencies = [
  "colored",
  "dunce",
@@ -4561,9 +4561,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -4573,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
If we wanted to read a Hardhat-tpe artifact, deserialization would fail because the artifact has `"bytecode": "0x1234"` whereas the CompactcontractBytecode artifact has `bytecode: { link objects, source, etc }`