### PR TITLE
refactor: use revm `log` hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,6 +3587,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.2.0"
+source = "git+https://github.com/bluealloy/revm#cb5fbb9adc36c8ee127dce92259356cecbb829b8"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3602,6 +3603,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "0.4.0"
+source = "git+https://github.com/bluealloy/revm#cb5fbb9adc36c8ee127dce92259356cecbb829b8"
 dependencies = [
  "bytes",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,7 +3587,6 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.2.0"
-source = "git+https://github.com/bluealloy/revm#7a5a2cdddf253c8500ba46eef3f05c1f1c59f0d1"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3603,7 +3602,6 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "0.4.0"
-source = "git+https://github.com/bluealloy/revm#7a5a2cdddf253c8500ba46eef3f05c1f1c59f0d1"
 dependencies = [
  "bytes",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ codegen-units = 1
 panic = "abort"
 debug = true
 
-[patch."https://github.com/bluealloy/revm"]
-revm = { path = "../../bluealloy/revm/crates/revm" }
-
 ## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
 #[patch."https://github.com/gakonst/ethers-rs"]
 #ethers = { path = "../ethers-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ codegen-units = 1
 panic = "abort"
 debug = true
 
+[patch."https://github.com/bluealloy/revm"]
+revm = { path = "../../bluealloy/revm/crates/revm" }
+
 ## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
 #[patch."https://github.com/gakonst/ethers-rs"]
 #ethers = { path = "../ethers-rs" }

--- a/evm/src/executor/inspector/stack.rs
+++ b/evm/src/executor/inspector/stack.rs
@@ -1,6 +1,6 @@
 use super::{Cheatcodes, Debugger, LogCollector, Tracer};
 use bytes::Bytes;
-use ethers::types::Address;
+use ethers::types::{Address, H256};
 use revm::{db::Database, CallInputs, CreateInputs, EVMData, Gas, Inspector, Interpreter, Return};
 
 /// Helper macro to call the same method on multiple inspectors without resorting to dynamic
@@ -81,6 +81,18 @@ where
         );
 
         Return::Continue
+    }
+
+    fn log(
+        &mut self,
+        evm_data: &mut EVMData<'_, DB>,
+        address: &Address,
+        topics: &[H256],
+        data: &Bytes,
+    ) {
+        call_inspectors!(inspector, [&mut self.tracer, &mut self.logs, &mut self.cheatcodes], {
+            inspector.log(evm_data, address, topics, data);
+        });
     }
 
     fn step_end(

--- a/evm/src/executor/inspector/utils.rs
+++ b/evm/src/executor/inspector/utils.rs
@@ -17,27 +17,6 @@ macro_rules! try_or_continue {
     };
 }
 
-/// Tries to convert a U256 to a usize and returns from the function on an error.
-///
-/// This is useful for opcodes that deal with the stack where parameters might be invalid and you
-/// want to defer error handling to the VM itself.
-macro_rules! as_usize_or_return {
-    ($v:expr) => {
-        if $v.0[1] != 0 || $v.0[2] != 0 || $v.0[3] != 0 {
-            return
-        } else {
-            $v.0[0] as usize
-        }
-    };
-    ($v:expr, $r:expr) => {
-        if $v.0[1] != 0 || $v.0[2] != 0 || $v.0[3] != 0 {
-            return $r
-        } else {
-            $v.0[0] as usize
-        }
-    };
-}
-
 /// Get the address of a contract creation
 pub fn get_create_address(call: &CreateInputs, nonce: u64) -> Address {
     match call.scheme {


### PR DESCRIPTION
Uses the `Inspector::log` hook in REVM. Blocked by https://github.com/bluealloy/revm/pull/85