### PR TITLE
fix(forge): Access list not resetting after setUp

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -288,7 +288,7 @@ mod tests {
         let mut runner = runner();
         let results = runner.test(&Filter::matches_all(), None).unwrap();
 
-        // 9 contracts being built
+        // 10 contracts being built
         assert_eq!(results.keys().len(), 10);
         for (key, contract_tests) in results {
             // for a bad setup, we dont want a successful test

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -289,7 +289,7 @@ mod tests {
         let results = runner.test(&Filter::matches_all(), None).unwrap();
 
         // 9 contracts being built
-        assert_eq!(results.keys().len(), 9);
+        assert_eq!(results.keys().len(), 10);
         for (key, contract_tests) in results {
             // for a bad setup, we dont want a successful test
             if key == "SetupTest.json:SetupTest" {
@@ -351,6 +351,19 @@ mod tests {
                 reasons[&"testFailWithRequire()".to_owned()],
                 vec!["constructor".to_owned(), "setUp".to_owned(), "four".to_owned()]
             );
+        }
+
+        #[test]
+        fn test_access_list_reset() {
+            let mut runner = runner();
+            let results = runner.test(&Filter::matches_all(), None).unwrap();
+            let results = &results["WhichTest.json:WhichTest"];
+            assert!(results["testA()"].success);
+            assert_eq!(results["testA()"].gas_used, 65577);
+            assert!(results["testB()"].success);
+            assert_eq!(results["testB()"].gas_used, 68263);
+            assert!(results["testC()"].success);
+            assert_eq!(results["testC()"].gas_used, 63611);
         }
 
         #[test]

--- a/forge/testdata/WarmColdTest.sol
+++ b/forge/testdata/WarmColdTest.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.7;
+
+contract DsTestMini {
+    bool public failed;
+
+    function fail() private {
+        failed = true;
+    }
+
+    function assertEq(uint a, uint b) internal {
+        if (a != b) {
+            fail();
+        }
+    }
+}
+
+contract Which {
+    uint256[] public s_playerFunds;
+    uint256 public s_totalFunds;
+
+    constructor() {
+        s_playerFunds = [
+            1,
+            15,
+            22,
+            199,
+            234,
+            5,
+            234,
+            5,
+            2345,
+            234,
+            555,
+            23423,
+            55
+        ];
+    }
+
+    function a() public {
+        uint256 totalFunds;
+        for (uint256 i = 0; i < s_playerFunds.length; i++) {
+            totalFunds = totalFunds + s_playerFunds[i];
+        }
+        s_totalFunds = totalFunds;
+    }
+
+    function b() external {
+        for (uint256 i = 0; i < s_playerFunds.length; i++) {
+            s_totalFunds += s_playerFunds[i];
+        }
+    }
+
+    function c() public {
+        uint256 totalFunds;
+        uint256[] memory playerFunds = s_playerFunds;
+        for (uint256 i = 0; i < playerFunds.length; i++) {
+            totalFunds = totalFunds + playerFunds[i];
+        }
+        s_totalFunds = totalFunds;
+    }
+}
+
+contract WhichTest is DsTestMini {
+    Which internal which;
+
+    function setUp() public {
+        which = new Which();
+    }
+
+    function testA() public {
+        which.a();
+    }
+
+    function testB() public {
+        which.b();
+    }
+
+    function testC() public {
+        which.c();
+    }
+}


### PR DESCRIPTION
fixes issues raised in this thread: https://twitter.com/brockjelmore/status/1504117274726342658?s=20&t=rJdFbrrfOeB8DocpF_apwg

since we reuse the evm after setup, the access list wouldnt get reset. so effectively, if you do a bunch of state changes inside setUp, those addresses and slots would be warm instead of cold in a test call