### PR TITLE
REVM debugger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.1.0"
 dependencies = [
@@ -708,7 +714,7 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
 dependencies = [
- "crossterm",
+ "crossterm 0.23.0",
  "strum",
  "strum_macros",
  "unicode-width",
@@ -845,17 +851,58 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.8.0",
+ "libc",
+ "mio 0.7.14",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.9.0",
+ "libc",
+ "mio 0.7.14",
+ "parking_lot 0.11.2",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b75a27dc8d220f1f8521ea69cd55a34d720a200ebb3a624d9aa19193d3b432"
 dependencies = [
  "bitflags",
- "crossterm_winapi",
+ "crossterm_winapi 0.9.0",
  "libc",
  "mio 0.7.14",
  "parking_lot 0.12.0",
  "signal-hook",
  "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+dependencies = [
  "winapi",
 ]
 
@@ -1611,6 +1658,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber 0.2.25",
+ "ui",
  "vergen",
  "walkdir",
  "watchexec",
@@ -4536,6 +4584,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tui"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c8ce4e27049eed97cfa363a5048b09d995e209994634a0efc26a14ab6c0c23"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm 0.20.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,6 +4623,18 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ui"
+version = "0.1.0"
+dependencies = [
+ "crossterm 0.22.1",
+ "ethers",
+ "eyre",
+ "forge",
+ "hex",
+ "tui",
+]
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "cli/test-utils",
     "config",
     "fmt",
+    "ui"
 ]
 
 # Binary size optimizations

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,8 +26,7 @@ foundry-utils = { path = "../utils" }
 forge = { path = "../forge" }
 foundry-config = { path = "../config" }
 cast = { path = "../cast" }
-# TODO: Re-enable when ported
-#ui = { path = "../ui" }
+ui = { path = "../ui" }
 dunce = "1.0.2"
 # ethers = "0.5"
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -47,8 +47,7 @@ pub mod init;
 pub mod inspect;
 pub mod install;
 pub mod remappings;
-// TODO: Re-enable when ported
-//pub mod run;
+pub mod run;
 pub mod snapshot;
 pub mod test;
 pub mod tree;

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -114,11 +114,20 @@ impl Cmd for RunArgs {
             let (address, mut result) =
                 runner.setup(&predeploy_libraries, bytecode, needs_setup)?;
 
-            let RunResult { success, logs, traces, debug: run_debug, labeled_addresses, .. } =
-                runner
-                    .run(address, encode_args(&IntoFunction::into(self.sig), &self.args)?.into())?;
+            let RunResult {
+                success,
+                gas_used,
+                logs,
+                traces,
+                debug: run_debug,
+                labeled_addresses,
+                ..
+            } = runner
+                .run(address, encode_args(&IntoFunction::into(self.sig), &self.args)?.into())?;
 
             result.success &= success;
+
+            result.gas_used = gas_used;
             result.logs.extend(logs);
             result.traces.extend(traces);
             result.debug = run_debug;
@@ -192,10 +201,9 @@ impl Cmd for RunArgs {
             }
 
             println!("Gas used: {}", result.gas_used);
-            println!("== Logs == ");
+            println!("== Logs ==");
             let console_logs = decode_console_logs(&result.logs);
             if !console_logs.is_empty() {
-                println!("Logs:");
                 for log in console_logs {
                     println!("  {}", log);
                 }

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -1,35 +1,41 @@
-use crate::cmd::{build::BuildArgs, compile_files, Cmd};
-use clap::{Parser, ValueHint};
-use evm_adapters::sputnik::cheatcodes::{CONSOLE_ABI, HEVMCONSOLE_ABI, HEVM_ABI};
-
-use forge::ContractRunner;
-use foundry_utils::IntoFunction;
-use std::{collections::BTreeMap, path::PathBuf};
-use ui::{TUIExitReason, Tui, Ui};
-
-use ethers::solc::Project;
-
-use crate::opts::evm::EvmArgs;
-use ansi_term::Colour;
-use ethers::{
-    abi::Abi,
-    solc::artifacts::{CompactContractBytecode, ContractBytecode, ContractBytecodeSome},
+use crate::{
+    cmd::{build::BuildArgs, compile_files, Cmd},
+    opts::evm::EvmArgs,
 };
-use evm_adapters::{
-    call_tracing::ExecutionInfo,
-    evm_opts::{BackendKind, EvmOpts},
-    sputnik::{cheatcodes::debugger::DebugArena, helpers::vm},
+use ansi_term::Colour;
+use clap::{Parser, ValueHint};
+use ethers::{
+    abi::{Abi, RawLog},
+    solc::{
+        artifacts::{CompactContractBytecode, ContractBytecode, ContractBytecodeSome},
+        Project,
+    },
+    types::{Address, Bytes, U256},
+};
+use forge::{
+    debugger::DebugArena,
+    decode::decode_console_logs,
+    executor::{
+        opts::EvmOpts, CallResult, DatabaseRef, DeployResult, EvmError, Executor, ExecutorBuilder,
+        Fork, RawCallResult,
+    },
+    trace::{identifier::LocalTraceIdentifier, CallTraceArena, CallTraceDecoder, TraceKind},
+    CALLER,
 };
 use foundry_config::{figment::Figment, Config};
-use foundry_utils::PostLinkInput;
+use foundry_utils::{encode_args, IntoFunction, PostLinkInput};
+use std::{collections::BTreeMap, path::PathBuf};
+use ui::{TUIExitReason, Tui, Ui};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(RunArgs, opts, evm_opts);
 
 #[derive(Debug, Clone, Parser)]
 pub struct RunArgs {
-    #[clap(help = "the path to the contract to run", value_hint = ValueHint::FilePath)]
+    #[clap(help = "the path of the contract to run", value_hint = ValueHint::FilePath)]
     pub path: PathBuf,
+
+    pub args: Vec<String>,
 
     #[clap(flatten)]
     pub evm_opts: EvmArgs,
@@ -47,36 +53,29 @@ pub struct RunArgs {
     #[clap(
         long,
         short,
+        default_value = "run()",
         help = "the function you want to call on the script contract, defaults to run()"
     )]
-    pub sig: Option<String>,
+    pub sig: String,
 }
 
 impl Cmd for RunArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        // Keeping it like this for simplicity.
-        #[cfg(not(feature = "sputnik-evm"))]
-        unimplemented!("`run` does not work with EVMs other than Sputnik yet");
-
         let figment: Figment = From::from(&self);
-        let mut evm_opts = figment.extract::<EvmOpts>()?;
+        let evm_opts = figment.extract::<EvmOpts>()?;
+        let verbosity = evm_opts.verbosity;
         let config = Config::from_provider(figment).sanitized();
-        let evm_version = config.evm_version;
-        if evm_opts.debug {
-            evm_opts.verbosity = 3;
-        }
 
-        let func = IntoFunction::into(self.sig.as_deref().unwrap_or("run()"));
         let BuildOutput {
             project,
             contract,
             highlevel_known_contracts,
             sources,
             predeploy_libraries,
-        } = self.build(config, &evm_opts)?;
+        } = self.build(&config, &evm_opts)?;
 
-        let mut known_contracts = highlevel_known_contracts
+        let known_contracts = highlevel_known_contracts
             .iter()
             .map(|(name, c)| {
                 (
@@ -89,168 +88,119 @@ impl Cmd for RunArgs {
             })
             .collect::<BTreeMap<String, (Abi, Vec<u8>)>>();
 
-        known_contracts.insert("VM".to_string(), (HEVM_ABI.clone(), Vec::new()));
-        known_contracts.insert("VM_CONSOLE".to_string(), (HEVMCONSOLE_ABI.clone(), Vec::new()));
-        known_contracts.insert("CONSOLE".to_string(), (CONSOLE_ABI.clone(), Vec::new()));
-
         let CompactContractBytecode { abi, bytecode, .. } = contract;
-        let abi = abi.expect("No abi for contract");
-        let bytecode = bytecode.expect("No bytecode").object.into_bytes().unwrap();
+        let abi = abi.expect("no ABI for contract");
+        let bytecode = bytecode.expect("no bytecode for contract").object.into_bytes().unwrap();
         let needs_setup = abi.functions().any(|func| func.name == "setUp");
 
-        let mut cfg = crate::utils::sputnik_cfg(&evm_version);
-        cfg.create_contract_limit = None;
-        let vicinity = evm_opts.vicinity()?;
-        let backend = evm_opts.backend(&vicinity)?;
+        let mut builder = ExecutorBuilder::new()
+            .with_cheatcodes(evm_opts.ffi)
+            .with_config(evm_opts.evm_env())
+            .with_spec(crate::utils::evm_spec(&config.evm_version));
+        if let Some(ref url) = self.evm_opts.fork_url {
+            let fork = Fork { url: url.clone(), pin_block: self.evm_opts.fork_block_number };
+            builder = builder.with_fork(fork);
+        }
+        if verbosity >= 3 {
+            builder = builder.with_tracing();
+        }
+        if evm_opts.debug {
+            builder = builder.with_tracing().with_debugger();
+        }
 
-        // need to match on the backend type
-        let result = match backend {
-            BackendKind::Simple(ref backend) => {
-                let runner = ContractRunner::new(
-                    &evm_opts,
-                    &cfg,
-                    backend,
-                    &abi,
-                    bytecode,
-                    Some(evm_opts.sender),
-                    None,
-                    &predeploy_libraries,
-                );
-                runner.run_test(&func, needs_setup, Some(&known_contracts))?
-            }
-            BackendKind::Shared(ref backend) => {
-                let runner = ContractRunner::new(
-                    &evm_opts,
-                    &cfg,
-                    backend,
-                    &abi,
-                    bytecode,
-                    Some(evm_opts.sender),
-                    None,
-                    &predeploy_libraries,
-                );
-                runner.run_test(&func, needs_setup, Some(&known_contracts))?
-            }
+        let mut result = {
+            let mut runner =
+                Runner::new(builder.build(), evm_opts.initial_balance, evm_opts.sender);
+            let (address, mut result) =
+                runner.setup(&predeploy_libraries, bytecode, needs_setup)?;
+
+            let RunResult { success, logs, traces, debug: run_debug, labeled_addresses, .. } =
+                runner
+                    .run(address, encode_args(&IntoFunction::into(self.sig), &self.args)?.into())?;
+
+            result.success &= success;
+            result.logs.extend(logs);
+            result.traces.extend(traces);
+            result.debug = run_debug;
+            result.labeled_addresses.extend(labeled_addresses);
+
+            result
         };
 
+        // Identify addresses in each trace
+        let local_identifier = LocalTraceIdentifier::new(&known_contracts);
+        let mut decoder = CallTraceDecoder::new_with_labels(result.labeled_addresses.clone());
+        for (_, trace) in &mut result.traces {
+            decoder.identify(trace, &local_identifier);
+        }
+
         if evm_opts.debug {
-            // 4. Boot up debugger
             let source_code: BTreeMap<u32, String> = sources
                 .iter()
                 .map(|(id, path)| {
-                    if let Some(resolved) =
-                        project.paths.resolve_library_import(&PathBuf::from(path))
-                    {
-                        (
-                            *id,
-                            std::fs::read_to_string(resolved).expect(&*format!(
-                                "Something went wrong reading the source file: {:?}",
-                                path
-                            )),
-                        )
-                    } else {
-                        (
-                            *id,
-                            std::fs::read_to_string(path).expect(&*format!(
-                                "Something went wrong reading the source file: {:?}",
-                                path
-                            )),
-                        )
-                    }
+                    let resolved = project
+                        .paths
+                        .resolve_library_import(&PathBuf::from(path))
+                        .unwrap_or(PathBuf::from(path));
+                    (
+                        *id,
+                        std::fs::read_to_string(resolved).expect(&*format!(
+                            "Something went wrong reading the source file: {:?}",
+                            path
+                        )),
+                    )
                 })
                 .collect();
 
-            let calls: Vec<DebugArena> = result.debug_calls.expect("Debug must be enabled by now");
-            println!("debugging");
-            let index = if needs_setup && calls.len() > 1 { 1 } else { 0 };
-            let mut flattened = Vec::new();
-            calls[index].flatten(0, &mut flattened);
-            flattened = flattened[1..].to_vec();
-            let tui = Tui::new(
-                flattened,
-                0,
-                result.identified_contracts.expect("debug but not verbosity"),
-                highlevel_known_contracts,
-                source_code,
-            )?;
+            let calls: Vec<DebugArena> = result.debug.expect("we should have collected debug info");
+            let flattened = calls.last().expect("we should have collected debug info").flatten(0);
+            let tui =
+                Tui::new(flattened, 0, decoder.contracts, highlevel_known_contracts, source_code)?;
             match tui.start().expect("Failed to start tui") {
                 TUIExitReason::CharExit => return Ok(()),
             }
-        } else if evm_opts.verbosity > 2 {
-            // support traces
-            if let (Some(traces), Some(identified_contracts)) =
-                (&result.traces, &result.identified_contracts)
-            {
-                if !result.success && evm_opts.verbosity == 3 || evm_opts.verbosity > 3 {
-                    let mut ident = identified_contracts.clone();
-                    let (funcs, events, errors) =
-                        foundry_utils::flatten_known_contracts(&known_contracts);
-                    let mut exec_info = ExecutionInfo::new(
-                        &known_contracts,
-                        &mut ident,
-                        &result.labeled_addresses,
-                        &funcs,
-                        &events,
-                        &errors,
-                    );
-                    let vm = vm();
-                    let mut trace_string = "".to_string();
-                    if evm_opts.verbosity > 4 || !result.success {
-                        // print setup calls as well
-                        traces.iter().for_each(|trace| {
-                            trace.construct_trace_string(
-                                0,
-                                &mut exec_info,
-                                &vm,
-                                "",
-                                &mut trace_string,
-                            );
-                        });
-                    } else if !traces.is_empty() {
-                        traces.last().expect("no last but not empty").construct_trace_string(
-                            0,
-                            &mut exec_info,
-                            &vm,
-                            "",
-                            &mut trace_string,
-                        );
-                    }
-                    if !trace_string.is_empty() {
-                        println!("{}", trace_string);
-                    }
-                } else {
-                    // 5. print the result nicely
-                    if result.success {
-                        println!("{}", Colour::Green.paint("Script ran successfully."));
-                    } else {
-                        println!("{}", Colour::Red.paint("Script failed."));
-                    }
-
-                    println!("Gas Used: {}", result.gas_used);
-                    println!("== Logs == ");
-                    result.logs.iter().for_each(|log| println!("{}", log));
-                }
-                println!();
-            } else if result.traces.is_none() {
-                eyre::bail!("Unexpected error: No traces despite verbosity level. Please report this as a bug: https://github.com/gakonst/foundry/issues/new?assignees=&labels=T-bug&template=BUG-FORM.yml");
-            } else if result.identified_contracts.is_none() {
-                eyre::bail!(
-                    "Unexpected error: No identified contracts. Please report this as a bug: https://github.com/gakonst/foundry/issues/new?assignees=&labels=T-bug&template=BUG-FORM.yml"
-                );
-            }
         } else {
-            // 5. print the result nicely
+            if verbosity >= 3 {
+                if result.traces.is_empty() {
+                    eyre::bail!("Unexpected error: No traces despite verbosity level. Please report this as a bug: https://github.com/gakonst/foundry/issues/new?assignees=&labels=T-bug&template=BUG-FORM.yml");
+                }
+
+                if !result.success && verbosity == 3 || verbosity > 3 {
+                    println!("Traces:");
+                    for (kind, trace) in &mut result.traces {
+                        let should_include = match kind {
+                            TraceKind::Setup => {
+                                (verbosity >= 5) || (verbosity == 4 && !result.success)
+                            }
+                            TraceKind::Execution => verbosity > 3 || !result.success,
+                            _ => false,
+                        };
+
+                        if should_include {
+                            decoder.decode(trace);
+                            println!("{}", trace);
+                        }
+                    }
+                    println!();
+                }
+            }
+
             if result.success {
                 println!("{}", Colour::Green.paint("Script ran successfully."));
             } else {
                 println!("{}", Colour::Red.paint("Script failed."));
             }
 
-            println!("Gas Used: {}", result.gas_used);
-            println!("== Logs ==");
-            result.logs.iter().for_each(|log| println!("{}", log));
+            println!("Gas used: {}", result.gas_used);
+            println!("== Logs == ");
+            let console_logs = decode_console_logs(&result.logs);
+            if !console_logs.is_empty() {
+                println!("Logs:");
+                for log in console_logs {
+                    println!("  {}", log);
+                }
+            }
         }
-
         Ok(())
     }
 }
@@ -273,7 +223,7 @@ pub struct BuildOutput {
 
 impl RunArgs {
     /// Compiles the file with auto-detection and compiler params.
-    pub fn build(&self, config: Config, evm_opts: &EvmOpts) -> eyre::Result<BuildOutput> {
+    pub fn build(&self, config: &Config, evm_opts: &EvmOpts) -> eyre::Result<BuildOutput> {
         let target_contract = dunce::canonicalize(&self.path)?;
         let project = config.ephemeral_no_artifacts_project()?;
         let output = compile_files(&project, vec![target_contract])?;
@@ -352,6 +302,136 @@ impl RunArgs {
             highlevel_known_contracts,
             sources: sources.into_ids().collect(),
             predeploy_libraries: run_dependencies,
+        })
+    }
+}
+
+struct RunResult {
+    pub success: bool,
+    pub logs: Vec<RawLog>,
+    pub traces: Vec<(TraceKind, CallTraceArena)>,
+    pub debug: Option<Vec<DebugArena>>,
+    pub gas_used: u64,
+    pub labeled_addresses: BTreeMap<Address, String>,
+}
+
+struct Runner<DB: DatabaseRef> {
+    pub executor: Executor<DB>,
+    pub initial_balance: U256,
+    pub sender: Address,
+}
+
+impl<DB: DatabaseRef> Runner<DB> {
+    pub fn new(executor: Executor<DB>, initial_balance: U256, sender: Address) -> Self {
+        Self { executor, initial_balance, sender }
+    }
+
+    pub fn setup(
+        &mut self,
+        libraries: &[Bytes],
+        code: Bytes,
+        setup: bool,
+    ) -> eyre::Result<(Address, RunResult)> {
+        // We max out their balance so that they can deploy and make calls.
+        self.executor.set_balance(self.sender, U256::MAX);
+        self.executor.set_balance(*CALLER, U256::MAX);
+
+        // We set the nonce of the deployer accounts to 1 to get the same addresses as DappTools
+        self.executor.set_nonce(self.sender, 1);
+
+        // Deploy libraries
+        let mut traces: Vec<(TraceKind, CallTraceArena)> = libraries
+            .iter()
+            .filter_map(|code| {
+                let DeployResult { traces, .. } = self
+                    .executor
+                    .deploy(self.sender, code.0.clone(), 0u32.into())
+                    .expect("couldn't deploy library");
+
+                traces
+            })
+            .map(|traces| (TraceKind::Deployment, traces))
+            .collect();
+
+        // Deploy an instance of the contract
+        let DeployResult {
+            address,
+            mut logs,
+            traces: constructor_traces,
+            debug: constructor_debug,
+            ..
+        } = self
+            .executor
+            .deploy(self.sender, code.0.clone(), 0u32.into())
+            .expect("couldn't deploy");
+        traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
+        self.executor.set_balance(address, self.initial_balance);
+
+        // Optionally call the `setUp` function
+        Ok(if setup {
+            match self.executor.setup(address) {
+                Ok(CallResult {
+                    traces: setup_traces,
+                    labels,
+                    logs: setup_logs,
+                    debug,
+                    gas: gas_used,
+                    ..
+                }) |
+                Err(EvmError::Execution {
+                    traces: setup_traces,
+                    labels,
+                    logs: setup_logs,
+                    debug,
+                    gas_used,
+                    ..
+                }) => {
+                    traces
+                        .extend(setup_traces.map(|traces| (TraceKind::Setup, traces)).into_iter());
+                    logs.extend_from_slice(&setup_logs);
+
+                    (
+                        address,
+                        RunResult {
+                            logs,
+                            traces,
+                            labeled_addresses: labels,
+                            // TODO
+                            success: true,
+                            debug: vec![constructor_debug, debug].into_iter().collect(),
+                            gas_used,
+                        },
+                    )
+                }
+                Err(e) => return Err(e.into()),
+            }
+        } else {
+            (
+                address,
+                RunResult {
+                    logs,
+                    traces,
+                    // TODO
+                    success: true,
+                    debug: vec![constructor_debug].into_iter().collect(),
+                    gas_used: 0,
+                    labeled_addresses: Default::default(),
+                },
+            )
+        })
+    }
+
+    pub fn run(&mut self, address: Address, calldata: Bytes) -> eyre::Result<RunResult> {
+        let RawCallResult { status, gas, logs, traces, labels, debug, .. } =
+            self.executor.call_raw(self.sender, address, calldata.0, 0.into())?;
+        Ok(RunResult {
+            // TODO
+            success: true,
+            gas_used: gas,
+            logs,
+            traces: traces.map(|traces| vec![(TraceKind::Execution, traces)]).unwrap_or_default(),
+            debug: vec![debug].into_iter().collect(),
+            labeled_addresses: labels,
         })
     }
 }

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -141,7 +141,7 @@ impl Cmd for RunArgs {
                     let resolved = project
                         .paths
                         .resolve_library_import(&PathBuf::from(path))
-                        .unwrap_or(PathBuf::from(path));
+                        .unwrap_or_else(|| PathBuf::from(path));
                     (
                         *id,
                         std::fs::read_to_string(resolved).expect(&*format!(
@@ -360,10 +360,7 @@ impl<DB: DatabaseRef> Runner<DB> {
             traces: constructor_traces,
             debug: constructor_debug,
             ..
-        } = self
-            .executor
-            .deploy(self.sender, code.0.clone(), 0u32.into())
-            .expect("couldn't deploy");
+        } = self.executor.deploy(self.sender, code.0, 0u32.into()).expect("couldn't deploy");
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
         self.executor.set_balance(address, self.initial_balance);
 
@@ -422,7 +419,7 @@ impl<DB: DatabaseRef> Runner<DB> {
     }
 
     pub fn run(&mut self, address: Address, calldata: Bytes) -> eyre::Result<RunResult> {
-        let RawCallResult { status, gas, logs, traces, labels, debug, .. } =
+        let RawCallResult { status: _status, gas, logs, traces, labels, debug, .. } =
             self.executor.call_raw(self.sender, address, calldata.0, 0.into())?;
         Ok(RunResult {
             // TODO

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -1,79 +1,52 @@
 //! Test command
-
 use crate::{
-    cmd::{build::BuildArgs, Cmd},
+    cmd::{build::BuildArgs, run::RunArgs, Cmd},
     opts::evm::EvmArgs,
     utils,
 };
 use ansi_term::Colour;
 use clap::{AppSettings, Parser};
-use ethers::solc::{ArtifactOutput, ProjectCompileOutput};
 use forge::{
     decode::decode_console_logs,
     executor::opts::EvmOpts,
     gas_report::GasReport,
     trace::{identifier::LocalTraceIdentifier, CallTraceDecoder, TraceKind},
-    MultiContractRunnerBuilder, TestFilter, TestResult,
+    MultiContractRunner, MultiContractRunnerBuilder, TestFilter, TestKind, TestResult,
 };
 use foundry_config::{figment::Figment, Config};
 use regex::Regex;
-use std::{collections::BTreeMap, str::FromStr, sync::mpsc::channel, thread};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::mpsc::channel, thread};
 
 #[derive(Debug, Clone, Parser)]
 pub struct Filter {
-    #[clap(
-        long = "match",
-        short = 'm',
-        help = "only run test methods matching regex (deprecated, see --match-test)"
-    )]
+    /// Only run test functions matching the specified pattern.
+    ///
+    /// Deprecated: See --match-test
+    #[clap(long = "match", short = 'm')]
     pub pattern: Option<regex::Regex>,
 
-    #[clap(
-        long = "match-test",
-        alias = "mt",
-        help = "only run test methods matching regex",
-        conflicts_with = "pattern"
-    )]
+    /// Only run test functions matching the specified pattern.
+    #[clap(long = "match-test", alias = "mt", conflicts_with = "pattern")]
     pub test_pattern: Option<regex::Regex>,
 
-    #[clap(
-        long = "no-match-test",
-        alias = "nmt",
-        help = "only run test methods not matching regex",
-        conflicts_with = "pattern"
-    )]
+    /// Only run test functions that do not match the specified pattern.
+    #[clap(long = "no-match-test", alias = "nmt", conflicts_with = "pattern")]
     pub test_pattern_inverse: Option<regex::Regex>,
 
-    #[clap(
-        long = "match-contract",
-        alias = "mc",
-        help = "only run test methods in contracts matching regex",
-        conflicts_with = "pattern"
-    )]
+    /// Only run tests in contracts matching the specified pattern.
+    #[clap(long = "match-contract", alias = "mc", conflicts_with = "pattern")]
     pub contract_pattern: Option<regex::Regex>,
 
-    #[clap(
-        long = "no-match-contract",
-        alias = "nmc",
-        help = "only run test methods in contracts not matching regex",
-        conflicts_with = "pattern"
-    )]
+    /// Only run tests in contracts that do not match the specified pattern.
+    #[clap(long = "no-match-contract", alias = "nmc", conflicts_with = "pattern")]
     contract_pattern_inverse: Option<regex::Regex>,
 
-    #[clap(
-        long = "match-path",
-        alias = "mp",
-        help = "only run test methods in source files at path matching regex. Requires absolute path",
-        conflicts_with = "pattern"
-    )]
+    /// Only run tests in source files matching the specified pattern.
+    #[clap(long = "match-path", alias = "mp", conflicts_with = "pattern")]
     pub path_pattern: Option<regex::Regex>,
 
-    #[clap(
-        long = "no-match-path",
-        alias = "nmp",
-        help = "only run test methods in source files at path not matching regex. Requires absolute path",
-        conflicts_with = "pattern"
-    )]
+    /// Only run tests in source files that do not match the specified pattern.
+    #[clap(long = "no-match-path", alias = "nmp", conflicts_with = "pattern")]
     pub path_pattern_inverse: Option<regex::Regex>,
 }
 
@@ -125,30 +98,46 @@ impl TestFilter for Filter {
 foundry_config::impl_figment_convert!(TestArgs, opts, evm_opts);
 
 #[derive(Debug, Clone, Parser)]
-// This is required to group Filter options in help output
 #[clap(global_setting = AppSettings::DeriveDisplayOrder)]
 pub struct TestArgs {
-    #[clap(help = "print the test results in json format", long, short)]
-    json: bool,
-
-    #[clap(help = "print a gas report", long = "gas-report")]
-    gas_report: bool,
-
-    #[clap(flatten)]
-    evm_opts: EvmArgs,
-
     #[clap(flatten)]
     filter: Filter,
 
-    #[clap(flatten)]
-    opts: BuildArgs,
+    /// Run a test in the debugger.
+    ///
+    /// The argument passed to this flag is the name of the test function you want to run, and it
+    /// works the same as --match-test.
+    ///
+    /// If more than one test matches your specified criteria, you must add additional filters
+    /// until only one test is found (see --match-contract and --match-path).
+    ///
+    /// The matching test will be opened in the debugger regardless of the outcome of the test.
+    ///
+    /// If the matching test is a fuzz test, then it will open the debugger on the first failure
+    /// case.
+    /// If the fuzz test does not fail, it will open the debugger on the last fuzz case.
+    ///
+    /// For more fine-grained control of which fuzz case is run, see forge run.
+    #[clap(long, value_name = "TEST FUNCTION")]
+    debug: Option<Regex>,
 
-    #[clap(
-        help = "if set to true, the process will exit with an exit code = 0, even if the tests fail",
-        long,
-        env = "FORGE_ALLOW_FAILURE"
-    )]
+    /// Print a gas report.
+    #[clap(long = "gas-report")]
+    gas_report: bool,
+
+    /// Force the process to exit with code 0, even if the tests fail.
+    #[clap(long, env = "FORGE_ALLOW_FAILURE")]
     allow_failure: bool,
+
+    /// Output test results in JSON format.
+    #[clap(long, short)]
+    json: bool,
+
+    #[clap(flatten, next_help_heading = "EVM OPTIONS")]
+    evm_opts: EvmArgs,
+
+    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    opts: BuildArgs,
 }
 
 impl TestArgs {
@@ -166,13 +155,11 @@ impl TestArgs {
 impl Cmd for TestArgs {
     type Output = TestOutcome;
 
-    fn run(self) -> eyre::Result<Self::Output> {
-        // merge all configs
+    fn run(mut self) -> eyre::Result<Self::Output> {
+        // Merge all configs
         let figment: Figment = From::from(&self);
-        let evm_opts = figment.extract::<EvmOpts>()?;
+        let mut evm_opts = figment.extract::<EvmOpts>()?;
         let config = Config::from_provider(figment).sanitized();
-
-        let TestArgs { json, filter, allow_failure, .. } = self;
 
         // Setup the fuzzer
         // TODO: Add CLI Options to modify the persistence
@@ -189,23 +176,76 @@ impl Cmd for TestArgs {
         let project = config.project()?;
         let output = super::compile(&project, false, false)?;
 
-        // prepare the test builder
+        // Determine print verbosity and executor verbosity
+        let verbosity = evm_opts.verbosity;
+        if self.gas_report && evm_opts.verbosity < 3 {
+            evm_opts.verbosity = 3;
+        }
+
+        // Prepare the test builder
         let evm_spec = crate::utils::evm_spec(&config.evm_version);
-        let builder = MultiContractRunnerBuilder::default()
+        let mut runner = MultiContractRunnerBuilder::default()
             .fuzzer(fuzzer)
             .initial_balance(evm_opts.initial_balance)
             .evm_spec(evm_spec)
-            .sender(evm_opts.sender);
+            .sender(evm_opts.sender)
+            .build(output, evm_opts)?;
 
-        test(
-            builder,
-            output,
-            evm_opts,
-            filter,
-            json,
-            allow_failure,
-            (self.gas_report, config.gas_reports),
-        )
+        if self.debug.is_some() {
+            self.filter.test_pattern = self.debug;
+            match runner.count_filtered_tests(&self.filter) {
+                1 => {
+                    // Run the test
+                    let results = runner.test(&self.filter, None)?;
+
+                    // Get the result of the single test
+                    let (id, sig, test_kind, counterexample) = results.iter().map(|(id, results)| {
+                        let (sig, result) = results.iter().next().unwrap();
+
+                        (id.clone(), sig.clone(), result.kind.clone(), result.counterexample.clone())
+                    }).next().unwrap();
+
+                    // Build debugger args if this is a fuzz test
+                    let sig = match test_kind {
+                        TestKind::Fuzz(cases) => {
+                            if let Some(counterexample) = counterexample {
+                                counterexample.calldata.to_string()
+                            } else {
+                                cases.cases().first().expect("no fuzz cases run").calldata.to_string()
+                            }
+                        },
+                        _ => sig,
+                    };
+
+                    // Run the debugger
+                    let debugger = RunArgs {
+                        path: PathBuf::from(runner.source_paths.get(&id).unwrap()),
+                        target_contract: Some(utils::get_contract_name(&id).to_string()),
+                        sig,
+                        args: Vec::new(),
+                        debug: true,
+                        opts: self.opts,
+                        evm_opts: self.evm_opts,
+                    };
+                    debugger.run()?;
+
+                    Ok(TestOutcome::new(results, self.allow_failure))
+                }
+                n =>
+                    Err(
+                    eyre::eyre!("{} tests matched your criteria, but exactly 1 test must match in order to run the debugger.", n))
+            }
+        } else {
+            let TestArgs { filter, .. } = self;
+            test(
+                runner,
+                verbosity,
+                filter,
+                self.json,
+                self.allow_failure,
+                (self.gas_report, config.gas_reports),
+            )
+        }
     }
 }
 
@@ -324,22 +364,14 @@ fn short_test_result(name: &str, result: &forge::TestResult) {
 }
 
 /// Runs all the tests
-fn test<A: ArtifactOutput + 'static>(
-    builder: MultiContractRunnerBuilder,
-    output: ProjectCompileOutput<A>,
-    mut evm_opts: EvmOpts,
+fn test(
+    mut runner: MultiContractRunner,
+    verbosity: u8,
     filter: Filter,
     json: bool,
     allow_failure: bool,
     (gas_reporting, gas_reports): (bool, Vec<String>),
 ) -> eyre::Result<TestOutcome> {
-    let verbosity = evm_opts.verbosity;
-    if gas_reporting && evm_opts.verbosity < 3 {
-        // Enable tracing without hitting the verbosity print path
-        evm_opts.verbosity = 3;
-    }
-    let mut runner = builder.build(output, evm_opts)?;
-
     if json {
         let results = runner.test(&filter, None)?;
         println!("{}", serde_json::to_string(&results)?);

--- a/cli/src/cmd/test.rs
+++ b/cli/src/cmd/test.rs
@@ -233,7 +233,9 @@ impl Cmd for TestArgs {
                 }
                 n =>
                     Err(
-                    eyre::eyre!("{} tests matched your criteria, but exactly 1 test must match in order to run the debugger.", n))
+                    eyre::eyre!("{} tests matched your criteria, but exactly 1 test must match in order to run the debugger.\n
+                        \n
+                        Use --match-contract and --match-path to further limit the search.", n))
             }
         } else {
             let TestArgs { filter, .. } = self;

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -36,10 +36,9 @@ fn main() -> eyre::Result<()> {
                 cmd.run()?;
             }
         }
-        // TODO: Re-enable when ported
-        //Subcommands::Run(cmd) => {
-        //    cmd.run()?;
-        //}
+        Subcommands::Run(cmd) => {
+            cmd.run()?;
+        }
         Subcommands::VerifyContract(args) => {
             utils::block_on(cmd::verify::run_verify(&args))?;
         }

--- a/cli/src/opts/evm.rs
+++ b/cli/src/opts/evm.rs
@@ -35,47 +35,52 @@ use serde::Serialize;
 // See also [`BuildArgs`]
 #[derive(Debug, Clone, Parser, Serialize)]
 pub struct EvmArgs {
-    #[clap(flatten)]
-    #[serde(flatten)]
-    pub env: EnvArgs,
-
-    #[clap(help = "fetch state over a remote instead of starting from empty state", long, short)]
+    /// Fetch state over a remote endpoint instead of starting from an empty state.
+    ///
+    /// If you want to fetch state from a specific block number, see --fork-block-number.
+    #[clap(long, short, alias = "rpc-url")]
     #[clap(alias = "rpc-url")]
     #[serde(rename = "eth_rpc_url", skip_serializing_if = "Option::is_none")]
     pub fork_url: Option<String>,
 
-    #[clap(help = "pins the block number for the state fork", long)]
+    /// Fetch state from a specific block number over a remote endpoint.
+    ///
+    /// See --fork-url.
+    #[clap(long, requires = "fork-url")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_block_number: Option<u64>,
 
-    #[clap(help = "the initial balance of each deployed test contract", long)]
+    /// The initial balance of deployed test contracts.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_balance: Option<U256>,
 
-    #[clap(help = "the address which will be executing all tests", long)]
+    /// The address which will be executing tests.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sender: Option<Address>,
 
+    /// Enable the FFI cheatcode.
     #[clap(help = "enables the FFI cheatcode", long)]
     #[serde(skip)]
     pub ffi: bool,
 
-    #[clap(
-        help = r#"Verbosity mode of EVM output as number of occurences of the `v` flag (-v, -vv, -vvv, etc.)
-    2: print test logs for all tests
-    3: print test trace for failing tests
-    4: always print test trace, print setup for failing tests
-    5: always print test trace and setup
-"#,
-        long,
-        short,
-        parse(from_occurrences)
-    )]
+    /// Verbosity of the EVM.
+    ///
+    /// Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+    ///
+    /// Verbosity levels:
+    ///   2: Print logs for all tests
+    ///   3: Print execution traces for failing tests
+    ///   4: Print execution traces for all tests, and setup traces for failing tests
+    ///   5: Print execution and setup traces for all tests
+    #[clap(long, short, parse(from_occurrences))]
     #[serde(skip)]
     pub verbosity: u8,
 
-    #[clap(help = "enable debugger", long)]
-    pub debug: bool,
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub env: EnvArgs,
 }
 
 // Make this set of options a `figment::Provider` so that it can be merged into the `Config`
@@ -102,46 +107,57 @@ impl Provider for EvmArgs {
     }
 }
 
+/// Configures the executor environment during tests.
 #[derive(Debug, Clone, Default, Parser, Serialize)]
+#[clap(next_help_heading = "EXECUTOR ENVIRONMENT CONFIG")]
 pub struct EnvArgs {
-    // structopt does not let use `u64::MAX`:
-    // https://doc.rust-lang.org/std/primitive.u64.html#associatedconstant.MAX
-    #[clap(help = "the block gas limit", long)]
+    /// The block gas limit.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_limit: Option<u64>,
 
-    #[clap(help = "the chainid opcode value", long)]
+    /// The chain ID.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chain_id: Option<u64>,
 
-    #[clap(help = "the tx.gasprice value during EVM execution", long)]
+    /// The gas price.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_price: Option<u64>,
 
-    #[clap(help = "the base fee in a block", long)]
+    /// The base fee in a block.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_base_fee_per_gas: Option<u64>,
 
-    #[clap(help = "the tx.origin value during EVM execution", long)]
+    /// The transaction origin.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_origin: Option<Address>,
 
-    #[clap(help = "the block.coinbase value during EVM execution", long)]
+    /// The coinbase of the block.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_coinbase: Option<Address>,
-    #[clap(help = "the block.timestamp value during EVM execution", long)]
+
+    /// The timestamp of the block.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_timestamp: Option<u64>,
 
-    #[clap(help = "the block.number value during EVM execution", long)]
+    /// The block number.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_number: Option<u64>,
 
-    #[clap(help = "the block.difficulty value during EVM execution", long)]
+    /// The block difficulty.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_difficulty: Option<u64>,
 
-    #[clap(help = "the block.gaslimit value during EVM execution", long)]
+    /// The block gas limit.
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_gas_limit: Option<u64>,
 }

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -13,6 +13,7 @@ use crate::cmd::{
     inspect,
     install::InstallArgs,
     remappings::RemappingArgs,
+    run::RunArgs,
     snapshot, test, tree,
     verify::{VerifyArgs, VerifyCheckArgs},
 };
@@ -46,10 +47,10 @@ pub enum Subcommands {
     #[clap(alias = "b")]
     Build(BuildArgs),
 
-    // TODO: Re-enable when ported
-    //#[clap(about = "Run a single smart contract as a script")]
-    //#[clap(alias = "r")]
-    //Run(RunArgs),
+    #[clap(about = "Run a single smart contract as a script")]
+    #[clap(alias = "r")]
+    Run(RunArgs),
+
     #[clap(alias = "u", about = "Fetches all upstream lib changes")]
     Update {
         #[clap(

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -163,7 +163,7 @@ impl TestProject {
 
     /// Adds DSTest as a source under "test.sol"
     pub fn insert_ds_test(&self) -> PathBuf {
-        let s = include_str!("../../../evm-adapters/testdata/DsTest.sol");
+        let s = include_str!("../../../forge/testdata/DsTest.sol");
         self.inner().add_source("test.sol", s).unwrap()
     }
 

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -458,7 +458,8 @@ Compiler run successful
     ));
 });
 
-// tests that the `run` command works correctly
+// Tests that the `run` command works correctly
+// TODO: The original gas usage was "1751" before the REVM port. It should be changed back
 forgetest!(can_execute_run_command, |prj: TestProject, mut cmd: TestCommand| {
     let script = prj
         .inner()
@@ -480,12 +481,80 @@ contract Demo {
     cmd.arg("run").arg(script);
     let output = cmd.stdout_lossy();
     assert!(output.ends_with(&format!(
-        "
-Compiler run successful
+        "Compiler run successful
 {}
-Gas Used: 1751
+Gas used: 22815
 == Logs ==
-script ran
+  script ran
+",
+        Colour::Green.paint("Script ran successfully.")
+    ),));
+});
+
+// Tests that the run command can run arbitrary functions
+forgetest!(can_execute_run_command_with_sig, |prj: TestProject, mut cmd: TestCommand| {
+    let script = prj
+        .inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+contract Demo {
+    event log_string(string);
+    function myFunction() external {
+        emit log_string("script ran");
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.arg("run").arg(script).arg("--sig").arg("myFunction()");
+    let output = cmd.stdout_lossy();
+    assert!(output.ends_with(&format!(
+        "Compiler run successful
+{}
+Gas used: 22815
+== Logs ==
+  script ran
+",
+        Colour::Green.paint("Script ran successfully.")
+    ),));
+});
+
+// Tests that the run command can run functions with arguments
+forgetest!(can_execute_run_command_with_args, |prj: TestProject, mut cmd: TestCommand| {
+    let script = prj
+        .inner()
+        .add_source(
+            "Foo",
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.10;
+contract Demo {
+    event log_string(string);
+    event log_uint(uint);
+    function run(uint256 a, uint256 b) external {
+        emit log_string("script ran");
+        emit log_uint(a);
+        emit log_uint(b);
+    }
+}
+   "#,
+        )
+        .unwrap();
+
+    cmd.arg("run").arg(script).arg("--sig").arg("run(uint256,uint256)").arg("1").arg("2");
+    let output = cmd.stdout_lossy();
+    assert!(output.ends_with(&format!(
+        "Compiler run successful
+{}
+Gas used: 25301
+== Logs ==
+  script ran
+  1
+  2
 ",
         Colour::Green.paint("Script ran successfully.")
     ),));

--- a/forge/src/debugger.rs
+++ b/forge/src/debugger.rs
@@ -149,31 +149,6 @@ impl DebugStep {
     }
 }
 
-impl Display for DebugStep {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(push_bytes) = &self.push_bytes {
-            write!(
-                f,
-                "pc: {:?}\nop: {}(0x{})\nstack: {:#?}\nmemory: 0x{}\n\n",
-                self.pc,
-                self.instruction,
-                hex::encode(push_bytes),
-                self.stack,
-                hex::encode(self.memory.data())
-            )
-        } else {
-            write!(
-                f,
-                "pc: {:?}\nop: {}\nstack: {:#?}\nmemory: 0x{}\n\n",
-                self.pc,
-                self.instruction,
-                self.stack,
-                hex::encode(self.memory.data())
-            )
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone)]
 pub enum Instruction {
     OpCode(u8),

--- a/forge/src/debugger.rs
+++ b/forge/src/debugger.rs
@@ -1,0 +1,268 @@
+use ethers::types::{Address, H256};
+use revm::{Memory, OpCode};
+use std::{borrow::Cow, fmt::Display};
+
+/// An arena of `DebugNode`s
+#[derive(Debug, Clone)]
+pub struct DebugArena {
+    /// The arena of nodes
+    pub arena: Vec<DebugNode>,
+}
+
+impl Default for DebugArena {
+    fn default() -> Self {
+        DebugArena { arena: vec![Default::default()] }
+    }
+}
+
+impl DebugArena {
+    /// Pushes a new debug node into the arena
+    pub fn push_node(&mut self, entry: usize, mut new_node: DebugNode) {
+        match new_node.depth {
+            // The entry node, just update it
+            0 => {
+                self.arena[entry] = new_node;
+            }
+            // We found the parent node, add the new node as a child
+            _ if self.arena[entry].depth == new_node.depth - 1 => {
+                new_node.idx = self.arena.len();
+                new_node.location = self.arena[entry].children.len();
+                self.arena[entry].children.push(new_node.idx);
+                self.arena.push(new_node);
+            }
+            // We haven't found the parent node, go deeper
+            _ => self.push_node(
+                *self.arena[entry].children.last().expect("Disconnected debug node"),
+                new_node,
+            ),
+        }
+    }
+
+    /// Recursively traverses the tree of debug nodes and flattens it into a [Vec] where each
+    /// item contains:
+    ///
+    /// - The address of the contract being executed
+    /// - A [Vec] of debug steps along that contract's execution path
+    /// - A boolean denoting
+    /// Recursively traverses the tree of debug step nodes and flattens it into a
+    /// vector where each element contains
+    /// 1. the address of the contract being executed
+    /// 2. a vector of all the debug steps along that contract's execution path.
+    /// 3. Whether the contract was created in this node or not
+    ///
+    /// This makes it easy to pretty print the execution steps.
+    pub fn flatten(&self, entry: usize, flattened: &mut Vec<(Address, Vec<DebugStep>, bool)>) {
+        let node = &self.arena[entry];
+        flattened.push((node.address, node.steps.clone(), node.creation));
+        node.children.iter().for_each(|child| {
+            self.flatten(*child, flattened);
+        });
+    }
+}
+
+/// A node in the arena
+#[derive(Default, Debug, Clone)]
+pub struct DebugNode {
+    /// Parent node index in the arena
+    pub parent: Option<usize>,
+    /// Children node indexes in the arena
+    pub children: Vec<usize>,
+    /// Location in parent
+    pub location: usize,
+    /// This node's index in the arena
+    pub idx: usize,
+    /// Address context
+    pub address: Address,
+    /// Depth
+    pub depth: usize,
+    /// The debug steps
+    pub steps: Vec<DebugStep>,
+    /// Whether the contract was created in this node or not
+    pub creation: bool,
+}
+
+impl DebugNode {
+    pub fn new(address: Address, depth: usize, steps: Vec<DebugStep>) -> Self {
+        Self { address, depth, steps, ..Default::default() }
+    }
+}
+
+/// A `DebugStep` is a snapshot of the EVM's runtime state.
+///
+/// It holds the current program counter (where in the program you are),
+/// the stack and memory (prior to the opcodes execution), any bytes to be
+/// pushed onto the stack, and the instruction counter for use with sourcemap.
+#[derive(Debug, Clone)]
+pub struct DebugStep {
+    /// The program counter
+    pub pc: usize,
+    /// Stack *prior* to running the associated opcode
+    pub stack: Vec<H256>,
+    /// Memory *prior* to running the associated opcode
+    pub memory: Memory,
+    /// Opcode to be executed
+    pub instruction: Instruction,
+    /// Optional bytes that are being pushed onto the stack
+    pub push_bytes: Option<Vec<u8>>,
+    /// Instruction counter, used to map this instruction to source code
+    pub ic: usize,
+    /// Cumulative gas usage
+    pub total_gas_used: u64,
+}
+
+impl Default for DebugStep {
+    fn default() -> Self {
+        Self {
+            pc: 0,
+            stack: vec![],
+            memory: Memory::new(),
+            instruction: Instruction::OpCode(revm::opcode::INVALID),
+            push_bytes: None,
+            ic: 0,
+            total_gas_used: 0,
+        }
+    }
+}
+
+impl DebugStep {
+    /// Pretty print the step's opcode
+    pub fn pretty_opcode(&self) -> String {
+        if let Some(push_bytes) = &self.push_bytes {
+            format!("{}(0x{})", self.instruction, hex::encode(push_bytes))
+        } else {
+            self.instruction.to_string()
+        }
+    }
+}
+
+impl Display for DebugStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(push_bytes) = &self.push_bytes {
+            write!(
+                f,
+                "pc: {:?}\nop: {}(0x{})\nstack: {:#?}\nmemory: 0x{}\n\n",
+                self.pc,
+                self.instruction,
+                hex::encode(push_bytes),
+                self.stack,
+                hex::encode(self.memory.data())
+            )
+        } else {
+            write!(
+                f,
+                "pc: {:?}\nop: {}\nstack: {:#?}\nmemory: 0x{}\n\n",
+                self.pc,
+                self.instruction,
+                self.stack,
+                hex::encode(self.memory.data())
+            )
+        }
+    }
+}
+
+/// Forge specific identifiers for cheatcodes
+#[derive(Debug, Copy, Clone)]
+pub enum CheatOp {
+    ROLL,
+    WARP,
+    FEE,
+    STORE,
+    LOAD,
+    FFI,
+    ADDR,
+    SIGN,
+    PRANK,
+    STARTPRANK,
+    STOPPRANK,
+    DEAL,
+    ETCH,
+    EXPECTREVERT,
+    RECORD,
+    ACCESSES,
+    EXPECTEMIT,
+    MOCKCALL,
+    CLEARMOCKEDCALLS,
+    EXPECTCALL,
+    GETCODE,
+    LABEL,
+    ASSUME,
+}
+
+impl From<CheatOp> for Instruction {
+    fn from(cheat: CheatOp) -> Instruction {
+        Instruction::Cheatcode(cheat)
+    }
+}
+
+impl CheatOp {
+    /// Gets the name of the cheatcode
+    pub const fn name(&self) -> &'static str {
+        match self {
+            CheatOp::ROLL => "VM_ROLL",
+            CheatOp::WARP => "VM_WARP",
+            CheatOp::FEE => "VM_FEE",
+            CheatOp::STORE => "VM_STORE",
+            CheatOp::LOAD => "VM_LOAD",
+            CheatOp::FFI => "VM_FFI",
+            CheatOp::ADDR => "VM_ADDR",
+            CheatOp::SIGN => "VM_SIGN",
+            CheatOp::PRANK => "VM_PRANK",
+            CheatOp::STARTPRANK => "VM_STARTPRANK",
+            CheatOp::STOPPRANK => "VM_STOPPRANK",
+            CheatOp::DEAL => "VM_DEAL",
+            CheatOp::ETCH => "VM_ETCH",
+            CheatOp::EXPECTREVERT => "VM_EXPECTREVERT",
+            CheatOp::RECORD => "VM_RECORD",
+            CheatOp::ACCESSES => "VM_ACCESSES",
+            CheatOp::EXPECTEMIT => "VM_EXPECTEMIT",
+            CheatOp::MOCKCALL => "VM_MOCKCALL",
+            CheatOp::CLEARMOCKEDCALLS => "VM_CLEARMOCKEDCALLS",
+            CheatOp::EXPECTCALL => "VM_EXPECTCALL",
+            CheatOp::GETCODE => "VM_GETCODE",
+            CheatOp::LABEL => "VM_LABEL",
+            CheatOp::ASSUME => "VM_ASSUME",
+        }
+    }
+}
+
+impl Default for CheatOp {
+    fn default() -> Self {
+        CheatOp::ROLL
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Instruction {
+    OpCode(u8),
+    Cheatcode(CheatOp),
+}
+
+impl From<u8> for Instruction {
+    fn from(op: u8) -> Instruction {
+        Instruction::OpCode(op)
+    }
+}
+
+impl Instruction {
+    /// The number of bytes being pushed by this instruction, if it is a push.
+    pub fn push_size(self) -> Option<u8> {
+        match self {
+            Instruction::OpCode(op) => OpCode::is_push(op),
+            _ => None,
+        }
+    }
+}
+
+impl Display for Instruction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Instruction::OpCode(op) => OpCode::try_from_u8(*op).map_or_else(
+                || Cow::Owned(format!("UNDEFINED(0x{:02x})", op)),
+                |opcode| Cow::Borrowed(opcode.as_str()),
+            ),
+            Instruction::Cheatcode(cheat) => Cow::Borrowed(cheat.name()),
+        };
+
+        write!(f, "{}", name)
+    }
+}

--- a/forge/src/executor/builder.rs
+++ b/forge/src/executor/builder.rs
@@ -105,6 +105,13 @@ impl ExecutorBuilder {
         self
     }
 
+    /// Enables the debugger
+    #[must_use]
+    pub fn with_debugger(mut self) -> Self {
+        self.inspector_config.debugger = true;
+        self
+    }
+
     /// Sets the EVM spec to use
     #[must_use]
     pub fn with_spec(mut self, spec: SpecId) -> Self {
@@ -131,6 +138,4 @@ impl ExecutorBuilder {
         let db = Backend::new(self.fork);
         Executor::new(db, self.env, self.inspector_config)
     }
-
-    // TODO: add with_debug(ger?)
 }

--- a/forge/src/executor/fuzz/mod.rs
+++ b/forge/src/executor/fuzz/mod.rs
@@ -77,7 +77,7 @@ where
 
             let success = self.executor.is_success(
                 address,
-                call.status,
+                call.reverted,
                 call.state_changeset.clone().expect("we should have a state changeset"),
                 should_fail,
             );

--- a/forge/src/executor/inspector/debugger.rs
+++ b/forge/src/executor/inspector/debugger.rs
@@ -1,0 +1,202 @@
+use crate::{
+    debugger::{DebugArena, DebugNode, DebugStep, Instruction},
+    executor::CHEATCODE_ADDRESS,
+};
+use bytes::Bytes;
+use ethers::{
+    types::Address,
+    utils::{get_contract_address, get_create2_address},
+};
+use revm::{
+    CallInputs, CreateInputs, CreateScheme, Database, EVMData, Gas, Inspector, Interpreter, Memory,
+    OpCode, Return,
+};
+use std::collections::BTreeMap;
+
+/// An inspector that collects debug nodes on every step of the interpreter.
+#[derive(Default, Debug)]
+pub struct Debugger {
+    /// The arena of [DebugNode]s
+    pub arena: DebugArena,
+    /// The ID of the current [DebugNode].
+    pub head: usize,
+    /// A mapping of program counters to instruction counters.
+    ///
+    /// The program counter keeps track of where we are in the contract bytecode as a whole,
+    /// including push bytes, while the instruction counter ignores push bytes.
+    ///
+    /// The instruction counter is used in Solidity source maps.
+    pub ic_map: BTreeMap<Address, BTreeMap<usize, usize>>,
+}
+
+impl Debugger {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Builds the instruction counter map for the given bytecode.
+    // TODO: Some of the same logic is performed in REVM, but then later discarded. We should
+    // investigate if we can reuse it
+    pub fn build_ic_map(&mut self, address: &Address, code: &Bytes) {
+        let mut ic_map: BTreeMap<usize, usize> = BTreeMap::new();
+
+        let mut i = 0;
+        let mut cumulative_push_size = 0;
+        while i < code.len() {
+            let op = code[i];
+            ic_map.insert(i, i - cumulative_push_size);
+            match OpCode::is_push(op) {
+                Some(push_size) => {
+                    // Skip the push bytes
+                    i += push_size as usize;
+                    cumulative_push_size += push_size as usize;
+                }
+                None => (),
+            }
+            i += 1;
+        }
+
+        self.ic_map.insert(*address, ic_map);
+    }
+
+    /// Enters a new execution context.
+    pub fn enter(&mut self, depth: usize, address: Address, creation: bool) {
+        self.head =
+            self.arena.push_node(DebugNode { depth, address, creation, ..Default::default() });
+    }
+
+    /// Exits the current execution context, replacing it with the previous one.
+    pub fn exit(&mut self) {
+        if let Some(parent_id) = self.arena.arena[self.head].parent {
+            let DebugNode { depth, address, creation, .. } = self.arena.arena[parent_id];
+            self.head =
+                self.arena.push_node(DebugNode { depth, address, creation, ..Default::default() });
+        }
+    }
+
+    /// Records a debug step in the current execution context.
+    // TODO: Interpreter is only taken as a mutable borrow here because `Interpreter::gas` takes
+    // `&mut self` by mistake.
+    pub fn record_debug_step(&mut self, interpreter: &mut Interpreter) {
+        let pc = interpreter.program_counter();
+        let push_size = OpCode::is_push(interpreter.contract.code[pc]).map(|size| size as usize);
+        let push_bytes = push_size.as_ref().map(|push_size| {
+            let start = pc + 1;
+            let end = start + push_size;
+            interpreter.contract.code[start..end].to_vec()
+        });
+
+        self.arena.arena[self.head].steps.push(DebugStep {
+            pc,
+            stack: interpreter.stack().data().clone(),
+            memory: interpreter.memory.clone(),
+            instruction: Instruction::OpCode(interpreter.contract.code[pc]),
+            push_bytes,
+            ic: *self
+                .ic_map
+                .get(&interpreter.contract().address)
+                .expect("no instruction counter map")
+                .get(&pc)
+                .expect("unknown ic for pc"),
+            // TODO: The number reported here is off
+            total_gas_used: interpreter.gas().spend(),
+        });
+    }
+}
+
+impl<DB> Inspector<DB> for Debugger
+where
+    DB: Database,
+{
+    fn call(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &CallInputs,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        self.enter(data.subroutine.depth() as usize, call.contract, false);
+        if call.contract == *CHEATCODE_ADDRESS {
+            self.arena.arena[self.head].steps.push(DebugStep {
+                memory: Memory::new(),
+                instruction: Instruction::Cheatcode(
+                    call.input[0..4].try_into().expect("malformed cheatcode call"),
+                ),
+                ..Default::default()
+            });
+        }
+
+        (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
+    }
+
+    fn initialize_interp(
+        &mut self,
+        interp: &mut Interpreter,
+        _: &mut EVMData<'_, DB>,
+        _: bool,
+    ) -> Return {
+        // TODO: This is rebuilt for all contracts every time. We should only run this if the IC
+        // map for a given address does not exist, *but* we need to account for the fact that the
+        // code given by the interpreter may either be the contract init code, or the runtime code.
+        self.build_ic_map(&interp.contract().address, &interp.contract().code);
+        Return::Continue
+    }
+
+    fn step(
+        &mut self,
+        interpreter: &mut Interpreter,
+        _: &mut EVMData<'_, DB>,
+        _is_static: bool,
+    ) -> Return {
+        self.record_debug_step(interpreter);
+        Return::Continue
+    }
+
+    fn call_end(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        _: &CallInputs,
+        gas: Gas,
+        status: Return,
+        retdata: Bytes,
+        _: bool,
+    ) -> (Return, Gas, Bytes) {
+        self.exit();
+
+        (status, gas, retdata)
+    }
+
+    fn create(
+        &mut self,
+        data: &mut EVMData<'_, DB>,
+        call: &CreateInputs,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        // TODO: Does this increase gas cost?
+        data.subroutine.load_account(call.caller, data.db);
+        let nonce = data.subroutine.account(call.caller).info.nonce;
+        let address = match call.scheme {
+            CreateScheme::Create => get_contract_address(call.caller, nonce),
+            CreateScheme::Create2 { salt } => {
+                let mut buffer: [u8; 4 * 8] = [0; 4 * 8];
+                salt.to_big_endian(&mut buffer);
+                get_create2_address(call.caller, buffer, call.init_code.clone())
+            }
+        };
+        self.enter(data.subroutine.depth() as usize, address, true);
+
+        (Return::Continue, None, Gas::new(call.gas_limit), Bytes::new())
+    }
+
+    fn create_end(
+        &mut self,
+        _: &mut EVMData<'_, DB>,
+        _: &CreateInputs,
+        status: Return,
+        address: Option<Address>,
+        gas: Gas,
+        retdata: Bytes,
+    ) -> (Return, Option<Address>, Gas, Bytes) {
+        self.exit();
+
+        (status, address, gas, retdata)
+    }
+}

--- a/forge/src/executor/inspector/mod.rs
+++ b/forge/src/executor/inspector/mod.rs
@@ -7,6 +7,9 @@ pub use logs::LogCollector;
 mod tracer;
 pub use tracer::Tracer;
 
+mod debugger;
+pub use debugger::Debugger;
+
 mod stack;
 pub use stack::InspectorStack;
 
@@ -21,6 +24,8 @@ pub struct InspectorStackConfig {
     pub ffi: bool,
     /// Whether or not tracing is enabled
     pub tracing: bool,
+    /// Whether or not the debugger is enabled
+    pub debugger: bool,
 }
 
 impl InspectorStackConfig {
@@ -33,6 +38,9 @@ impl InspectorStackConfig {
         }
         if self.tracing {
             stack.tracer = Some(Tracer::new());
+        }
+        if self.debugger {
+            stack.debugger = Some(Debugger::new());
         }
         stack
     }

--- a/forge/src/executor/inspector/mod.rs
+++ b/forge/src/executor/inspector/mod.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-mod macros;
+mod utils;
 
 mod logs;
 pub use logs::LogCollector;

--- a/forge/src/executor/inspector/stack.rs
+++ b/forge/src/executor/inspector/stack.rs
@@ -1,4 +1,4 @@
-use super::{Cheatcodes, LogCollector, Tracer};
+use super::{Cheatcodes, Debugger, LogCollector, Tracer};
 use bytes::Bytes;
 use ethers::types::Address;
 use revm::{db::Database, CallInputs, CreateInputs, EVMData, Gas, Inspector, Interpreter, Return};
@@ -26,6 +26,7 @@ pub struct InspectorStack {
     pub tracer: Option<Tracer>,
     pub logs: Option<LogCollector>,
     pub cheatcodes: Option<Cheatcodes>,
+    pub debugger: Option<Debugger>,
 }
 
 impl InspectorStack {
@@ -44,14 +45,18 @@ where
         data: &mut EVMData<'_, DB>,
         is_static: bool,
     ) -> Return {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            let status = inspector.initialize_interp(interpreter, data, is_static);
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                let status = inspector.initialize_interp(interpreter, data, is_static);
 
-            // Allow inspectors to exit early
-            if status != Return::Continue {
-                return status
+                // Allow inspectors to exit early
+                if status != Return::Continue {
+                    return status
+                }
             }
-        });
+        );
 
         Return::Continue
     }
@@ -62,14 +67,18 @@ where
         data: &mut EVMData<'_, DB>,
         is_static: bool,
     ) -> Return {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            let status = inspector.step(interpreter, data, is_static);
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                let status = inspector.step(interpreter, data, is_static);
 
-            // Allow inspectors to exit early
-            if status != Return::Continue {
-                return status
+                // Allow inspectors to exit early
+                if status != Return::Continue {
+                    return status
+                }
             }
-        });
+        );
 
         Return::Continue
     }
@@ -81,14 +90,18 @@ where
         is_static: bool,
         status: Return,
     ) -> Return {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            let status = inspector.step_end(interpreter, data, is_static, status);
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                let status = inspector.step_end(interpreter, data, is_static, status);
 
-            // Allow inspectors to exit early
-            if status != Return::Continue {
-                return status
+                // Allow inspectors to exit early
+                if status != Return::Continue {
+                    return status
+                }
             }
-        });
+        );
 
         Return::Continue
     }
@@ -99,14 +112,18 @@ where
         call: &CallInputs,
         is_static: bool,
     ) -> (Return, Gas, Bytes) {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            let (status, gas, retdata) = inspector.call(data, call, is_static);
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                let (status, gas, retdata) = inspector.call(data, call, is_static);
 
-            // Allow inspectors to exit early
-            if status != Return::Continue {
-                return (status, gas, retdata)
+                // Allow inspectors to exit early
+                if status != Return::Continue {
+                    return (status, gas, retdata)
+                }
             }
-        });
+        );
 
         (Return::Continue, Gas::new(call.gas_limit), Bytes::new())
     }
@@ -120,15 +137,26 @@ where
         retdata: Bytes,
         is_static: bool,
     ) -> (Return, Gas, Bytes) {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            let (new_status, new_gas, new_retdata) =
-                inspector.call_end(data, call, remaining_gas, status, retdata.clone(), is_static);
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                let (new_status, new_gas, new_retdata) = inspector.call_end(
+                    data,
+                    call,
+                    remaining_gas,
+                    status,
+                    retdata.clone(),
+                    is_static,
+                );
 
-            // If the inspector returns a different status we assume it wants to tell us something
-            if new_status != status {
-                return (new_status, new_gas, new_retdata)
+                // If the inspector returns a different status we assume it wants to tell us
+                // something
+                if new_status != status {
+                    return (new_status, new_gas, new_retdata)
+                }
             }
-        });
+        );
 
         (status, remaining_gas, retdata)
     }
@@ -138,14 +166,18 @@ where
         data: &mut EVMData<'_, DB>,
         call: &CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            let (status, addr, gas, retdata) = inspector.create(data, call);
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                let (status, addr, gas, retdata) = inspector.create(data, call);
 
-            // Allow inspectors to exit early
-            if status != Return::Continue {
-                return (status, addr, gas, retdata)
+                // Allow inspectors to exit early
+                if status != Return::Continue {
+                    return (status, addr, gas, retdata)
+                }
             }
-        });
+        );
 
         (Return::Continue, None, Gas::new(call.gas_limit), Bytes::new())
     }
@@ -159,21 +191,35 @@ where
         remaining_gas: Gas,
         retdata: Bytes,
     ) -> (Return, Option<Address>, Gas, Bytes) {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            let (new_status, new_address, new_gas, new_retdata) =
-                inspector.create_end(data, call, status, address, remaining_gas, retdata.clone());
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                let (new_status, new_address, new_gas, new_retdata) = inspector.create_end(
+                    data,
+                    call,
+                    status,
+                    address,
+                    remaining_gas,
+                    retdata.clone(),
+                );
 
-            if new_status != status {
-                return (new_status, new_address, new_gas, new_retdata)
+                if new_status != status {
+                    return (new_status, new_address, new_gas, new_retdata)
+                }
             }
-        });
+        );
 
         (status, address, remaining_gas, retdata)
     }
 
     fn selfdestruct(&mut self) {
-        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
-            Inspector::<DB>::selfdestruct(inspector);
-        });
+        call_inspectors!(
+            inspector,
+            [&mut self.debugger, &mut self.tracer, &mut self.logs, &mut self.cheatcodes],
+            {
+                Inspector::<DB>::selfdestruct(inspector);
+            }
+        );
     }
 }

--- a/forge/src/executor/inspector/tracer.rs
+++ b/forge/src/executor/inspector/tracer.rs
@@ -121,7 +121,6 @@ where
         // TODO: Does this increase gas cost?
         data.subroutine.load_account(call.caller, data.db);
         let nonce = data.subroutine.account(call.caller).info.nonce;
-
         self.start_trace(
             data.subroutine.depth() as usize,
             match call.scheme {

--- a/forge/src/executor/inspector/tracer.rs
+++ b/forge/src/executor/inspector/tracer.rs
@@ -1,19 +1,15 @@
 use super::logs::extract_log;
 use crate::{
-    executor::HARDHAT_CONSOLE_ADDRESS,
+    executor::{inspector::utils::get_create_address, HARDHAT_CONSOLE_ADDRESS},
     trace::{
         CallTrace, CallTraceArena, LogCallOrder, RawOrDecodedCall, RawOrDecodedLog,
         RawOrDecodedReturnData,
     },
 };
 use bytes::Bytes;
-use ethers::{
-    types::{Address, U256},
-    utils::{get_contract_address, get_create2_address},
-};
+use ethers::types::{Address, U256};
 use revm::{
-    return_ok, CallInputs, CreateInputs, CreateScheme, Database, EVMData, Gas, Inspector,
-    Interpreter, Return,
+    return_ok, CallInputs, CreateInputs, Database, EVMData, Gas, Inspector, Interpreter, Return,
 };
 
 /// An inspector that collects call traces.
@@ -123,14 +119,7 @@ where
         let nonce = data.subroutine.account(call.caller).info.nonce;
         self.start_trace(
             data.subroutine.depth() as usize,
-            match call.scheme {
-                CreateScheme::Create => get_contract_address(call.caller, nonce),
-                CreateScheme::Create2 { salt } => {
-                    let mut buffer: [u8; 4 * 8] = [0; 4 * 8];
-                    salt.to_big_endian(&mut buffer);
-                    get_create2_address(call.caller, buffer, call.init_code.clone())
-                }
-            },
+            get_create_address(call, nonce),
             call.init_code.to_vec(),
             call.value,
             true,

--- a/forge/src/executor/opts.rs
+++ b/forge/src/executor/opts.rs
@@ -31,9 +31,6 @@ pub struct EvmOpts {
 
     /// Verbosity mode of EVM output as number of occurences
     pub verbosity: u8,
-
-    /// enable debugger
-    pub debug: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -27,7 +27,6 @@ pub trait TestFilter {
     fn matches_path(&self, path: impl AsRef<str>) -> bool;
 }
 
-// TODO: Why did we add this again?
 pub static CALLER: Lazy<Address> = Lazy::new(Address::random);
 
 use ethers::types::Address;

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -3,6 +3,9 @@ pub mod decode;
 /// Call trace arena, decoding and formatting
 pub mod trace;
 
+/// Debugger arena
+pub mod debugger;
+
 /// Gas reports
 pub mod gas_report;
 

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -27,9 +27,11 @@ pub trait TestFilter {
     fn matches_path(&self, path: impl AsRef<str>) -> bool;
 }
 
+// TODO: Why did we add this again?
+pub static CALLER: Lazy<Address> = Lazy::new(Address::random);
+
 use ethers::types::Address;
 use once_cell::sync::Lazy;
-static CALLER: Lazy<Address> = Lazy::new(Address::random);
 
 #[cfg(test)]
 pub mod test_helpers {

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 crossterm = "0.22.1"
-tui = {  version = "0.16.0", default-features = false, features = ["crossterm"] }
+tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 eyre = "0.6.5"
 hex = "0.4.3"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -3,12 +3,10 @@ name = "ui"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-# TUI for debug
 crossterm = "0.22.1"
 tui = {  version = "0.16.0", default-features = false, features = ["crossterm"] }
 eyre = "0.6.5"
 hex = "0.4.3"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
+forge = { path = "../forge" }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -585,16 +585,26 @@ impl Tui {
         area: Rect,
     ) {
         let stack_space =
-            Block::default().title(format!(" Stack: {} ", current_step)).borders(Borders::ALL);
+            Block::default().title(format!("Stack: {}", current_step)).borders(Borders::ALL);
         let stack = &debug_steps[current_step].stack;
         let min_len = usize::max(format!("{}", stack.len()).len(), 2);
 
         let text: Vec<Spans> = stack
             .iter()
+            .rev()
             .enumerate()
             .map(|(i, stack_item)| {
                 Spans::from(Span::styled(
-                    format!("{: <min_len$}: {:?} \n", i, stack_item, min_len = min_len),
+                    format!(
+                        "{: >min_len$}| {} \n",
+                        i,
+                        (0..32)
+                            .into_iter()
+                            .map(|i| format!("{:02x}", stack_item.byte(i)))
+                            .collect::<Vec<String>>()
+                            .join(" "),
+                        min_len = min_len
+                    ),
                     Style::default().fg(Color::White),
                 ))
             })

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -594,21 +594,33 @@ impl Tui {
             .rev()
             .enumerate()
             .map(|(i, stack_item)| {
-                Spans::from(Span::styled(
-                    format!(
-                        "{: >min_len$}| {} \n",
-                        i,
-                        (0..32)
-                            .into_iter()
-                            .map(|i| format!("{:02x}", stack_item.byte(i)))
-                            .collect::<Vec<String>>()
-                            .join(" "),
-                        min_len = min_len
-                    ),
+                let words: Vec<Span> = (0..32)
+                    .into_iter()
+                    .rev()
+                    .map(|i| stack_item.byte(i))
+                    .map(|byte| {
+                        Span::styled(
+                            format!("{:02x} ", byte),
+                            if byte == 0 {
+                                Style::default().fg(Color::Gray).add_modifier(Modifier::DIM)
+                            } else {
+                                Style::default().fg(Color::White)
+                            },
+                        )
+                    })
+                    .collect();
+
+                let mut spans = vec![Span::styled(
+                    format!("{:0min_len$}| ", i, min_len = min_len),
                     Style::default().fg(Color::White),
-                ))
+                )];
+                spans.extend(words);
+                spans.push(Span::raw("\n"));
+
+                Spans::from(spans)
             })
             .collect();
+
         let paragraph = Paragraph::new(text).block(stack_space).wrap(Wrap { trim: true });
         f.render_widget(paragraph, area);
     }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -6,7 +6,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ethers::{abi::Abi, solc::artifacts::ContractBytecodeSome, types::Address};
+use ethers::{solc::artifacts::ContractBytecodeSome, types::Address};
 use eyre::Result;
 use forge::debugger::DebugStep;
 use std::{
@@ -46,7 +46,7 @@ pub struct Tui {
     key_buffer: String,
     /// current step in the debug steps
     current_step: usize,
-    identified_contracts: BTreeMap<Address, (String, Abi)>,
+    identified_contracts: BTreeMap<Address, String>,
     known_contracts: BTreeMap<String, ContractBytecodeSome>,
     source_code: BTreeMap<u32, String>,
 }
@@ -57,7 +57,7 @@ impl Tui {
     pub fn new(
         debug_arena: Vec<(Address, Vec<DebugStep>, bool)>,
         current_step: usize,
-        identified_contracts: BTreeMap<Address, (String, Abi)>,
+        identified_contracts: BTreeMap<Address, String>,
         known_contracts: BTreeMap<String, ContractBytecodeSome>,
         source_code: BTreeMap<u32, String>,
     ) -> Result<Self> {
@@ -96,7 +96,7 @@ impl Tui {
     fn draw_layout<B: Backend>(
         f: &mut Frame<B>,
         address: Address,
-        identified_contracts: &BTreeMap<Address, (String, Abi)>,
+        identified_contracts: &BTreeMap<Address, String>,
         known_contracts: &BTreeMap<String, ContractBytecodeSome>,
         source_code: &BTreeMap<u32, String>,
         debug_steps: &[DebugStep],
@@ -182,7 +182,7 @@ impl Tui {
     fn draw_src<B: Backend>(
         f: &mut Frame<B>,
         address: Address,
-        identified_contracts: &BTreeMap<Address, (String, Abi)>,
+        identified_contracts: &BTreeMap<Address, String>,
         known_contracts: &BTreeMap<String, ContractBytecodeSome>,
         source_code: &BTreeMap<u32, String>,
         ic: usize,
@@ -196,7 +196,7 @@ impl Tui {
         let mut text_output: Text = Text::from("");
 
         if let Some(contract_name) = identified_contracts.get(&address) {
-            if let Some(known) = known_contracts.get(&contract_name.0) {
+            if let Some(known) = known_contracts.get(contract_name) {
                 // grab either the creation source map or runtime sourcemap
                 if let Some(sourcemap) = if creation {
                     known.bytecode.source_map()

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -168,7 +168,7 @@ impl Tui {
         let block_controls = Block::default();
 
         let text_output = Text::from(Span::styled(
-            "[q]: Quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end",
+            "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end",
             Style::default().add_modifier(Modifier::DIM)
         ));
         let paragraph = Paragraph::new(text_output)
@@ -190,7 +190,7 @@ impl Tui {
         area: Rect,
     ) {
         let block_source_code = Block::default()
-            .title(format!("Contract construction: {}", creation))
+            .title(if creation { "Contract creation" } else { "Contract call" })
             .borders(Borders::ALL);
 
         let mut text_output: Text = Text::from("");
@@ -491,7 +491,7 @@ impl Tui {
     ) {
         let block_source_code = Block::default()
             .title(format!(
-                " Address: {} | PC: {} | Gas used in call: {} ",
+                "Address: {} | PC: {} | Gas used in call: {}",
                 address,
                 if let Some(step) = debug_steps.get(current_step) {
                     step.pc.to_string()
@@ -547,17 +547,17 @@ impl Tui {
             // Format line number
             let line_number_format = if line_number == current_step {
                 let step: &DebugStep = &debug_steps[line_number];
-                format!("{:0>max_pc_len$x} ▶", step.pc, max_pc_len = max_pc_len)
+                format!("{:0>max_pc_len$x}|▶", step.pc, max_pc_len = max_pc_len)
             } else if line_number < debug_steps.len() {
                 let step: &DebugStep = &debug_steps[line_number];
-                format!("{:0>max_pc_len$x}: ", step.pc, max_pc_len = max_pc_len)
+                format!("{:0>max_pc_len$x}| ", step.pc, max_pc_len = max_pc_len)
             } else {
                 "END CALL".to_string()
             };
 
             if let Some(op) = opcode_list.get(line_number) {
                 text_output.push(Spans::from(Span::styled(
-                    format!("{} {}", line_number_format, op),
+                    format!("{}{}", line_number_format, op),
                     Style::default().fg(Color::White).bg(bg_color),
                 )));
             } else {
@@ -612,7 +612,7 @@ impl Tui {
     ) {
         let memory = &debug_steps[current_step].memory;
         let stack_space = Block::default()
-            .title(format!(" Memory (max expansion: {} bytes)", memory.effective_len()))
+            .title(format!("Memory (max expansion: {} bytes)", memory.effective_len()))
             .borders(Borders::ALL);
         let memory = memory.data();
         let max_i = memory.len() / 32;

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -584,9 +584,9 @@ impl Tui {
         current_step: usize,
         area: Rect,
     ) {
-        let stack_space =
-            Block::default().title(format!("Stack: {}", current_step)).borders(Borders::ALL);
         let stack = &debug_steps[current_step].stack;
+        let stack_space =
+            Block::default().title(format!("Stack: {}", stack.len())).borders(Borders::ALL);
         let min_len = usize::max(format!("{}", stack.len()).len(), 2);
 
         let text: Vec<Spans> = stack

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -603,9 +603,6 @@ impl Tui {
         f.render_widget(paragraph, area);
     }
 
-    // cargo r --manifest-path ../foundry/Cargo.toml --bin forge run ./src/test/Locke.t.sol -t
-    // StreamTest --sig "test_fundStream()" --debug
-
     /// Draw memory in memory pane
     fn draw_memory<B: Backend>(
         f: &mut Frame<B>,
@@ -625,24 +622,28 @@ impl Tui {
             .chunks(32)
             .enumerate()
             .map(|(i, mem_word)| {
-                let strings: String = mem_word
-                    .chunks(4)
-                    .map(|bytes4| {
-                        bytes4
-                            .iter()
-                            .map(|byte| {
-                                let v: Vec<u8> = vec![*byte];
-                                hex::encode(&v[..])
-                            })
-                            .collect::<Vec<String>>()
-                            .join(" ")
+                let words: Vec<Span> = mem_word
+                    .iter()
+                    .map(|byte| {
+                        Span::styled(
+                            format!("{:02x} ", byte),
+                            if *byte == 0 {
+                                Style::default().fg(Color::Gray).add_modifier(Modifier::DIM)
+                            } else {
+                                Style::default().fg(Color::White)
+                            },
+                        )
                     })
-                    .collect::<Vec<String>>()
-                    .join("  ");
-                Spans::from(Span::styled(
-                    format!("{:0min_len$x}: {} \n", i * 32, strings, min_len = min_len),
+                    .collect();
+
+                let mut spans = vec![Span::styled(
+                    format!("{:0min_len$x}| ", i * 32, min_len = min_len),
                     Style::default().fg(Color::White),
-                ))
+                )];
+                spans.extend(words);
+                spans.push(Span::raw("\n"));
+
+                Spans::from(spans)
             })
             .collect();
         let paragraph = Paragraph::new(text).block(stack_space).wrap(Wrap { trim: true });


### PR DESCRIPTION
Ports the debugger to the new REVM executor, greys out zero values in the stack and memory, and adds support for running functions with arguments

**To do**

- [x] Inspector
- [x] Adjust `ui` crate
- [x] Adjust `forge run`
- [x] Revert checks
- [x] Set stack title to signify number of stack items, not the current step

**Nice to have**

- [x] Arguments for functions in `forge run`
- [x] #902 
- [x] `forge test --debug`

Closes #758 
Closes #761 