### PR TITLE
feat(utils): decode `expectRevert(bytes4)` cheatcode

### DIFF
--- a/evm-adapters/src/call_tracing.rs
+++ b/evm-adapters/src/call_tracing.rs
@@ -518,7 +518,6 @@ impl CallTrace {
 
                     #[cfg(feature = "sputnik")]
                     if self.addr == *CHEATCODE_ADDRESS && func.name == "expectRevert" {
-                        // try to decode better than just `bytes` for `expectRevert`
                         if let Ok(decoded) =
                             foundry_utils::decode_revert(&self.data, Some(exec_info.errors))
                         {


### PR DESCRIPTION
## Motivation

Fondry is not decoding error selectors for `expectRevert(bytes4)` cheatcode.

Sample code:
```solidity
// SPDX-License-Identifier: GPL-3.0-or-later
pragma solidity 0.8.12;

import { Vm } from "forge-std/Vm.sol";
import { DSTest } from "ds-test/test.sol";

error A();

contract DecodeSelectorTest is DSTest {
  Vm internal vm = Vm(HEVM_ADDRESS);

  function testExpectRevertBytes4() external {
    vm.expectRevert(A.selector);
    this.revertA();
  }

  function revertA() external pure {
    revert A();
  }
}
```

Current output:
```log
Running 1 test for DecodeSelectorTest.json:DecodeSelectorTest
[PASS] testExpectRevertBytes4() (gas: 3638)
Traces:

  [3638] DecodeSelectorTest::testExpectRevertBytes4()
    ├─ [0] VM::expectRevert(0xf446c1d0)
    │   └─ ← ()
    ├─ [164] DecodeSelectorTest::revertA()
    │   └─ ← "A()"
    └─ ← ()
```
## Solution

Decode the 4 bytes selector following `expectRevert(bytes)` implementation.

New output:
```log
Running 1 test for DecodeSelectorTest.json:DecodeSelectorTest
[PASS] testExpectRevertBytes4() (gas: 3638)
Traces:

  [3638] DecodeSelectorTest::testExpectRevertBytes4()
    ├─ [0] VM::expectRevert(A())
    │   └─ ← ()
    ├─ [164] DecodeSelectorTest::revertA()
    │   └─ ← "A()"
    └─ ← ()
```
