### PR TITLE
feat(cast/pretty-calldata): do not fail if no 4byte sigs found

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -569,7 +569,7 @@ pub async fn pretty_calldata(calldata: impl AsRef<str>, offline: bool) -> Result
     let sigs = if offline {
         vec![]
     } else {
-        fourbyte(selector).await.unwrap_or(vec![]).into_iter().map(|sig| sig.0).collect()
+        fourbyte(selector).await.unwrap_or_default().into_iter().map(|sig| sig.0).collect()
     };
     let (_, data) = calldata.split_at(8);
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -569,7 +569,7 @@ pub async fn pretty_calldata(calldata: impl AsRef<str>, offline: bool) -> Result
     let sigs = if offline {
         vec![]
     } else {
-        fourbyte(selector).await?.into_iter().map(|sig| sig.0).collect()
+        fourbyte(selector).await.unwrap_or(vec![]).into_iter().map(|sig| sig.0).collect()
     };
     let (_, data) = calldata.split_at(8);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Pretty printing is useful even if no sig is found on 4byte. Also we state in the description that we only print signature **if** available, so we shouldn't be failing if no signature found.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Provide default empty vector if no sigs found.