### PR TITLE
Make FFI hex string decoding more flexible 

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -647,9 +647,15 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                     Err(err) => return evm_error(&err.to_string()),
                 };
 
-                // get the hex string & decode it
+                // get the hex string
                 let output = unsafe { std::str::from_utf8_unchecked(&output) };
-                let decoded = match hex::decode(&output.trim()[2..]) {
+                let mut output = output.trim();
+                //remove "0x" only if present 
+                if output.starts_with("0x") {
+                    output = &output[2..]
+                }
+                //decode hex
+                let decoded = match hex::decode(output) {
                     Ok(res) => res,
                     Err(err) => return evm_error(&err.to_string()),
                 };

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -649,11 +649,7 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
 
                 // get the hex string
                 let output = unsafe { std::str::from_utf8_unchecked(&output) };
-                let mut output = output.trim();
-                //remove "0x" only if present 
-                if output.starts_with("0x") {
-                    output = &output[2..]
-                }
+                let output = output.strip_prefix("0x").unwrap_or(output);
                 //decode hex
                 let decoded = match hex::decode(output) {
                     Ok(res) => res,


### PR DESCRIPTION
## Motivation

Currently, ffi decoding removes the first two characters in the hex string indiscriminately, assuming they are "0x". This is surprising behaviour, which can confuse users. Even for experienced users, this causes inconveniences, since they often have to manually add "0x" to their payloads when using this cheatcode. See https://github.com/gakonst/lootloose/blob/master/scripts/metadata.js#L30 as an example of this behaviour. 

## Solution

This PR introduces a check to see if the first two characters are indeed "0x" before trimming. This should be backwards compatible 

## Testing 

I tried writing a test but it seems like FFI tests are currently disabled for non-unix systems (is this being fixed?). I did some manual verification and this seems to work with both cases. 
