### PR TITLE
Docker Pipeline for x86 Images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,5 @@
 name: Build and Publish Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on: 
   workflow_dispatch:
   workflow_call:
@@ -22,9 +17,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -33,7 +25,6 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1.14.1
         with:
           registry: ${{ env.REGISTRY }}
@@ -66,13 +57,13 @@ jobs:
           echo "TAGS -> ${{ steps.meta.outputs.tags }}, ${{ steps.additional_tags.outputs.additional_tag }}"
           echo "LABELS ->  ${{ steps.meta.outputs.labels }}"
         
-      # Build and push Docker image with Buildx (don't push on PR)
+      # Build and push Docker image
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v2.10.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }},${{ steps.additional_tags.outputs.additional_tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,16 +34,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.2.0
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1.6.0
-        with:
-          install: true
-
+        
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -74,4 +65,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,21 +40,27 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       # Creates an additional 'latest' or 'nightly' tag
-      - name: Assign Additional Docker Metadata
-        id: additional_tags
+      # If the job is triggered via cron schedule, tag nightly and nightly-{SHA}
+      # If the job is triggered via workflow dispatch and on a master branch, tag branch and latest
+      # Otherwise, just tag as the branch name
+      - name: Finalize Docker Metadata
+        id: docker_tagging
         run: |
-          if [[ "${{ steps.meta.outputs.tags }}" == *"foundry:main" ]] || [[ "${{ steps.meta.outputs.tags }}" == *"foundry:master" ]]; then
-            echo "assigning latest tag"
-            echo "::set-output name=additional_tag::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          if [[ "${{ github.event_name }}" == 'schedule' ]]; then
+            echo "cron trigger, assigning nightly tag"
+            echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}"
+          elif [[ "${GITHUB_REF##*/}" == "main" ]] || [[ ${GITHUB_REF##*/} == "master" ]]; then
+            echo "manual trigger from master/main branch, assigning latest tag"
+            echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           else
-            echo "assigning nightly tag"
-            echo "::set-output name=additonal_tag::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}"
+            echo "Neither scheduled nor manual release from main branch. Just tagging as branch name"
+            echo "::set-output name=docker_tags::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}"
           fi
 
       # Log docker metadata to explicitly know what is being pushed
       - name: Inspect Docker Metadata
         run: |
-          echo "TAGS -> ${{ steps.meta.outputs.tags }}, ${{ steps.additional_tags.outputs.additional_tag }}"
+          echo "TAGS -> ${{ steps.docker_tagging.outputs.docker_tags }}"
           echo "LABELS ->  ${{ steps.meta.outputs.labels }}"
         
       # Build and push Docker image
@@ -65,5 +71,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }},${{ steps.additional_tags.outputs.additional_tag }}
+          tags: ${{ steps.docker_tagging.outputs.docker_tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: docker-publish-all
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on: 
+  push:
+    tags: [ 'v*.*.*' ]
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+  # Will resolve to gakonst/foundry
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.2.0
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1.6.0
+        with:
+          install: true
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        
+
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,13 +30,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Compute release name and tag
-        id: release_info
-        run: |
-          if [[ $IS_NIGHTLY ]]; then
-            echo "::set-output name=tag_name::nightly-${GITHUB_SHA}"
-            echo "::set-output name=release_name::Nightly ($(date '+%Y-%m-%d'))"
-
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -54,9 +47,25 @@ jobs:
         uses: docker/metadata-action@v3.6.2
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Creates an additional 'latest' or 'nightly' tag
+      - name: Assign Additional Docker Metadata
+        id: additional_tags
+        run: |
+          if [[ "${{ steps.meta.outputs.tags }}" == *"foundry:main" ]] || [[ "${{ steps.meta.outputs.tags }}" == *"foundry:master" ]]; then
+            echo "assigning latest tag"
+            echo "::set-output name=additional_tag::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          else
+            echo "assigning nightly tag"
+            echo "::set-output name=additonal_tag::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${GITHUB_SHA}"
+          fi
+
+      # Log docker metadata to explicitly know what is being pushed
+      - name: Inspect Docker Metadata
+        run: |
+          echo "TAGS -> ${{ steps.meta.outputs.tags }}, ${{ steps.additional_tags.outputs.additional_tag }}"
+          echo "LABELS ->  ${{ steps.meta.outputs.labels }}"
         
-
-
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -65,5 +74,5 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }},${{ steps.additional_tags.outputs.additional_tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: docker-publish-all
+name: Build and Publish Docker
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
@@ -6,13 +6,8 @@ name: docker-publish-all
 # documentation.
 
 on: 
-  push:
-    tags: [ 'v*.*.*' ]
-    branches:
-      - master
-      - main
   workflow_dispatch:
-    tags: [ 'v*.*.*' ]
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io
@@ -34,7 +29,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        
+
+      - name: Compute release name and tag
+        id: release_info
+        run: |
+          if [[ $IS_NIGHTLY ]]; then
+            echo "::set-output name=tag_name::nightly-${GITHUB_SHA}"
+            echo "::set-output name=release_name::Nightly ($(date '+%Y-%m-%d'))"
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release_docker:
     name: Release Docker
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+    uses: ./.github/workflows/docker-publish.yml
 
-      - name: Run Docker Release
-        uses: ./.github/workflows/docker-publish.yml@main
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           toTag: ${{ steps.release_info.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
   release_docker:
     name: Release Docker
     uses: ./.github/workflows/docker-publish.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,16 @@ jobs:
           toTag: ${{ steps.release_info.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release_docker:
+    name: Release Docker
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
+      - name: Run Docker Release
+        uses: ./.github/workflows/docker-publish.yml@main
   release:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}


### PR DESCRIPTION
## Motivation
We should release docker images alongside the binary releases.
##### Note: currently the pipeline only builds amd64 images. They seem to run fine on my M1 devices, but future improvement will to be a native arm64 image. Some of foundry's dependencies won't compile on Docker's arm64v8+musl, but we can address this issue in the future as an iterative improvement. 

## Solution
Add a new github workflow file that builds, tags, and pushes the foundry docker image. The workflow is called as part of the Release Version pipeline and runs in parallel to the binary releases job matrix. 

The images will be pushed to `ghcr.io/gakonst/foundry:{master,latest}` when run manually and to `ghrc.io/gakonst/foundry:nightly-{sha}` when the nightly builds are run.

Job takes 20-25 min based on my testing. Here's an example [workflow run](https://github.com/dmfxyz/foundry/actions/runs/2045639908), and here is my forked[ ghcr repository](https://github.com/dmfxyz/foundry/pkgs/container/foundry)