### PR TITLE
fix(cast): Fix Find Block Nested Tokio Runtime

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -541,7 +541,7 @@ async fn main() -> eyre::Result<()> {
             let selector = contract.abi().functions().last().unwrap().short_signature();
             println!("0x{}", hex::encode(selector));
         }
-        Subcommands::FindBlock(cmd) => cmd.run()?,
+        Subcommands::FindBlock(cmd) => cmd.run()?.await?,
         Subcommands::Wallet { command } => match command {
             WalletSubcommands::New { path, password, unsafe_password } => {
                 let mut rng = thread_rng();

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -5,7 +5,7 @@ use cast::Cast;
 use clap::Parser;
 use ethers::prelude::*;
 use eyre::Result;
-use futures::{join, future::BoxFuture};
+use futures::{future::BoxFuture, join};
 
 #[derive(Debug, Clone, Parser)]
 pub struct FindBlockArgs {
@@ -17,13 +17,6 @@ pub struct FindBlockArgs {
 
 impl Cmd for FindBlockArgs {
     type Output = BoxFuture<'static, Result<()>>;
-
-    // fn run(self) -> Result<Self::Output> {
-    //     let FindBlockArgs { timestamp, rpc_url } = self;
-    //     let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
-    //     rt.block_on(Self::query_block(timestamp, rpc_url))?;
-    //     Ok(())
-    // }
 
     fn run(self) -> Result<Self::Output> {
         let FindBlockArgs { timestamp, rpc_url } = self;

--- a/cli/src/cmd/cast/find_block.rs
+++ b/cli/src/cmd/cast/find_block.rs
@@ -5,7 +5,7 @@ use cast::Cast;
 use clap::Parser;
 use ethers::prelude::*;
 use eyre::Result;
-use futures::join;
+use futures::{join, future::BoxFuture};
 
 #[derive(Debug, Clone, Parser)]
 pub struct FindBlockArgs {
@@ -16,13 +16,18 @@ pub struct FindBlockArgs {
 }
 
 impl Cmd for FindBlockArgs {
-    type Output = ();
+    type Output = BoxFuture<'static, Result<()>>;
+
+    // fn run(self) -> Result<Self::Output> {
+    //     let FindBlockArgs { timestamp, rpc_url } = self;
+    //     let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
+    //     rt.block_on(Self::query_block(timestamp, rpc_url))?;
+    //     Ok(())
+    // }
 
     fn run(self) -> Result<Self::Output> {
         let FindBlockArgs { timestamp, rpc_url } = self;
-        let rt = tokio::runtime::Runtime::new().expect("could not start tokio rt");
-        rt.block_on(Self::query_block(timestamp, rpc_url))?;
-        Ok(())
+        Ok(Box::pin(Self::query_block(timestamp, rpc_url)))
     }
 }
 

--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -39,7 +39,7 @@ macro_rules! forgetest {
     ($test:ident, $style:expr, $fun:expr) => {
         #[test]
         fn $test() {
-            let (prj, cmd) = $crate::util::setup(stringify!($test), $style);
+            let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
             $fun(prj, cmd);
         }
     };
@@ -69,7 +69,7 @@ macro_rules! forgetest_ignore {
         #[test]
         #[ignore]
         fn $test() {
-            let (prj, cmd) = $crate::util::setup(stringify!($test), $style);
+            let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
             $fun(prj, cmd);
         }
     };
@@ -84,7 +84,7 @@ macro_rules! forgetest_init {
     ($test:ident, $style:expr, $fun:expr) => {
         #[test]
         fn $test() {
-            let (prj, cmd) = $crate::util::setup(stringify!($test), $style);
+            let (prj, cmd) = $crate::util::setup_forge(stringify!($test), $style);
             $crate::util::initialize(prj.root());
             $fun(prj, cmd);
         }
@@ -136,7 +136,7 @@ macro_rules! forgetest_external {
                 return
             };
 
-            let (prj, mut cmd) = $crate::util::setup(stringify!($test), $style);
+            let (prj, mut cmd) = $crate::util::setup_forge(stringify!($test), $style);
 
             // Wipe the default structure
             prj.wipe();

--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -45,6 +45,20 @@ macro_rules! forgetest {
     };
 }
 
+#[macro_export]
+macro_rules! casttest {
+    ($test:ident, $fun:expr) => {
+        $crate::casttest!($test, $crate::ethers_solc::PathStyle::Dapptools, $fun);
+    };
+    ($test:ident, $style:expr, $fun:expr) => {
+        #[test]
+        fn $test() {
+            let (prj, cmd) = $crate::util::setup_cast(stringify!($test), $style);
+            $fun(prj, cmd);
+        }
+    };
+}
+
 /// A helper macro to ignore `forgetest!` that should not run on CI
 #[macro_export]
 macro_rules! forgetest_ignore {

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -25,7 +25,7 @@ static CURRENT_DIR_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 /// Contains a `forge init` initialized project
 pub static FORGE_INITIALIZED: Lazy<TestProject> = Lazy::new(|| {
-    let (prj, mut cmd) = setup("init-template", PathStyle::Dapptools);
+    let (prj, mut cmd) = setup_forge("init-template", PathStyle::Dapptools);
     cmd.args(["init", "--force"]);
     cmd.assert_non_empty_stdout();
     prj
@@ -61,12 +61,12 @@ pub fn clone_remote(
 ///
 /// The name given will be used to create the directory. Generally, it should
 /// correspond to the test name.
-pub fn setup(name: &str, style: PathStyle) -> (TestProject, TestCommand) {
-    setup_project(TestProject::new(name, style))
+pub fn setup_forge(name: &str, style: PathStyle) -> (TestProject, TestCommand) {
+    setup_forge_project(TestProject::new(name, style))
 }
 
-pub fn setup_project(test: TestProject) -> (TestProject, TestCommand) {
-    let cmd = test.command();
+pub fn setup_forge_project(test: TestProject) -> (TestProject, TestCommand) {
+    let cmd = test.forge_command();
     (test, cmd)
 }
 
@@ -75,7 +75,7 @@ pub fn setup_cast(name: &str, style: PathStyle) -> (TestProject, TestCommand) {
 }
 
 pub fn setup_cast_project(test: TestProject) -> (TestProject, TestCommand) {
-    let cmd = test.ccommand();
+    let cmd = test.cast_command();
     (test, cmd)
 }
 
@@ -194,8 +194,8 @@ impl TestProject {
     }
 
     /// Creates a new command that is set to use the forge executable for this project
-    pub fn command(&self) -> TestCommand {
-        let mut cmd = self.bin();
+    pub fn forge_command(&self) -> TestCommand {
+        let mut cmd = self.forge_bin();
         cmd.current_dir(&self.inner.root());
         TestCommand {
             project: self.clone(),
@@ -207,8 +207,8 @@ impl TestProject {
     }
 
     /// Creates a new command that is set to use the cast executable for this project
-    pub fn ccommand(&self) -> TestCommand {
-        let mut cmd = self.cbin();
+    pub fn cast_command(&self) -> TestCommand {
+        let mut cmd = self.cast_bin();
         cmd.current_dir(&self.inner.root());
         TestCommand {
             project: self.clone(),
@@ -220,13 +220,13 @@ impl TestProject {
     }
 
     /// Returns the path to the forge executable.
-    pub fn bin(&self) -> process::Command {
+    pub fn forge_bin(&self) -> process::Command {
         let forge = self.root.join(format!("../forge{}", env::consts::EXE_SUFFIX));
         process::Command::new(forge)
     }
 
     /// Returns the path to the cast executable.
-    pub fn cbin(&self) -> process::Command {
+    pub fn cast_bin(&self) -> process::Command {
         let cast = self.root.join(format!("../cast{}", env::consts::EXE_SUFFIX));
         process::Command::new(cast)
     }
@@ -237,7 +237,7 @@ impl TestProject {
         I: IntoIterator<Item = A>,
         A: AsRef<OsStr>,
     {
-        let mut cmd = self.bin();
+        let mut cmd = self.forge_bin();
         cmd.arg("config").arg("--root").arg(self.root()).args(args).arg("--json");
         let output = cmd.output().unwrap();
         let c = String::from_utf8_lossy(&output.stdout);
@@ -312,12 +312,12 @@ impl TestCommand {
     }
 
     /// Resets the command
-    pub fn fuse(&mut self) -> &mut TestCommand {
-        self.set_cmd(self.project.bin())
+    pub fn forge_fuse(&mut self) -> &mut TestCommand {
+        self.set_cmd(self.project.forge_bin())
     }
 
-    pub fn cfuse(&mut self) -> &mut TestCommand {
-        self.set_cmd(self.project.cbin())
+    pub fn cast_fuse(&mut self) -> &mut TestCommand {
+        self.set_cmd(self.project.cast_bin())
     }
 
     /// Sets the current working directory
@@ -381,11 +381,11 @@ impl TestCommand {
 
     /// Returns the `Config` as spit out by `forge config`
     pub fn config(&mut self) -> Config {
-        self.fuse().args(["config", "--json"]);
+        self.forge_fuse().args(["config", "--json"]);
         let output = self.output();
         let c = String::from_utf8_lossy(&output.stdout);
         let config = serde_json::from_str(c.as_ref()).unwrap();
-        self.fuse();
+        self.forge_fuse();
         config
     }
 

--- a/cli/tests/cast.rs
+++ b/cli/tests/cast.rs
@@ -1,0 +1,27 @@
+//! Contains various tests for checking cast commands
+use std::env;
+
+use foundry_cli_test_utils::{
+    casttest,
+    util::{TestCommand, TestProject},
+};
+
+// tests that the `cast find-block` command works correctly
+casttest!(finds_block, |_: TestProject, mut cmd: TestCommand| {
+    // Construct args
+    let timestamp = "1647843609".to_string();
+    let eth_rpc_url = env::var("ETH_RPC_URL").unwrap();
+
+    // Call `cast find-block`
+    cmd.args([
+        "find-block",
+        "--rpc-url",
+        eth_rpc_url.as_str(),
+        &timestamp
+    ]);
+    let output = cmd.stdout_lossy();
+    println!("{}", output);
+
+    // Expect successful block query
+    assert!(output.contains("6574364"));
+});

--- a/cli/tests/cast.rs
+++ b/cli/tests/cast.rs
@@ -8,17 +8,18 @@ use foundry_cli_test_utils::{
 
 // tests that the `cast find-block` command works correctly
 casttest!(finds_block, |_: TestProject, mut cmd: TestCommand| {
+    // Skip fork tests if the RPC url is not set.
+    if std::env::var("ETH_RPC_URL").is_err() {
+        eprintln!("Skipping test finds_block. ETH_RPC_URL is not set.");
+        return
+    };
+
     // Construct args
     let timestamp = "1647843609".to_string();
     let eth_rpc_url = env::var("ETH_RPC_URL").unwrap();
 
     // Call `cast find-block`
-    cmd.args([
-        "find-block",
-        "--rpc-url",
-        eth_rpc_url.as_str(),
-        &timestamp
-    ]);
+    cmd.args(["find-block", "--rpc-url", eth_rpc_url.as_str(), &timestamp]);
     let output = cmd.stdout_lossy();
     println!("{}", output);
 

--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -207,7 +207,7 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     cmd.unset_env("DAPP_REMAPPINGS");
     pretty_err(&remappings_txt, fs::remove_file(&remappings_txt));
 
-    cmd.set_cmd(prj.bin()).args(["config", "--basic"]);
+    cmd.set_cmd(prj.forge_bin()).args(["config", "--basic"]);
     let expected = profile.into_basic().to_string_pretty().unwrap();
     pretty_eq!(expected.trim().to_string(), cmd.stdout().trim().to_string());
 });
@@ -280,7 +280,7 @@ forgetest_init!(can_emit_extra_output, |prj: TestProject, mut cmd: TestCommand| 
         ethers::solc::utils::read_json_file(artifact_path).unwrap();
     assert!(artifact.metadata.is_some());
 
-    cmd.fuse().args(["build", "--extra-output-files", "metadata", "--force"]).root_arg();
+    cmd.forge_fuse().args(["build", "--extra-output-files", "metadata", "--force"]).root_arg();
     cmd.assert_non_empty_stdout();
 
     let metadata_path = prj.paths().artifacts.join("Contract.sol/Contract.metadata.json");
@@ -411,17 +411,17 @@ contract Foo {}
     let stdout = cmd.stdout_lossy();
     assert!(stdout.contains("Compiler run successful"));
 
-    cmd.fuse().args(["build", "--force", "--use", "solc:0.8.11"]).root_arg();
+    cmd.forge_fuse().args(["build", "--force", "--use", "solc:0.8.11"]).root_arg();
 
     assert!(stdout.contains("Compiler run successful"));
 
     // fails to use solc that does not exist
-    cmd.fuse().args(["build", "--use", "this/solc/does/not/exist"]);
+    cmd.forge_fuse().args(["build", "--use", "this/solc/does/not/exist"]);
     assert!(cmd.stderr_lossy().contains("this/solc/does/not/exist does not exist"));
 
     // 0.8.11 was installed in previous step, so we can use the path to this directly
     let local_solc = ethers::solc::Solc::find_svm_installed_version("0.8.11").unwrap().unwrap();
-    cmd.fuse().args(["build", "--force", "--use"]).arg(local_solc.solc).root_arg();
+    cmd.forge_fuse().args(["build", "--force", "--use"]).arg(local_solc.solc).root_arg();
     assert!(stdout.contains("Compiler run successful"));
 });
 


### PR DESCRIPTION
`cast find-block` crashes since the Command abstraction introduced a nested tokio runtime bug.

This PR introduces a few small changes to bubble up the future created by querying the rpc for the block. It also adds a unit test for `cast find-block` as well as the supporting `test-utils` functions.
