### PR TITLE
feat(forge): Expand forge install error handling

### DIFF
--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -88,8 +88,7 @@ pub(crate) fn install(
 /// installs the dependency as an ordinary folder instead of a submodule
 fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
     let output = Command::new("git")
-        // --quiet prevents git from sending info messages to stderr
-        .args(&["clone", "--quiet", &dep.url, &dep.name])
+        .args(&["clone", &dep.url, &dep.name])
         .current_dir(&libs)
         .stdout(Stdio::piped())
         .output()?;
@@ -127,8 +126,7 @@ fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
 fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre::Result<()> {
     // install the dep
     let output = Command::new("git")
-        // --quiet prevents git from sending info messages to stderr
-        .args(&["submodule", "add", "--quiet", &dep.url, &dep.name])
+        .args(&["submodule", "add", &dep.url, &dep.name])
         .current_dir(&libs)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -141,6 +141,14 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
         )
     } else if stderr.contains("not a git repository") {
         eyre::bail!("\"{}\" is not a git repository", &dep.url)
+    } else if stderr.contains("paths are ignored by one of your .gitignore files") {
+        let error = stderr
+            .trim()
+            .split('\n')
+            .filter(|l| !l.starts_with("hint:"))
+            .collect::<Vec<&str>>()
+            .join("\n");
+        eyre::bail!("{}", error)
     }
 
     // call update on it

--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -144,11 +144,8 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
     } else if stderr.contains("not a git repository") {
         eyre::bail!("\"{}\" is not a git repository", &dep.url)
     } else if stderr.contains("paths are ignored by one of your .gitignore files") {
-        let error = stderr
-            .lines()
-            .filter(|l| !l.starts_with("hint:"))
-            .collect::<Vec<&str>>()
-            .join("\n");
+        let error =
+            stderr.lines().filter(|l| !l.starts_with("hint:")).collect::<Vec<&str>>().join("\n");
         eyre::bail!("{}", error)
     } else if !&output.status.success() {
         eyre::bail!("{}", stderr.trim())

--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -147,8 +147,7 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
         eyre::bail!("\"{}\" is not a git repository", &dep.url)
     } else if stderr.contains("paths are ignored by one of your .gitignore files") {
         let error = stderr
-            .trim()
-            .split('\n')
+            .lines()
             .filter(|l| !l.starts_with("hint:"))
             .collect::<Vec<&str>>()
             .join("\n");

--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -102,7 +102,7 @@ fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
             "Destination path \"{}\" already exists and is not an empty directory.",
             &dep.name
         )
-    } else if !stderr.trim().is_empty() {
+    } else if !&output.status.success() {
         eyre::bail!("{}", stderr.trim())
     }
 
@@ -150,7 +150,7 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
             .collect::<Vec<&str>>()
             .join("\n");
         eyre::bail!("{}", error)
-    } else if !stderr.trim().is_empty() {
+    } else if !&output.status.success() {
         eyre::bail!("{}", stderr.trim())
     }
 

--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -102,6 +102,8 @@ fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
             "Destination path \"{}\" already exists and is not an empty directory.",
             &dep.name
         )
+    } else if !stderr.trim().is_empty() {
+        eyre::bail!("{}", stderr.trim())
     }
 
     if let Some(ref tag) = dep.tag {
@@ -149,6 +151,8 @@ fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre:
             .collect::<Vec<&str>>()
             .join("\n");
         eyre::bail!("{}", error)
+    } else if !stderr.trim().is_empty() {
+        eyre::bail!("{}", stderr.trim())
     }
 
     // call update on it

--- a/cli/src/cmd/install.rs
+++ b/cli/src/cmd/install.rs
@@ -88,7 +88,8 @@ pub(crate) fn install(
 /// installs the dependency as an ordinary folder instead of a submodule
 fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
     let output = Command::new("git")
-        .args(&["clone", &dep.url, &dep.name])
+        // --quiet prevents git from sending info messages to stderr
+        .args(&["clone", "--quiet", &dep.url, &dep.name])
         .current_dir(&libs)
         .stdout(Stdio::piped())
         .output()?;
@@ -126,7 +127,8 @@ fn install_as_folder(dep: &Dependency, libs: &Path) -> eyre::Result<()> {
 fn install_as_submodule(dep: &Dependency, libs: &Path, no_commit: bool) -> eyre::Result<()> {
     // install the dep
     let output = Command::new("git")
-        .args(&["submodule", "add", &dep.url, &dep.name])
+        // --quiet prevents git from sending info messages to stderr
+        .args(&["submodule", "add", "--quiet", &dep.url, &dep.name])
         .current_dir(&libs)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Motivation

`forge install` eats unknown errors and fails silently, reporting a successful install when there wasn't one.

## Solution

`install_as_submodule` now handles a (common?) error related to `git submodule add` failing when the added path is blocked by `.gitignore`.

In addition a catch-all was added to `install_as_submodule` and `install_as_folder` to report unexpected errors instead of failing silently.

The `--quiet` flag was added to prevent `git` from sending info messages to `stderr`, which is its default behavior.
