### PR TITLE
feat: add storage diskmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1285,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1384,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1439,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#679ba09b92dc8b61963721354fea8490d9d9e04b"
+source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "colored",
  "dunce",
@@ -1709,6 +1709,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -37,3 +37,6 @@ proptest = "1.0.0"
 
 # Display
 ansi_term = "0.12.1"
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -14,6 +14,9 @@ pub use executor::abi;
 /// Fuzzing wrapper for executors
 pub mod fuzz;
 
+/// Support for storing things and disk.
+pub mod storage;
+
 // Re-exports
 pub use ethers::types::Address;
 pub use hashbrown::HashMap;

--- a/evm/src/storage/diskmap.rs
+++ b/evm/src/storage/diskmap.rs
@@ -1,0 +1,115 @@
+use std::{collections::HashMap, fmt, fs, hash, ops, path::PathBuf};
+
+use tracing::{trace, warn};
+
+/// Disk-serializable HashMap
+///
+/// How to read and save the contents of the type will be up to the user,
+/// See [DiskMap::save()], [DiskMap::reload()]
+#[derive(Debug)]
+pub(crate) struct DiskMap<K: hash::Hash + Eq, V> {
+    /// Where this file is stored
+    path: PathBuf,
+    /// Data it holds
+    cache: HashMap<K, V>,
+    /// Whether to write to disk
+    transient: bool,
+}
+
+impl<K: hash::Hash + Eq, V> ops::Deref for DiskMap<K, V> {
+    type Target = HashMap<K, V>;
+    fn deref(&self) -> &Self::Target {
+        &self.cache
+    }
+}
+
+impl<K: hash::Hash + Eq, V> ops::DerefMut for DiskMap<K, V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cache
+    }
+}
+
+impl<K: hash::Hash + Eq, V> DiskMap<K, V> {
+    /// Creates a new, empty `DiskMap`
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        trace!("path={:?}", path);
+        DiskMap { path, cache: HashMap::new(), transient: false }
+    }
+
+    /// Reads the contents of the diskmap file and returns the read cache
+    pub fn read<F, E>(path: impl Into<PathBuf>, read: F) -> Self
+    where
+        F: Fn(fs::File) -> Result<HashMap<K, V>, E>,
+        E: fmt::Display,
+    {
+        let mut map = Self::new(path);
+        trace!("reading diskmap path={:?}", map.path);
+        map.reload(read);
+        map
+    }
+
+    /// The path where the diskmap is (will be) stored
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    /// Consumes the type and returns the underlying map
+    pub fn into_inner(self) -> HashMap<K, V> {
+        self.cache
+    }
+
+    /// Sets the `transient` to the given bool value
+    pub fn set_transient(mut self, transient: bool) -> Self {
+        self.transient = transient;
+        self
+    }
+
+    /// Marks the cache as transient.
+    ///
+    /// A transient cache will never be written to disk
+    pub fn transient(self) -> Self {
+        self.set_transient(true)
+    }
+
+    /// Reloads the cache.
+    ///
+    /// This will replace the current cache with the contents of the file the diskmap points to,
+    /// overwriting all changes
+    fn reload<F, E>(&mut self, read: F)
+    where
+        F: Fn(fs::File) -> Result<HashMap<K, V>, E>,
+        E: fmt::Display,
+    {
+        if self.transient {
+            return
+        }
+        trace!("reverting diskmap {:?}", self.path);
+        let _ = fs::File::open(self.path.clone())
+            .map_err(|e| trace!("Failed to open disk map: {}", e))
+            .and_then(|f| read(f).map_err(|e| warn!("Failed to read disk map: {}", e)))
+            .and_then(|m| {
+                self.cache = m;
+                Ok(())
+            });
+    }
+
+    /// Saves the diskmap to the file it points to
+    ///
+    /// The closure is expected to do the actual writing
+    pub fn save<F, E>(&self, write: F)
+    where
+        F: Fn(&HashMap<K, V>, &mut fs::File) -> Result<(), E>,
+        E: fmt::Display,
+    {
+        if self.transient {
+            return
+        }
+        trace!("saving diskmap {:?}", self.path);
+        let _ = fs::File::create(&self.path)
+            .map_err(|e| warn!("Failed to open disk map for writing: {}", e))
+            .and_then(|mut f| {
+                write(&self.cache, &mut f).map_err(|e| warn!("Failed to write to disk map: {}", e))
+            });
+    }
+}

--- a/evm/src/storage/diskmap.rs
+++ b/evm/src/storage/diskmap.rs
@@ -84,13 +84,12 @@ impl<K: hash::Hash + Eq, V> DiskMap<K, V> {
         if self.transient {
             return
         }
-        trace!("reverting diskmap {:?}", self.path);
+        trace!("reloading diskmap {:?}", self.path);
         let _ = fs::File::open(self.path.clone())
             .map_err(|e| trace!("Failed to open disk map: {}", e))
             .and_then(|f| read(f).map_err(|e| warn!("Failed to read disk map: {}", e)))
-            .and_then(|m| {
+            .map(|m| {
                 self.cache = m;
-                Ok(())
             });
     }
 

--- a/evm/src/storage/mod.rs
+++ b/evm/src/storage/mod.rs
@@ -15,6 +15,15 @@ pub struct StorageMap {
 
 impl StorageMap {
     /// Creates new storage map at given _directory_.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    ///  use foundry_evm::storage::StorageMap;
+    /// let mut map = StorageMap::read("data dir");
+    /// map.insert(100u64.into(), 99u64.into());
+    /// map.save();
+    /// ```
     pub fn read(path: impl AsRef<Path>) -> Self {
         StorageMap { cache: diskmap::DiskMap::read(path.as_ref().join("storage.json"), read_u256) }
     }
@@ -77,7 +86,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn should_save_and_reload_storage_map() {
+    fn can_save_and_reload_storage_map() {
         let tempdir = tempdir().unwrap();
         let mut map = StorageMap::read(tempdir.path());
         map.set_value(100u64.into(), 300u64.into());

--- a/evm/src/storage/mod.rs
+++ b/evm/src/storage/mod.rs
@@ -1,0 +1,96 @@
+//! disk storage support and helpers
+
+use ethers::types::U256;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+pub mod diskmap;
+
+/// Disk-backed map for storage slots, uses json.
+pub struct StorageMap {
+    cache: diskmap::DiskMap<U256, U256>,
+}
+
+impl StorageMap {
+    /// Creates new storage map at given _directory_.
+    pub fn read(path: impl AsRef<Path>) -> Self {
+        StorageMap { cache: diskmap::DiskMap::read(path.as_ref().join("storage.json"), read_u256) }
+    }
+
+    /// Creates transient storage map (no changes are saved to disk).
+    pub fn transient() -> Self {
+        StorageMap { cache: diskmap::DiskMap::new("storage.json").transient() }
+    }
+
+    /// The path where the diskmap is (will be) stored
+    pub fn path(&self) -> &PathBuf {
+        self.cache.path()
+    }
+
+    /// Get the cache map.
+    pub fn inner(&self) -> &HashMap<U256, U256> {
+        &self.cache
+    }
+
+    /// Consumes the type and returns the underlying map
+    pub fn into_inner(self) -> HashMap<U256, U256> {
+        self.cache.into_inner()
+    }
+
+    pub fn save(&self) {
+        self.cache.save(write_u256)
+    }
+
+    /// Sets new value for given U256.
+    pub fn set_value(&mut self, key: U256, value: U256) -> Option<U256> {
+        self.cache.insert(key, value)
+    }
+
+    /// Removes an entry
+    pub fn remove(&mut self, key: U256) {
+        self.cache.remove(&key);
+    }
+}
+
+/// Read a hash map of U256 -> U256
+fn read_u256<R>(reader: R) -> Result<HashMap<U256, U256>, serde_json::Error>
+where
+    R: ::std::io::Read,
+{
+    serde_json::from_reader(reader)
+}
+
+/// Write a hash map of U256 -> U256
+fn write_u256<W>(m: &HashMap<U256, U256>, writer: &mut W) -> Result<(), serde_json::Error>
+where
+    W: ::std::io::Write,
+{
+    serde_json::to_writer(writer, m)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tempfile::tempdir;
+
+    #[test]
+    fn should_save_and_reload_storage_map() {
+        let tempdir = tempdir().unwrap();
+        let mut map = StorageMap::read(tempdir.path());
+        map.set_value(100u64.into(), 300u64.into());
+        map.set_value(1337u64.into(), 99u64.into());
+        map.save();
+
+        let map = StorageMap::read(tempdir.path());
+        assert_eq!(
+            map.into_inner(),
+            HashMap::<U256, U256>::from([
+                (100u64.into(), 300u64.into()),
+                (1337u64.into(), 99u64.into()),
+            ])
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Add diskmap type that can be used to store things on disk.
StorageMap stores storage entries, which we will use to enable storage caching
ref #1000 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
