### PR TITLE
fix: deployment in forks

### DIFF
--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -21,6 +21,7 @@ pub struct ExecutorBuilder {
     /// The configuration used to build an [InspectorStack].
     inspector_config: InspectorStackConfig,
     fork: Option<Fork>,
+    gas_limit: Option<U256>,
 }
 
 #[derive(Clone, Debug)]
@@ -145,6 +146,15 @@ impl ExecutorBuilder {
         self
     }
 
+    /// Sets the executor gas limit.
+    ///
+    /// See [Executor::gas_limit] for more info on why you might want to set this.
+    #[must_use]
+    pub fn with_gas_limit(mut self, gas_limit: U256) -> Self {
+        self.gas_limit = Some(gas_limit);
+        self
+    }
+
     /// Configure the execution environment (gas limit, chain spec, ...)
     #[must_use]
     pub fn with_config(mut self, env: Env) -> Self {
@@ -163,6 +173,7 @@ impl ExecutorBuilder {
     /// Builds the executor as configured.
     pub fn build(self) -> Executor<Backend> {
         let db = Backend::new(self.fork, &self.env);
-        Executor::new(db, self.env, self.inspector_config)
+        let gas_limit = self.gas_limit.unwrap_or(self.env.block.gas_limit);
+        Executor::new(db, self.env, self.inspector_config, gas_limit)
     }
 }

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -164,13 +164,22 @@ pub struct Executor<DB: DatabaseRef> {
     pub(crate) db: CacheDB<DB>,
     env: Env,
     inspector_config: InspectorStackConfig,
+    /// The gas limit for calls and deployments. This is different from the gas limit imposed by
+    /// the passed in environment, as those limits are used by the EVM for certain opcodes like
+    /// `gaslimit`.
+    gas_limit: U256,
 }
 
 impl<DB> Executor<DB>
 where
     DB: DatabaseRef,
 {
-    pub fn new(inner_db: DB, env: Env, inspector_config: InspectorStackConfig) -> Self {
+    pub fn new(
+        inner_db: DB,
+        env: Env,
+        inspector_config: InspectorStackConfig,
+        gas_limit: U256,
+    ) -> Self {
         let mut db = CacheDB::new(inner_db);
 
         // Need to create a non-empty contract on the cheatcodes address so `extcodesize` checks
@@ -180,7 +189,7 @@ where
             revm::AccountInfo { code: Some(Bytes::from_static(&[1])), ..Default::default() },
         );
 
-        Executor { db, env, inspector_config }
+        Executor { db, env, inspector_config, gas_limit }
     }
 
     /// Set the balance of an account.
@@ -448,7 +457,8 @@ where
         let mut db = CacheDB::new(EmptyDB());
         db.insert_cache(address, self.db.basic(address));
         db.commit(state_changeset);
-        let executor = Executor::new(db, self.env.clone(), self.inspector_config.clone());
+        let executor =
+            Executor::new(db, self.env.clone(), self.inspector_config.clone(), self.gas_limit);
 
         let mut success = !reverted;
         if success {
@@ -470,7 +480,11 @@ where
             // We always set the gas price to 0 so we can execute the transaction regardless of
             // network conditions - the actual gas price is kept in `self.block` and is applied by
             // the cheatcode handler if it is enabled
-            block: BlockEnv { basefee: 0.into(), ..self.env.block.clone() },
+            block: BlockEnv {
+                basefee: 0.into(),
+                gas_limit: self.gas_limit,
+                ..self.env.block.clone()
+            },
             tx: TxEnv {
                 caller,
                 transact_to,
@@ -479,6 +493,7 @@ where
                 // As above, we set the gas price to 0.
                 gas_price: 0.into(),
                 gas_priority_fee: None,
+                gas_limit: self.gas_limit.as_u64(),
                 ..self.env.tx.clone()
             },
         }

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -427,8 +427,14 @@ where
 
         let mut inspector = self.inspector_config.stack();
         let (status, out, gas, _) = evm.inspect_commit(&mut inspector);
-        let address = match out {
-            TransactOut::Create(_, Some(addr)) => addr,
+        let address = match status {
+            return_ok!() => {
+                if let TransactOut::Create(_, Some(addr)) = out {
+                    addr
+                } else {
+                    panic!("deployment succeeded, but we got no address. this is a bug.");
+                }
+            }
             // TODO: We should have better error handling logic in the test runner
             // regarding deployments in general
             _ => eyre::bail!("deployment failed: {:?}", status),

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -57,7 +57,7 @@ impl EvmOpts {
                     timestamp: self.env.block_timestamp.into(),
                     difficulty: self.env.block_difficulty.into(),
                     basefee: self.env.block_base_fee_per_gas.into(),
-                    gas_limit: self.env.block_gas_limit.unwrap_or(self.env.gas_limit).into(),
+                    gas_limit: self.gas_limit(),
                 },
                 cfg: CfgEnv {
                     chain_id: self.env.chain_id.unwrap_or(99).into(),
@@ -66,12 +66,16 @@ impl EvmOpts {
                 },
                 tx: TxEnv {
                     gas_price: self.env.gas_price.into(),
-                    gas_limit: self.env.block_gas_limit.unwrap_or(self.env.gas_limit),
+                    gas_limit: self.gas_limit().as_u64(),
                     caller: self.sender,
                     ..Default::default()
                 },
             }
         }
+    }
+
+    pub fn gas_limit(&self) -> U256 {
+        self.env.block_gas_limit.unwrap_or(self.env.gas_limit).into()
     }
 
     /// Returns the configured chain id, which will be

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -210,6 +210,7 @@ impl MultiContractRunner {
                     .with_cheatcodes(self.evm_opts.ffi)
                     .with_config(env.clone())
                     .with_spec(self.evm_spec)
+                    .with_gas_limit(self.evm_opts.gas_limit())
                     .with_fork(self.fork.clone());
 
                 if self.evm_opts.verbosity >= 3 {


### PR DESCRIPTION
Contains some fixes encountered when running Spells mainnet. We should push out a new nightly as well to make sure this does not affect anyone

Works now, 1 failing test, unsure if unrelated:

```
Failed tests:
[FAIL] test_bytecode_matches() (gas: 2838891)

Encountered a total of 1 failing tests, 19 tests succeeded
```