### PR TITLE
feat(forge): stderr output for ffi processes

### DIFF
--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -22,7 +22,10 @@ use sputnik::{
     gasometer, Capture, Config, Context, CreateScheme, ExitError, ExitReason, ExitRevert,
     ExitSucceed, Handler, Memory, Opcode, Runtime, Transfer,
 };
-use std::{process::Command, process::Stdio, rc::Rc};
+use std::{
+    process::{Command, Stdio},
+    rc::Rc,
+};
 
 use ethers::{
     abi::{RawLog, Token},
@@ -671,13 +674,12 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 }
 
                 // execute the command & get the stdout
-                let output = match Command::new(&args[0])
-                    .args(&args[1..])
-                    .stderr(Stdio::inherit())
-                    .output() {
-                    Ok(res) => res.stdout,
-                    Err(err) => return evm_error(&err.to_string()),
-                };
+                let output =
+                    match Command::new(&args[0]).args(&args[1..]).stderr(Stdio::inherit()).output()
+                    {
+                        Ok(res) => res.stdout,
+                        Err(err) => return evm_error(&err.to_string()),
+                    };
 
                 // get the hex string
                 let output = unsafe { std::str::from_utf8_unchecked(&output) };

--- a/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
+++ b/evm-adapters/src/sputnik/cheatcodes/cheatcode_handler.rs
@@ -22,7 +22,7 @@ use sputnik::{
     gasometer, Capture, Config, Context, CreateScheme, ExitError, ExitReason, ExitRevert,
     ExitSucceed, Handler, Memory, Opcode, Runtime, Transfer,
 };
-use std::{process::Command, rc::Rc};
+use std::{process::Command, process::Stdio, rc::Rc};
 
 use ethers::{
     abi::{RawLog, Token},
@@ -671,7 +671,10 @@ impl<'a, 'b, B: Backend, P: PrecompileSet> CheatcodeStackExecutor<'a, 'b, B, P> 
                 }
 
                 // execute the command & get the stdout
-                let output = match Command::new(&args[0]).args(&args[1..]).output() {
+                let output = match Command::new(&args[0])
+                    .args(&args[1..])
+                    .stderr(Stdio::inherit())
+                    .output() {
                     Ok(res) => res.stdout,
                     Err(err) => return evm_error(&err.to_string()),
                 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The stderr output of an FFI process currently gets ignored making it hard to debug FFI commands.

## Solution

This PR instead pipes the process stderr to forge's stderr. This allows use of `console.error(...)` and equivalents to get output and debug FFI scripts.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
