### PR TITLE
feat(forge): colored memory words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,6 +4644,7 @@ dependencies = [
  "eyre",
  "forge",
  "hex",
+ "revm",
  "tui",
 ]
 

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -10,3 +10,4 @@ eyre = "0.6.5"
 hex = "0.4.3"
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
 forge = { path = "../forge" }
+revm = { package = "revm", git = "https://github.com/bluealloy/revm", default-features = false, features = ["std", "k256", "with-serde"] }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -643,13 +643,16 @@ impl Tui {
         // color memory words based on write/read
         let (mut word, mut color) =
             if let Instruction::OpCode(op) = debug_steps[current_step].instruction {
-                let w = debug_steps[current_step].stack[debug_steps[current_step].stack.len() - 1]
-                    .as_usize() /
-                    32;
-                match op {
-                    0x51 => (Some(w), Some(Color::Cyan)), // read mem word
-                    0x52 => (Some(w), Some(Color::Red)),  // write mem word
-                    _ => (None, None),
+                let stack_len = debug_steps[current_step].stack.len();
+                if stack_len > 0 {
+                    let w = debug_steps[current_step].stack[stack_len - 1];
+                    match op {
+                        0x51 => (Some(w.as_usize() / 32), Some(Color::Cyan)), // read mem word
+                        0x52 => (Some(w.as_usize() / 32), Some(Color::Red)),  // write mem word
+                        _ => (None, None),
+                    }
+                } else {
+                    (None, None)
                 }
             } else {
                 (None, None)
@@ -657,10 +660,11 @@ impl Tui {
 
         // color word on previous write op
         if current_step > 0 {
-            if let Instruction::OpCode(op) = debug_steps[current_step - 1].instruction {
+            let prev_step = current_step - 1;
+            let stack_len = debug_steps[prev_step].stack.len();
+            if let Instruction::OpCode(op) = debug_steps[prev_step].instruction {
                 if op == 0x52 {
-                    let prev_top = debug_steps[current_step - 1].stack
-                        [debug_steps[current_step - 1].stack.len() - 1];
+                    let prev_top = debug_steps[prev_step].stack[stack_len - 1];
                     word = Some(prev_top.as_usize() / 32);
                     color = Some(Color::Green);
                 }


### PR DESCRIPTION
## Motivation
Showcase memory changes in debugger

## Solution
Color reads as cyan, soon to overwrite as red, and just overwrote as green. see screenshots:

About to overwrite:
![image](https://user-images.githubusercontent.com/31553173/160256247-b7d75b20-94b8-42e0-b717-2bfea4cca981.png)

Just overwrote (see previous op is `MSTORE`):
![image](https://user-images.githubusercontent.com/31553173/160256003-5d368ee3-beb9-404c-9cf0-81296ee5d682.png)

Read:
![image](https://user-images.githubusercontent.com/31553173/160256231-2c00300d-9019-4a7c-8daf-eddffa402584.png)


(ignore that the dimming and such doesnt work on my terminal. weird alacritty settings)
