### PR TITLE
feat: alpine based docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:alpine as builder
+
+ENV GLIBC_REPO=https://github.com/sgerrand/alpine-pkg-glibc
+ENV GLIBC_VERSION=2.35-r0
+
+RUN set -ex && apk update \
+    && apk add --no-cache ca-certificates \
+        curl bash git jq build-base linux-headers libstdc++ ca-certificates \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
+    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
+        do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done \
+    && apk add --no-cache /tmp/*.apk \
+    && rm /tmp/*.apk
+
+WORKDIR /usr/src/foundry
+COPY . .
+
+ENV RUSTFLAGS="-C target-cpu=native"
+RUN cargo build --release
+
+RUN strip /usr/src/foundry/target/release/cast \
+    && strip /usr/src/foundry/target/release/forge
+
+FROM alpine:latest
+
+COPY --from=builder /usr/src/foundry/target/release/cast /usr/local/bin/cast
+COPY --from=builder /usr/src/foundry/target/release/forge /usr/local/bin/forge
+
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -71,7 +71,7 @@ pub trait Cmd: clap::Parser + Sized {
     fn run(self) -> eyre::Result<Self::Output>;
 }
 
-use ethers::solc::{artifacts::CompactContractBytecode, Project, ProjectCompileOutput};
+use ethers::solc::{artifacts::CompactContractBytecode, Artifact, Project, ProjectCompileOutput};
 
 use foundry_utils::to_table;
 
@@ -125,16 +125,10 @@ If you are in a subdirectory in a Git repository, try adding `--root .`"#,
             let mut sizes = BTreeMap::new();
             for (_, contracts) in compiled_contracts.into_iter() {
                 for (name, contract) in contracts {
-                    let bytecode: CompactContractBytecode = contract.into();
-                    let size = if let Some(code) = bytecode.bytecode {
-                        if let Some(object) = code.object.as_bytes() {
-                            object.to_vec().len()
-                        } else {
-                            0
-                        }
-                    } else {
-                        0
-                    };
+                    let size = contract
+                        .get_bytecode_bytes()
+                        .map(|bytes| bytes.0.len())
+                        .unwrap_or_default();
                     sizes.insert(name, size);
                 }
             }


### PR DESCRIPTION
## Motivation

I have tasks that need to run in the cloud where bringing up a K8s pod
that I can attach to with `cast` would be nice. A docker image is required
for this and I'm sure other people would want a docker image so putting
the dockerfile here makes sense.

## Solution

This commit creates a docker image that includes
both `cast` and `forge`.

It builds off of https://github.com/gakonst/foundry/pull/914.

The image comes out to 26.4MB.

```bash
/ # du -h /usr/local/bin/forge
12.8M   /usr/local/bin/forge
/ # du -h /usr/local/bin/cast
7.1M    /usr/local/bin/cast
```

Example usage:

```bash
$ docker run --rm --entrypoint cast foundry:latest block --rpc-url https://mainnet.optimism.io latest
$ docker run --rm foundry:latest 'cast block --rpc-url https://mainnet.optimism.io latest'
```

Co-authored-by: Abdul Rabbani

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
---

One question is whether or not the container should include `bash` - some people might want to mount in bash scripts to run. I personally think yes but did not include `bash` in the image as to keep it minimal, will update if there is consensus around this.