### PR TITLE
fix: fix prank cheatcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.2.0"
-source = "git+https://github.com/bluealloy/revm#db1812f5f53b1b00c9f1bc4a0b7484dd291b4b9c"
+source = "git+https://github.com/bluealloy/revm#7a5a2cdddf253c8500ba46eef3f05c1f1c59f0d1"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "0.4.0"
-source = "git+https://github.com/bluealloy/revm#db1812f5f53b1b00c9f1bc4a0b7484dd291b4b9c"
+source = "git+https://github.com/bluealloy/revm#7a5a2cdddf253c8500ba46eef3f05c1f1c59f0d1"
 dependencies = [
  "bytes",
  "k256",

--- a/evm/src/executor/inspector/cheatcodes/env.rs
+++ b/evm/src/executor/inspector/cheatcodes/env.rs
@@ -41,8 +41,9 @@ fn prank(
         new_caller,
         new_origin,
         // Note: When calling a cheatcode, the depth is not increased. Because of that, the depth
-        // we actually want to prank at is 1 level deeper.
-        depth: depth + 1,
+        // we actually want to prank at is 1 level deeper. However, because pranks are applied
+        // *before* the depth is increased, we need to go a whole TWO levels deeper!
+        depth: depth + 2,
         single_call,
     };
 

--- a/evm/src/executor/inspector/debugger.rs
+++ b/evm/src/executor/inspector/debugger.rs
@@ -97,7 +97,7 @@ where
     fn call(
         &mut self,
         data: &mut EVMData<'_, DB>,
-        call: &CallInputs,
+        call: &mut CallInputs,
         _: bool,
     ) -> (Return, Gas, Bytes) {
         self.enter(data.subroutine.depth() as usize, call.contract, false);
@@ -201,7 +201,7 @@ where
     fn create(
         &mut self,
         data: &mut EVMData<'_, DB>,
-        call: &CreateInputs,
+        call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // TODO: Does this increase gas cost?
         data.subroutine.load_account(call.caller, data.db);

--- a/evm/src/executor/inspector/logs.rs
+++ b/evm/src/executor/inspector/logs.rs
@@ -61,7 +61,7 @@ where
     fn call(
         &mut self,
         _: &mut EVMData<'_, DB>,
-        call: &CallInputs,
+        call: &mut CallInputs,
         _: bool,
     ) -> (Return, Gas, Bytes) {
         if call.contract == *HARDHAT_CONSOLE_ADDRESS {

--- a/evm/src/executor/inspector/stack.rs
+++ b/evm/src/executor/inspector/stack.rs
@@ -109,7 +109,7 @@ where
     fn call(
         &mut self,
         data: &mut EVMData<'_, DB>,
-        call: &CallInputs,
+        call: &mut CallInputs,
         is_static: bool,
     ) -> (Return, Gas, Bytes) {
         call_inspectors!(
@@ -164,7 +164,7 @@ where
     fn create(
         &mut self,
         data: &mut EVMData<'_, DB>,
-        call: &CreateInputs,
+        call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         call_inspectors!(
             inspector,

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -65,7 +65,7 @@ where
     fn call(
         &mut self,
         data: &mut EVMData<'_, DB>,
-        call: &CallInputs,
+        call: &mut CallInputs,
         _: bool,
     ) -> (Return, Gas, Bytes) {
         if call.contract != *HARDHAT_CONSOLE_ADDRESS {
@@ -119,7 +119,7 @@ where
     fn create(
         &mut self,
         data: &mut EVMData<'_, DB>,
-        call: &CreateInputs,
+        call: &mut CreateInputs,
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // TODO: Does this increase gas cost?
         data.subroutine.load_account(call.caller, data.db);


### PR DESCRIPTION
Correctly apply `msg.sender` prank to both transfers and calls. Previously the sender was changed, but after we had already checked if our previous non-pranked sender had enough funds for any transfers in the call. 

With https://github.com/bluealloy/revm/pull/84 we know apply the prank in `call` and `create` before this check happens. 
Unfortunately, this is also before the call depth is increased, so there is some annoying depth math involved