### PR TITLE
WIP: Install Foundry from local path

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -21,6 +21,7 @@ while [[ $1 ]]; do
     -r|--repo)        shift; FOUNDRYUP_REPO=$1;;
     -b|--branch)      shift; FOUNDRYUP_BRANCH=$1;;
     -v|--version)     shift; FOUNDRYUP_VERSION=$1;;
+    --path)           shift; FOUNDRYUP_LOCAL_REPO=$1;;
     -h|--help)        FOUNDRYUP_HELP="1";;
 
     *) printf "foundryup: internal error: %q\\n" "$1"; exit 1
@@ -39,6 +40,38 @@ OPTIONS:
     -b, --branch    Install a specific branch
     -r, --repo      Install a forks main branch"
     exit 0
+fi
+
+# Installs foundry from a local repository if --path parameter is provided
+if [[ -n "$FOUNDRYUP_LOCAL_REPO" ]]; then
+  echo "Installing from a local foundry repository"
+
+  # Ignore branches/versions as we do not want to modify local git state
+  if [ -n "$FOUNDRYUP_REPO" ] || [ -n "$FOUNDRY_BRANCH" || [ -n "$FOUNDRY_VERSION" ]]; then
+    echo "foundryup: WARN --branch, --version, and --repo arguments are ignored during local install"
+  fi
+
+  if ! command -v cargo &> /dev/null ; then
+    # Error if cargo is not already installed.
+    echo "foundryup: cargo is not installed. Please install it first."
+    exit 1
+  fi
+
+  # Enter local repo and build
+  FOUNDRY_REPO="$PWD/$FOUNDRYUP_LOCAL_REPO"
+  echo "Installing from $FOUNDRY_REPO"
+  cd $FOUNDRY_REPO
+  cargo build --release
+
+  # Remove existing installations if they exist
+  rm -f "$FOUNDRY_BIN_DIR/forge"
+  rm -f "$FOUNDRY_BIN_DIR/cast"
+
+  # Symlink from local repo binaries to bin dir
+  ln -s "$PWD/target/release/forge" "$FOUNDRY_BIN_DIR/forge"
+  ln -s "$PWD/target/release/cast" "$FOUNDRY_BIN_DIR/cast"
+  echo foundryup: done!
+  exit 0
 fi
 
 FOUNDRYUP_REPO=${FOUNDRYUP_REPO-gakonst/foundry}

--- a/foundryup/install
+++ b/foundryup/install
@@ -38,7 +38,8 @@ OPTIONS:
     -h, --help      Print help information
     -v, --version   Install a specific version
     -b, --branch    Install a specific branch
-    -r, --repo      Install a forks main branch"
+    -r, --repo      Install a forks main branch
+    --path          Install from a local repository"
     exit 0
 fi
 


### PR DESCRIPTION
## Motivation
This PR addresses issue #929 by adding the ability to install forge and cast from local repositories.

## Solution
Add a `--path` argument to the `foundryup` up script. The value of the argument should be a relative path to a local foundry repo. Then:

1. cd into the path
2. run cargo install
3. remove any existing `forge` or `cast` binaries that exist in the `$FOUNDRY_BIN_DIR`
4. symlink the locally installed binaries to `$FOUNDRY_BIN_DIR/{forge, cast}`

The symlinks are destroyed whenever a new remote or release version of Foundry is installed using `foundryup`

PR is WIP
Todo
- [ ] Update Help Message
- [ ] Update README
- [ ] Integrate code review feedback
