### PR TITLE
feat(config): ignore spdx license not provided warning by default

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -861,7 +861,7 @@ impl Default for Config {
             verbosity: 0,
             remappings: vec![],
             libraries: vec![],
-            ignored_error_codes: vec![],
+            ignored_error_codes: vec![SolidityErrorCode::SpdxLicenseNotProvided],
             __non_exhaustive: (),
         }
     }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -13,7 +13,7 @@ use figment::{
 // reexport so cli types can implement `figment::Provider` to easily merge compiler arguments
 pub use figment;
 use semver::Version;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use ethers_core::types::{Address, U256};
 pub use ethers_solc::artifacts::OptimizerDetails;
@@ -127,8 +127,8 @@ pub struct Config {
     pub verbosity: u8,
     /// url of the rpc server that should be used for any rpc calls
     pub eth_rpc_url: Option<String>,
-    /// list of solidity error codes to always silence
-    pub ignored_error_codes: Vec<u64>,
+    /// list of solidity error codes to always silence in the compiler output
+    pub ignored_error_codes: Vec<SolidityErrorCode>,
     /// The number of test cases that must execute for each property test
     pub fuzz_runs: u32,
     /// Whether to allow ffi cheatcodes in test
@@ -390,7 +390,7 @@ impl Config {
             .allowed_path(&self.__root.0)
             .allowed_paths(&self.libs)
             .solc_config(SolcConfig::builder().settings(self.solc_settings()?).build())
-            .ignore_error_codes(self.ignored_error_codes.clone())
+            .ignore_error_codes(self.ignored_error_codes.iter().copied().map(Into::into))
             .set_auto_detect(self.is_auto_detect())
             .set_offline(self.offline)
             .set_cached(cached)
@@ -864,6 +864,49 @@ impl Default for Config {
             ignored_error_codes: vec![],
             __non_exhaustive: (),
         }
+    }
+}
+/// A non-exhaustive list of solidity error codes
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SolidityErrorCode {
+    /// Warning that SPDX license identifier not provided in source file
+    SpdxLicenseNotProvided,
+    Other(u64),
+}
+
+impl From<SolidityErrorCode> for u64 {
+    fn from(code: SolidityErrorCode) -> u64 {
+        match code {
+            SolidityErrorCode::SpdxLicenseNotProvided => 1878,
+            SolidityErrorCode::Other(code) => code,
+        }
+    }
+}
+
+impl From<u64> for SolidityErrorCode {
+    fn from(code: u64) -> Self {
+        match code {
+            1878 => SolidityErrorCode::SpdxLicenseNotProvided,
+            other => SolidityErrorCode::Other(other),
+        }
+    }
+}
+
+impl Serialize for SolidityErrorCode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64((*self).into())
+    }
+}
+
+impl<'de> Deserialize<'de> for SolidityErrorCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        u64::deserialize(deserializer).map(Into::into)
     }
 }
 

--- a/evm-adapters/src/sputnik/forked_backend/cache.rs
+++ b/evm-adapters/src/sputnik/forked_backend/cache.rs
@@ -506,11 +506,8 @@ struct SharedBackendInner {
 #[cfg(test)]
 mod tests {
     use crate::sputnik::vicinity;
-    use ethers::{
-        providers::{Http, Provider},
-        types::Address,
-    };
-    use std::convert::TryFrom;
+    use ethers::types::Address;
+
     use tokio::runtime::Runtime;
 
     use super::*;

--- a/evm-adapters/src/sputnik/forked_backend/rpc.rs
+++ b/evm-adapters/src/sputnik/forked_backend/rpc.rs
@@ -196,12 +196,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
 
-    use ethers::{
-        providers::{Http, Provider},
-        types::Address,
-    };
+    use ethers::types::Address;
     use sputnik::Config;
     use tokio::runtime::Runtime;
 

--- a/evm-adapters/src/sputnik/state.rs
+++ b/evm-adapters/src/sputnik/state.rs
@@ -225,17 +225,13 @@ mod tests {
         forked_backend::MemCache, helpers::new_vicinity, new_shared_cache, SharedBackend,
         SharedCache,
     };
-    use ethers::{
-        abi::Address,
-        prelude::{Http, Provider},
-    };
+    use ethers::abi::Address;
     use once_cell::sync::Lazy;
     use sputnik::{
         backend::{MemoryBackend, MemoryVicinity},
         executor::stack::MemoryStackState,
         Config,
     };
-    use std::convert::TryFrom;
 
     // We need a bunch of global static values in order to satisfy sputnik's lifetime requirements
     // for `'static` so that we can Send them


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Closes #938
Previously we didn't ignore this error by default
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add `SolidityErrorCode` enum
* ignore `SolidityErrorCode::SpdxLicenseNotProvided` by default

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
