### PR TITLE
[WIP] x86 Docker Image Pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,13 +30,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Compute release name and tag
-        id: release_info
-        run: |
-          if [[ $IS_NIGHTLY ]]; then
-            echo "::set-output name=tag_name::nightly-${GITHUB_SHA}"
-            echo "::set-output name=release_name::Nightly ($(date '+%Y-%m-%d'))"
-
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,7 +47,6 @@ jobs:
         uses: docker/metadata-action@v3.6.2
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: latest
         
 
 
@@ -59,5 +58,5 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags == 'nigthly' && 'nightly' }}, ${{ (steps.meta.outputs.tags == 'master' || steps.meta.outputs.tags == 'main') && 'latest'}}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,16 +34,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.2.0
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1.6.0
-        with:
-          install: true
-
+        
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -74,4 +65,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: docker-publish-all
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on: 
+  push:
+    tags: [ 'v*.*.*' ]
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+  # Will resolve to gakonst/foundry
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.2.0
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1.6.0
+        with:
+          install: true
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        
+
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,7 @@ jobs:
         uses: docker/metadata-action@v3.6.2
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: latest
         
 
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,13 +6,8 @@ name: docker-publish-all
 # documentation.
 
 on: 
-  push:
-    tags: [ 'v*.*.*' ]
-    branches:
-      - master
-      - main
   workflow_dispatch:
-    tags: [ 'v*.*.*' ]
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io
@@ -34,7 +29,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        
+
+      - name: Compute release name and tag
+        id: release_info
+        run: |
+          if [[ $IS_NIGHTLY ]]; then
+            echo "::set-output name=tag_name::nightly-${GITHUB_SHA}"
+            echo "::set-output name=release_name::Nightly ($(date '+%Y-%m-%d'))"
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: docker-publish-all
+name: Build and Publish Docker
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release_docker:
     name: Release Docker
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+    uses: ./.github/workflows/docker-publish.yml
 
-      - name: Run Docker Release
-        uses: ./.github/workflows/docker-publish.yml@main
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: ./.github/workflows/docker-publish.yml
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Run Docker Release
+        uses: ./.github/workflows/docker-publish.yml
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Docker Release
-        uses: ./.github/workflows/docker-publish.yml
+        uses: ./.github/workflows/docker-publish.yml@main
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,11 @@ jobs:
           toTag: ${{ steps.release_info.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+  release_docker:
+    name: Release Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/docker-publish.yml
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
   release_docker:
     name: Release Docker
     runs-on: ubuntu-latest
+    needs: prepare
     steps:
       - uses: ./.github/workflows/docker-publish.yml
   release:


### PR DESCRIPTION
## Motivation
(wip, just some notes for now)
We should release new docker images alongside binary releases.

Currently, due to GH's lack of arm64 runners and dependency issues for musl on arm64 emulation, the pipeline only builds docker images for x86 machines. The x86 images seem to run fine on the M1 mac I have, but ideally we would build a fully arm64 native image. Continuing to work on that, but wanted to get a draft PR out. Happy to dive into the weeds here or on TG (a few messages there already), but I don't have a write-up on the arm64 compiling issues (yet, but I will write one).

### Some thoughts:

How do we want to do versioning?
- We should consider adding version tags (maybe this is already on the roadmap?) so that we can tag the images appropriately and so that external pipelines which rely on imaged versions are stable.
- For now, we can just use the same approach as binary builds.

Do we want to build nightly?
- I personally think we should just build the image whenever a new binary is built, but would also understand the perspective that a new docker image should only be built on a non-nightly/versioned release.

Are we OK just releasing the x86 version first?
- I say yes, since it's an incremental development and the arm64 issue is likely to take a bit of time to resolve.

Other Notes:
Job runs parallel to all other release jobs. Took 20-25 min in my testing to build the image.
Image will currently be pushed as `gakonst/foundry:{branch}`

## Solution
Basic github action that integrates with the existing release workflow.
