### PR TITLE
fix(evm-adapters) remove `checkTopic` error from `expectEmit` in `testFailExpectEmitWithCall1` and `testFailExpectEmitWithCall2`

### DIFF
--- a/evm-adapters/testdata/CheatCodes.sol
+++ b/evm-adapters/testdata/CheatCodes.sol
@@ -439,7 +439,7 @@ contract CheatCodes is DSTest {
         ExpectEmit emitter = new ExpectEmit();
         hevm.deal(address(this), 1 ether);
         hevm.expectEmit(true,true,false,true);
-        emit Transfer(address(this), address(1338), 1 gwei);
+        emit Transfer(address(this), address(1337), 1 gwei);
         emitter.t4(payable(address(1337)), 100 gwei);
     }
 
@@ -449,7 +449,7 @@ contract CheatCodes is DSTest {
         ExpectEmit emitter = new ExpectEmit();
         hevm.deal(address(this), 1 ether);
         hevm.expectEmit(true,true,false,true);
-        emit Transfer(address(this), address(1338), 100 gwei);
+        emit Transfer(address(this), address(1337), 100 gwei);
         emitter.t5(payable(address(1337)), 100 gwei);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The function `testFailExpectEmitWithCall1` is supposed to fail due to "data is different." However, the test is failing due to two reasons, which are
1. "data is different"
2. `checkTopic3` is `false`

In other words, even if the data is the same as emitted by `t4()`, i.e., `emit Transfer(address(this), address(1338), 100 gwei);` the test will also fail. Hence, it is best to let this test to only fail due to "data is different."

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
`emit Transfer(address(this), address(1337), 1 gwei);` will fail *only* due to "data is different"
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
