### PR TITLE
Update forge readme with new hevm cheatcode

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -166,6 +166,10 @@ which implements the following methods:
 
 - `function getCode(string calldata) external returns (bytes memory)`: Fetches bytecode from a contract artifact. The parameter can either be in the form `ContractFile.sol` (if the filename and contract name are the same), `ContractFile.sol:ContractName`, or `./path/to/artifact.json`.
 
+- `function label(address addr, string calldata label) external`: Label an address in test traces.
+
+- `function assume(bool) external`: When fuzzing, generate new inputs if conditional not met
+
 The below example uses the `warp` cheatcode to override the timestamp & `expectRevert` to expect a specific revert string:
 
 ```solidity
@@ -233,59 +237,88 @@ contract ExpectEmit {
 A full interface for all cheatcodes is here:
 ```solidity
 interface Hevm {
-    // Set block.timestamp (newTimestamp)
-    function warp(uint256) external;
-    // Set block.height (newHeight)
+    interface CheatCodes {
+      function warp(uint256) external;
+    // Set block.timestamp
+
     function roll(uint256) external;
-    // Set block.basefee (newBasefee)
+    // Set block.number
+
     function fee(uint256) external;
-    // Loads a storage slot from an address (who, slot)
-    function load(address,bytes32) external returns (bytes32);
-    // Stores a value to an address' storage slot, (who, slot, value)
-    function store(address,bytes32,bytes32) external;
-    // Signs data, (privateKey, digest) => (v, r, s)
-    function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
-    // Gets address for a given private key, (privateKey) => (address)
-    function addr(uint256) external returns (address);
-    // Performs a foreign function call via terminal, (stringInputs) => (result)
+    // Set block.basefee
+
+    function load(address account, bytes32 slot) external returns (bytes32);
+    // Loads a storage slot from an address
+
+    function store(address account, bytes32 slot, bytes32 value) external;
+    // Stores a value to an address' storage slot
+
+    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+    // Signs data
+
+    function addr(uint256 privateKey) external returns (address);
+    // Computes address for a given private key
+
     function ffi(string[] calldata) external returns (bytes memory);
-    // Sets the *next* call's msg.sender to be the input address
+    // Performs a foreign function call via terminal
+
     function prank(address) external;
-    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
+    // Sets the *next* call's msg.sender to be the input address
+
     function startPrank(address) external;
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
+
+    function prank(address, address) external;
     // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
-    function prank(address,address) external;
+
+    function startPrank(address, address) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
-    function startPrank(address,address) external;
-    // Resets subsequent calls' msg.sender to be `address(this)`
+
     function stopPrank() external;
-    // Sets an address' balance, (who, newBalance)
-    function deal(address, uint256) external;
-    // Sets an address' code, (who, newCode)
-    function etch(address, bytes calldata) external;
-    // Expects an error on next call
+    // Resets subsequent calls' msg.sender to be `address(this)`
+
+    function deal(address who, uint256 newBalance) external;
+    // Sets an address' balance
+
+    function etch(address who, bytes calldata code) external;
+    // Sets an address' code
+
     function expectRevert(bytes calldata) external;
     function expectRevert(bytes4) external;
-    // Record all storage reads and writes
+    // Expects an error on next call
+
     function record() external;
-    // Gets all accessed reads and write slot from a recording session, for a given address
+    // Record all storage reads and writes
+
     function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    // Gets all accessed reads and write slot from a recording session, for a given address
+
+    function expectEmit(bool, bool, bool, bool) external;
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
     // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
-    function expectEmit(bool,bool,bool,bool) external;
+
+    function mockCall(address, bytes calldata, bytes calldata) external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity
     // function will be mocked.
-    function mockCall(address,bytes calldata,bytes calldata) external;
-    // Clears all mocked calls
+
     function clearMockedCalls() external;
+    // Clears all mocked calls
+
+    function expectCall(address, bytes calldata) external;
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
-    function expectCall(address,bytes calldata) external;
-    // Fetches the contract bytecode from its artifact file
+
     function getCode(string calldata) external returns (bytes memory);
+    // Gets the bytecode for a contract in the project given the path to the contract.
+
+    function label(address addr, string calldata label) external;
+    // Label an address in test traces
+
+    function assume(bool) external;
+    // When fuzzing, generate new inputs if conditional not met
 }
 ```
 ### `console.log`

--- a/forge/README.md
+++ b/forge/README.md
@@ -237,8 +237,7 @@ contract ExpectEmit {
 A full interface for all cheatcodes is here:
 ```solidity
 interface Hevm {
-    interface CheatCodes {
-      function warp(uint256) external;
+    function warp(uint256) external;
     // Set block.timestamp
 
     function roll(uint256) external;

--- a/forge/README.md
+++ b/forge/README.md
@@ -237,87 +237,63 @@ contract ExpectEmit {
 A full interface for all cheatcodes is here:
 ```solidity
 interface Hevm {
+    // Set block.timestamp (newTimestamp)
     function warp(uint256) external;
-    // Set block.timestamp
-
+    // Set block.height (newHeight)
     function roll(uint256) external;
-    // Set block.number
-
+    // Set block.basefee (newBasefee)
     function fee(uint256) external;
-    // Set block.basefee
-
-    function load(address account, bytes32 slot) external returns (bytes32);
-    // Loads a storage slot from an address
-
-    function store(address account, bytes32 slot, bytes32 value) external;
-    // Stores a value to an address' storage slot
-
-    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
-    // Signs data
-
-    function addr(uint256 privateKey) external returns (address);
-    // Computes address for a given private key
-
+    // Loads a storage slot from an address (who, slot)
+    function load(address,bytes32) external returns (bytes32);
+    // Stores a value to an address' storage slot, (who, slot, value)
+    function store(address,bytes32,bytes32) external;
+    // Signs data, (privateKey, digest) => (v, r, s)
+    function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
+    // Gets address for a given private key, (privateKey) => (address)
+    function addr(uint256) external returns (address);
+    // Performs a foreign function call via terminal, (stringInputs) => (result)
     function ffi(string[] calldata) external returns (bytes memory);
-    // Performs a foreign function call via terminal
-
-    function prank(address) external;
     // Sets the *next* call's msg.sender to be the input address
-
-    function startPrank(address) external;
+    function prank(address) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
-
-    function prank(address, address) external;
+    function startPrank(address) external;
     // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
-
-    function startPrank(address, address) external;
+    function prank(address,address) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
-
-    function stopPrank() external;
+    function startPrank(address,address) external;
     // Resets subsequent calls' msg.sender to be `address(this)`
-
-    function deal(address who, uint256 newBalance) external;
-    // Sets an address' balance
-
-    function etch(address who, bytes calldata code) external;
-    // Sets an address' code
-
+    function stopPrank() external;
+    // Sets an address' balance, (who, newBalance)
+    function deal(address, uint256) external;
+    // Sets an address' code, (who, newCode)
+    function etch(address, bytes calldata) external;
+    // Expects an error on next call
     function expectRevert(bytes calldata) external;
     function expectRevert(bytes4) external;
-    // Expects an error on next call
-
-    function record() external;
     // Record all storage reads and writes
-
-    function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
-
-    function expectEmit(bool, bool, bool, bool) external;
+    function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
     // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
-
-    function mockCall(address, bytes calldata, bytes calldata) external;
+    function expectEmit(bool,bool,bool,bool) external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity
     // function will be mocked.
-
-    function clearMockedCalls() external;
+    function mockCall(address,bytes calldata,bytes calldata) external;
     // Clears all mocked calls
-
-    function expectCall(address, bytes calldata) external;
+    function clearMockedCalls() external;
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
-
+    function expectCall(address,bytes calldata) external;
+    // Fetches the contract bytecode from its artifact file
     function getCode(string calldata) external returns (bytes memory);
-    // Gets the bytecode for a contract in the project given the path to the contract.
-
-    function label(address addr, string calldata label) external;
     // Label an address in test traces
-
-    function assume(bool) external;
+    function label(address addr, string calldata label) external;
     // When fuzzing, generate new inputs if conditional not met
+    function assume(bool) external;
 }
 ```
 ### `console.log`


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The new added hevm cheat code  `label` and `assume` are not updated on the forge readme page.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
I appended the new  hevm cheat code  `label` and `assume` under the forge readme's `Cheat codes`
<img width="762" alt="image" src="https://user-images.githubusercontent.com/94717259/159073931-4f3b1a34-3754-4d71-b621-f4dae31da375.png">
<img width="582" alt="image" src="https://user-images.githubusercontent.com/94717259/159074697-b5652135-845b-4bda-8a41-8c271ba45876.png">

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
