### PR TITLE
docs: fix broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# <h1 align="center"> foundry </h1>
+# <h1 align="center">Foundry</h1>
 
-![Github Actions](https://github.com/gakonst/foundry/workflows/Tests/badge.svg)
+![Github Actions](https://img.shields.io/github/workflow/status/gakonst/foundry/test?style=flat-square)
 [![Telegram Chat][tg-badge]][tg-url] [![Crates.io][crates-badge]][crates-url]
 
-[crates-badge]: https://img.shields.io/crates/v/foundry.svg
+[crates-badge]: https://img.shields.io/crates/v/foundry.svg?style=flat-square
 [crates-url]: https://crates.io/crates/foundry-rs
 [tg-badge]:
-  https://img.shields.io/endpoint?color=neon&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Ffoundry_rs
+  https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Ffoundry_rs
 [tg-url]: https://t.me/foundry_rs
 
 **Foundry is a blazing fast, portable and modular toolkit for Ethereum
@@ -153,9 +153,9 @@ You can find additional setup guides in the [Foundry Book][foundry-book]:
 - [Setting up VSCode][vscode-setup]
 - [Shell autocompletions][shell-setup]
 
-[vscode-setup]: https://onbjerg.github.io/foundry-book/guides/vscode.html
+[vscode-setup]: https://onbjerg.github.io/foundry-book/config/vscode.html
 [shell-setup]:
-  https://onbjerg.github.io/foundry-book/guides/shell-autocompletion.html
+  https://onbjerg.github.io/foundry-book/config/shell-autocompletion.html
 
 ### Troubleshooting Installation
 


### PR DESCRIPTION
The book was restructured recently so some of the links are broken. Also makes the badges more consistently styled