### PR TITLE
REVM gas fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.2.0"
-source = "git+https://github.com/onbjerg/revm?branch=onbjerg/tracer-ends#7a243f84a4ea9f5a969e9546bbf3d6b6096c845e"
+source = "git+https://github.com/bluealloy/revm#db1812f5f53b1b00c9f1bc4a0b7484dd291b4b9c"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "0.4.0"
-source = "git+https://github.com/onbjerg/revm?branch=onbjerg/tracer-ends#7a243f84a4ea9f5a969e9546bbf3d6b6096c845e"
+source = "git+https://github.com/bluealloy/revm#db1812f5f53b1b00c9f1bc4a0b7484dd291b4b9c"
 dependencies = [
  "bytes",
  "k256",

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -429,11 +429,11 @@ impl<DB: DatabaseRef> Runner<DB> {
     }
 
     pub fn run(&mut self, address: Address, calldata: Bytes) -> eyre::Result<RunResult> {
-        let RawCallResult { reverted, gas, logs, traces, labels, debug, .. } =
+        let RawCallResult { reverted, gas, stipend, logs, traces, labels, debug, .. } =
             self.executor.call_raw(self.sender, address, calldata.0, 0.into())?;
         Ok(RunResult {
             success: !reverted,
-            gas,
+            gas: gas - stipend,
             logs,
             traces: traces.map(|traces| vec![(TraceKind::Execution, traces)]).unwrap_or_default(),
             debug: vec![debug].into_iter().collect(),

--- a/cli/src/cmd/run.rs
+++ b/cli/src/cmd/run.rs
@@ -117,13 +117,7 @@ impl Cmd for RunArgs {
                 runner.setup(&predeploy_libraries, bytecode, needs_setup)?;
 
             let RunResult {
-                success,
-                gas_used,
-                logs,
-                traces,
-                debug: run_debug,
-                labeled_addresses,
-                ..
+                success, gas, logs, traces, debug: run_debug, labeled_addresses, ..
             } = runner.run(
                 address,
                 if let Some(calldata) = self.sig.strip_prefix("0x") {
@@ -135,7 +129,7 @@ impl Cmd for RunArgs {
 
             result.success &= success;
 
-            result.gas_used = gas_used;
+            result.gas = gas;
             result.logs.extend(logs);
             result.traces.extend(traces);
             result.debug = run_debug;
@@ -208,7 +202,7 @@ impl Cmd for RunArgs {
                 println!("{}", Colour::Red.paint("Script failed."));
             }
 
-            println!("Gas used: {}", result.gas_used);
+            println!("Gas used: {}", result.gas);
             println!("== Logs ==");
             let console_logs = decode_console_logs(&result.logs);
             if !console_logs.is_empty() {
@@ -327,7 +321,7 @@ struct RunResult {
     pub logs: Vec<RawLog>,
     pub traces: Vec<(TraceKind, CallTraceArena)>,
     pub debug: Option<Vec<DebugArena>>,
-    pub gas_used: u64,
+    pub gas: u64,
     pub labeled_addresses: BTreeMap<Address, String>,
 }
 
@@ -389,7 +383,7 @@ impl<DB: DatabaseRef> Runner<DB> {
                     labels,
                     logs: setup_logs,
                     debug,
-                    gas: gas_used,
+                    gas,
                     ..
                 }) |
                 Err(EvmError::Execution {
@@ -398,7 +392,7 @@ impl<DB: DatabaseRef> Runner<DB> {
                     labels,
                     logs: setup_logs,
                     debug,
-                    gas_used,
+                    gas,
                     ..
                 }) => {
                     traces
@@ -413,7 +407,7 @@ impl<DB: DatabaseRef> Runner<DB> {
                             labeled_addresses: labels,
                             success: !reverted,
                             debug: vec![constructor_debug, debug].into_iter().collect(),
-                            gas_used,
+                            gas,
                         },
                     )
                 }
@@ -427,7 +421,7 @@ impl<DB: DatabaseRef> Runner<DB> {
                     traces,
                     success: true,
                     debug: vec![constructor_debug].into_iter().collect(),
-                    gas_used: 0,
+                    gas: 0,
                     labeled_addresses: Default::default(),
                 },
             )
@@ -439,7 +433,7 @@ impl<DB: DatabaseRef> Runner<DB> {
             self.executor.call_raw(self.sender, address, calldata.0, 0.into())?;
         Ok(RunResult {
             success: !reverted,
-            gas_used: gas,
+            gas,
             logs,
             traces: traces.map(|traces| vec![(TraceKind::Execution, traces)]).unwrap_or_default(),
             debug: vec![debug].into_iter().collect(),

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -459,7 +459,6 @@ Compiler run successful
 });
 
 // Tests that the `run` command works correctly
-// TODO: The original gas usage was "1751" before the REVM port. It should be changed back
 forgetest!(can_execute_run_command, |prj: TestProject, mut cmd: TestCommand| {
     let script = prj
         .inner()
@@ -483,7 +482,7 @@ contract Demo {
     assert!(output.ends_with(&format!(
         "Compiler run successful
 {}
-Gas used: 22815
+Gas used: 1751
 == Logs ==
   script ran
 ",
@@ -515,7 +514,7 @@ contract Demo {
     assert!(output.ends_with(&format!(
         "Compiler run successful
 {}
-Gas used: 22815
+Gas used: 1751
 == Logs ==
   script ran
 ",
@@ -550,7 +549,7 @@ contract Demo {
     assert!(output.ends_with(&format!(
         "Compiler run successful
 {}
-Gas used: 25301
+Gas used: 3957
 == Logs ==
   script ran
   1

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -25,7 +25,7 @@ rlp = "0.5.1"
 
 bytes = "1.1.0"
 thiserror = "1.0.29"
-revm = { package = "revm", git = "https://github.com/onbjerg/revm", branch = "onbjerg/tracer-ends", default-features = false, features = ["std", "k256"] }
+revm = { package = "revm", git = "https://github.com/bluealloy/revm", default-features = false, features = ["std", "k256"] }
 hashbrown = "0.12"
 once_cell = "1.9.0"
 parking_lot = "0.12.0"

--- a/forge/src/executor/fuzz/mod.rs
+++ b/forge/src/executor/fuzz/mod.rs
@@ -78,7 +78,7 @@ where
             let success = self.executor.is_success(
                 address,
                 call.reverted,
-                call.state_changeset.clone().expect("we should have a state changeset"),
+                call.state_changeset.clone(),
                 should_fail,
             );
 

--- a/forge/src/executor/inspector/debugger.rs
+++ b/forge/src/executor/inspector/debugger.rs
@@ -62,7 +62,9 @@ impl Debugger {
             let op = code[i];
             ic_map.insert(i, i - cumulative_push_size);
             if opcode_infos[op as usize].is_push {
-                // Skip the push bytes
+                // Skip the push bytes.
+                //
+                // For more context on the math, see: https://github.com/bluealloy/revm/blob/007b8807b5ad7705d3cacce4d92b89d880a83301/crates/revm/src/interpreter/contract.rs#L114-L115
                 i += (op - opcode::PUSH1 + 1) as usize;
                 cumulative_push_size += (op - opcode::PUSH1 + 1) as usize;
             }

--- a/forge/src/executor/inspector/debugger.rs
+++ b/forge/src/executor/inspector/debugger.rs
@@ -155,8 +155,7 @@ where
         };
 
         // Calculate the current amount of gas used
-        // TODO: The copy here is only because `gas` takes `&mut self`
-        let gas = *interpreter.gas();
+        let gas = interpreter.gas();
         let total_gas_spent = gas.spend() - self.previous_gas_block + self.current_gas_block;
         if opcode_info.gas_block_end {
             self.previous_gas_block = interpreter.contract.gas_block(pc);

--- a/forge/src/executor/inspector/tracer.rs
+++ b/forge/src/executor/inspector/tracer.rs
@@ -108,7 +108,7 @@ where
         if call.contract != *HARDHAT_CONSOLE_ADDRESS {
             self.fill_trace(
                 matches!(status, return_ok!()),
-                gas_used(data.env.cfg.spec_id, &gas),
+                gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
                 retdata.to_vec(),
             );
         }
@@ -154,7 +154,11 @@ where
                 .map_or(vec![], |code| code.to_vec()),
             None => vec![],
         };
-        self.fill_trace(matches!(status, return_ok!()), gas_used(data.env.cfg.spec_id, &gas), code);
+        self.fill_trace(
+            matches!(status, return_ok!()),
+            gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
+            code,
+        );
 
         (status, address, gas, retdata)
     }

--- a/forge/src/executor/inspector/utils.rs
+++ b/forge/src/executor/inspector/utils.rs
@@ -2,7 +2,7 @@ use ethers::{
     types::Address,
     utils::{get_contract_address, get_create2_address},
 };
-use revm::{CreateInputs, CreateScheme};
+use revm::{CreateInputs, CreateScheme, Gas, SpecId};
 
 /// Returns [Return::Continue] on an error, discarding the error.
 ///
@@ -48,4 +48,10 @@ pub fn get_create_address(call: &CreateInputs, nonce: u64) -> Address {
             get_create2_address(call.caller, buffer, call.init_code.clone())
         }
     }
+}
+
+/// Get the gas used, accounting for refunds
+pub fn gas_used(spec: SpecId, gas: &Gas) -> u64 {
+    let refund_quotient = if SpecId::enabled(spec, SpecId::LONDON) { 5 } else { 2 };
+    gas.spend() - (gas.refunded() as u64).min(gas.spend() / 5)
 }

--- a/forge/src/executor/inspector/utils.rs
+++ b/forge/src/executor/inspector/utils.rs
@@ -53,5 +53,5 @@ pub fn get_create_address(call: &CreateInputs, nonce: u64) -> Address {
 /// Get the gas used, accounting for refunds
 pub fn gas_used(spec: SpecId, gas: &Gas) -> u64 {
     let refund_quotient = if SpecId::enabled(spec, SpecId::LONDON) { 5 } else { 2 };
-    gas.spend() - (gas.refunded() as u64).min(gas.spend() / 5)
+    gas.spend() - (gas.refunded() as u64).min(gas.spend() / refund_quotient)
 }

--- a/forge/src/executor/inspector/utils.rs
+++ b/forge/src/executor/inspector/utils.rs
@@ -2,7 +2,7 @@ use ethers::{
     types::Address,
     utils::{get_contract_address, get_create2_address},
 };
-use revm::{CreateInputs, CreateScheme, Gas, SpecId};
+use revm::{CreateInputs, CreateScheme, SpecId};
 
 /// Returns [Return::Continue] on an error, discarding the error.
 ///
@@ -51,7 +51,7 @@ pub fn get_create_address(call: &CreateInputs, nonce: u64) -> Address {
 }
 
 /// Get the gas used, accounting for refunds
-pub fn gas_used(spec: SpecId, gas: &Gas) -> u64 {
+pub fn gas_used(spec: SpecId, spent: u64, refunded: u64) -> u64 {
     let refund_quotient = if SpecId::enabled(spec, SpecId::LONDON) { 5 } else { 2 };
-    gas.spend() - (gas.refunded() as u64).min(gas.spend() / refund_quotient)
+    spent - (refunded).min(spent / refund_quotient)
 }

--- a/forge/src/executor/mod.rs
+++ b/forge/src/executor/mod.rs
@@ -52,6 +52,7 @@ pub enum EvmError {
         reverted: bool,
         reason: String,
         gas: u64,
+        stipend: u64,
         logs: Vec<RawLog>,
         traces: Option<CallTraceArena>,
         debug: Option<DebugArena>,
@@ -90,6 +91,8 @@ pub struct CallResult<D: Detokenize> {
     pub result: D,
     /// The gas used for the call
     pub gas: u64,
+    /// The initial gas stipend for the transaction
+    pub stipend: u64,
     /// The logs emitted during the call
     pub logs: Vec<RawLog>,
     /// The labels assigned to addresses during the call
@@ -116,6 +119,8 @@ pub struct RawCallResult {
     pub result: Bytes,
     /// The gas used for the call
     pub gas: u64,
+    /// The initial gas stipend for the transaction
+    pub stipend: u64,
     /// The logs emitted during the call
     pub logs: Vec<RawLog>,
     /// The labels assigned to addresses during the call
@@ -138,6 +143,7 @@ impl Default for RawCallResult {
             reverted: false,
             result: Bytes::new(),
             gas: 0,
+            stipend: 0,
             logs: Vec::new(),
             labels: BTreeMap::new(),
             traces: None,
@@ -223,6 +229,7 @@ where
             status,
             reverted,
             gas,
+            stipend,
             logs,
             labels,
             traces,
@@ -236,6 +243,7 @@ where
                     reverted,
                     result,
                     gas,
+                    stipend,
                     logs,
                     labels,
                     traces,
@@ -250,6 +258,7 @@ where
                     reverted,
                     reason,
                     gas,
+                    stipend,
                     logs,
                     traces,
                     debug,
@@ -294,6 +303,7 @@ where
             status,
             reverted,
             gas,
+            stipend,
             logs,
             labels,
             traces,
@@ -307,6 +317,7 @@ where
                     reverted,
                     result,
                     gas,
+                    stipend,
                     logs,
                     labels,
                     traces,
@@ -321,6 +332,7 @@ where
                     reverted,
                     reason,
                     gas,
+                    stipend,
                     logs,
                     traces,
                     debug,
@@ -361,7 +373,8 @@ where
             status,
             reverted: !matches!(status, return_ok!()),
             result,
-            gas: gas.saturating_sub(stipend),
+            gas,
+            stipend,
             logs: logs.to_vec(),
             labels,
             traces,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -311,7 +311,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
         {
             Ok(CallResult {
                 reverted,
-                gas: gas_used,
+                gas,
                 logs: execution_logs,
                 traces: execution_trace,
                 labels: new_labels,
@@ -320,12 +320,12 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             }) => {
                 labeled_addresses.extend(new_labels);
                 logs.extend(execution_logs);
-                (reverted, None, gas_used, execution_trace, state_changeset)
+                (reverted, None, gas, execution_trace, state_changeset)
             }
             Err(EvmError::Execution {
                 reverted,
                 reason,
-                gas_used,
+                gas,
                 logs: execution_logs,
                 traces: execution_trace,
                 labels: new_labels,
@@ -334,7 +334,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             }) => {
                 labeled_addresses.extend(new_labels);
                 logs.extend(execution_logs);
-                (reverted, Some(reason), gas_used, execution_trace, state_changeset)
+                (reverted, Some(reason), gas, execution_trace, state_changeset)
             }
             Err(err) => {
                 tracing::error!(?err);
@@ -343,12 +343,8 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
         };
         traces.extend(execution_traces.map(|traces| (TraceKind::Execution, traces)).into_iter());
 
-        let success = self.executor.is_success(
-            setup.address,
-            reverted,
-            state_changeset.expect("we should have a state changeset"),
-            should_fail,
-        );
+        let success =
+            self.executor.is_success(setup.address, reverted, state_changeset, should_fail);
 
         // Record test execution time
         tracing::debug!(
@@ -507,11 +503,12 @@ mod tests {
 
         // get the counterexample with shrinking enabled by default
         let counterexample = res.counterexample.unwrap();
+
+        // casting to u64 here is safe because the shrunk result is always gonna be small
+        // enough to fit in a u64, whereas as seen below, that's not possible without
+        // shrinking
         let product_with_shrinking: u64 =
-                // casting to u64 here is safe because the shrunk result is always gonna be small
-                // enough to fit in a u64, whereas as seen below, that's not possible without
-                // shrinking
-                counterexample.args.into_iter().map(|x| x.into_uint().unwrap().as_u64()).product();
+            counterexample.args.into_iter().map(|x| x.into_uint().unwrap().as_u64()).product();
 
         let mut cfg = FuzzConfig::default();
         cfg.failure_persistence = None;

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -103,8 +103,8 @@ impl TestKind {
             TestKind::Standard(gas) => TestKindGas::Standard(*gas),
             TestKind::Fuzz(fuzzed) => TestKindGas::Fuzz {
                 runs: fuzzed.cases().len(),
-                median: fuzzed.median_gas(),
-                mean: fuzzed.mean_gas(),
+                median: fuzzed.median_gas(false),
+                mean: fuzzed.mean_gas(false),
             },
         }
     }
@@ -305,13 +305,14 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
 
         // Run unit test
         let start = Instant::now();
-        let (reverted, reason, gas_used, execution_traces, state_changeset) = match self
+        let (reverted, reason, gas, stipend, execution_traces, state_changeset) = match self
             .executor
             .call::<(), _, _>(self.sender, address, func.clone(), (), 0.into(), self.errors)
         {
             Ok(CallResult {
                 reverted,
                 gas,
+                stipend,
                 logs: execution_logs,
                 traces: execution_trace,
                 labels: new_labels,
@@ -320,12 +321,13 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             }) => {
                 labeled_addresses.extend(new_labels);
                 logs.extend(execution_logs);
-                (reverted, None, gas, execution_trace, state_changeset)
+                (reverted, None, gas, stipend, execution_trace, state_changeset)
             }
             Err(EvmError::Execution {
                 reverted,
                 reason,
                 gas,
+                stipend,
                 logs: execution_logs,
                 traces: execution_trace,
                 labels: new_labels,
@@ -334,7 +336,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             }) => {
                 labeled_addresses.extend(new_labels);
                 logs.extend(execution_logs);
-                (reverted, Some(reason), gas, execution_trace, state_changeset)
+                (reverted, Some(reason), gas, stipend, execution_trace, state_changeset)
             }
             Err(err) => {
                 tracing::error!(?err);
@@ -350,7 +352,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
         tracing::debug!(
             duration = ?Instant::now().duration_since(start),
             %success,
-            %gas_used
+            %gas
         );
 
         Ok(TestResult {
@@ -358,7 +360,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             reason,
             counterexample: None,
             logs,
-            kind: TestKind::Standard(gas_used),
+            kind: TestKind::Standard(gas - stipend),
             traces,
             labeled_addresses,
         })

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -149,8 +149,6 @@ pub fn recurse_link<'a>(
     }
 }
 
-const BASE_TX_COST: u64 = 21000;
-
 /// Helper trait for converting types to Functions. Helpful for allowing the `call`
 /// function on the EVM to be generic over `String`, `&str` and `Function`.
 pub trait IntoFunction {
@@ -181,23 +179,6 @@ impl<'a> IntoFunction for &'a str {
             .parse_function(self)
             .unwrap_or_else(|_| panic!("could not convert {} to function", self))
     }
-}
-
-/// Given a gas value and a calldata array, it subtracts the calldata cost from the
-/// gas value, as well as the 21k base gas cost for all transactions.
-pub fn remove_extra_costs(gas: U256, calldata: &[u8]) -> U256 {
-    let mut calldata_cost = 0;
-    for i in calldata {
-        if *i != 0 {
-            // TODO: Check if EVM pre-eip2028 and charge 64
-            // GTXDATANONZERO = 16
-            calldata_cost += 16
-        } else {
-            // GTXDATAZERO = 4
-            calldata_cost += 4;
-        }
-    }
-    gas.saturating_sub(calldata_cost.into()).saturating_sub(BASE_TX_COST.into())
 }
 
 /// Flattens a group of contracts into maps of all events and functions


### PR DESCRIPTION
- Accounts for refunds in traces and the debugger
- Removes the gas stipend
- Merges `call_raw` and `call_raw_committing`

There's a weird issue with refunds/stipends that I will have to investigate more. The behaviour can be observed when running tests in https://github.com/anticlimactic/foundry-issue with traces on.

We should also consider upstreaming a flag or similar in REVM that just skips the stipend

Closes #812