### PR TITLE
docs: fix typo in cast find-block

### DIFF
--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -506,7 +506,7 @@ pub enum Subcommands {
     },
     #[clap(
         name = "find-block",
-        about = "Prints the block number closes to the provided timestamp"
+        about = "Prints the block number closest to the provided timestamp"
     )]
     FindBlock(FindBlockArgs),
     #[clap(about = "Generate shell completions script")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
On account of https://github.com/onbjerg/foundry-book/pull/134#discussion_r835773938 fixes the typo in the cast cli.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->