### PR TITLE
fix: various trace fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,8 +1241,9 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
- "ethers-addressbook 0.1.0",
+ "ethers-addressbook",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1255,17 +1256,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1276,6 +1267,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1293,6 +1285,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1314,6 +1307,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1327,6 +1321,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1352,6 +1347,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1365,6 +1361,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1387,6 +1384,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1418,6 +1416,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1440,6 +1439,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
+source = "git+https://github.com/gakonst/ethers-rs#72dfc52ec041f4368a00aa9a27305f777ec710d8"
 dependencies = [
  "colored",
  "dunce",
@@ -1724,7 +1724,7 @@ name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
  "ethers",
- "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-addressbook",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,8 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
- "ethers-addressbook",
+ "ethers-addressbook 0.1.0",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1251,6 +1250,16 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "0.1.0"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1267,7 +1276,6 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1285,7 +1293,6 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1307,7 +1314,6 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1321,7 +1327,6 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1347,7 +1352,6 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1361,7 +1365,6 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1384,7 +1387,6 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1416,7 +1418,6 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1439,7 +1440,6 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#95a384b1218d9a83eac8c14362086e56f5bacc5a"
 dependencies = [
  "colored",
  "dunce",
@@ -1724,7 +1724,7 @@ name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
  "ethers",
- "ethers-addressbook",
+ "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",
@@ -4176,7 +4176,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "svm-rs"
 version = "0.2.9"
-source = "git+https://github.com/roynalnaruto/svm-rs#c32014f34308629cb1d98a8fdad29e527a8066d7"
+source = "git+https://github.com/roynalnaruto/svm-rs#a128bea693fcb3c468687dbec4312c4b00d2432e"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "svm-rs-builds"
 version = "0.1.0"
-source = "git+https://github.com/roynalnaruto/svm-rs#c32014f34308629cb1d98a8fdad29e527a8066d7"
+source = "git+https://github.com/roynalnaruto/svm-rs#a128bea693fcb3c468687dbec4312c4b00d2432e"
 dependencies = [
  "build_const",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ panic = "abort"
 debug = 0
 
 ## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
-#[patch."https://github.com/gakonst/ethers-rs"]
-#ethers = { path = "../ethers-rs" }
-#ethers-core = { path = "../ethers-rs/ethers-core" }
-#ethers-providers = { path = "../ethers-rs/ethers-providers" }
-#ethers-signers = { path = "../ethers-rs/ethers-signers" }
-#ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
-#ethers-solc = { path = "../ethers-rs/ethers-solc" }
+[patch."https://github.com/gakonst/ethers-rs"]
+ethers = { path = "../ethers-rs" }
+ethers-core = { path = "../ethers-rs/ethers-core" }
+ethers-providers = { path = "../ethers-rs/ethers-providers" }
+ethers-signers = { path = "../ethers-rs/ethers-signers" }
+ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
+ethers-solc = { path = "../ethers-rs/ethers-solc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,3 @@ codegen-units = 1
 panic = "abort"
 # We end up stripping away these symbols anyway
 debug = 0
-
-## Patch ethers-rs with a local checkout then run `cargo update -p ethers`
-[patch."https://github.com/gakonst/ethers-rs"]
-ethers = { path = "../ethers-rs" }
-ethers-core = { path = "../ethers-rs/ethers-core" }
-ethers-providers = { path = "../ethers-rs/ethers-providers" }
-ethers-signers = { path = "../ethers-rs/ethers-signers" }
-ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
-ethers-solc = { path = "../ethers-rs/ethers-solc" }

--- a/evm/src/trace/identifier.rs
+++ b/evm/src/trace/identifier.rs
@@ -27,7 +27,9 @@ impl LocalTraceIdentifier {
         Self {
             local_contracts: known_contracts
                 .iter()
-                .map(|(id, (abi, runtime_code))| (runtime_code.clone(), (id.slug(), abi.clone())))
+                .map(|(id, (abi, runtime_code))| {
+                    (runtime_code.clone(), (id.name.clone(), abi.clone()))
+                })
                 .collect(),
         }
     }

--- a/evm/src/trace/identifier.rs
+++ b/evm/src/trace/identifier.rs
@@ -1,4 +1,7 @@
-use ethers::abi::{Abi, Address};
+use ethers::{
+    abi::{Abi, Address},
+    prelude::ArtifactId,
+};
 use std::collections::BTreeMap;
 
 /// Trace identifiers figure out what ABIs and labels belong to all the addresses of the trace.
@@ -20,13 +23,11 @@ pub struct LocalTraceIdentifier {
 }
 
 impl LocalTraceIdentifier {
-    pub fn new(known_contracts: &BTreeMap<String, (Abi, Vec<u8>)>) -> Self {
+    pub fn new(known_contracts: &BTreeMap<ArtifactId, (Abi, Vec<u8>)>) -> Self {
         Self {
             local_contracts: known_contracts
                 .iter()
-                .map(|(name, (abi, runtime_code))| {
-                    (runtime_code.clone(), (name.clone(), abi.clone()))
-                })
+                .map(|(id, (abi, runtime_code))| (runtime_code.clone(), (id.slug(), abi.clone())))
                 .collect(),
         }
     }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1008,13 +1008,14 @@ mod tests {
 
     #[test]
     fn test_linking() {
-        let contract_names = [
+        let mut contract_names = [
             "DSTest.json:DSTest",
             "Lib.json:Lib",
             "LibraryConsumer.json:LibraryConsumer",
             "LibraryLinkingTest.json:LibraryLinkingTest",
             "NestedLib.json:NestedLib",
         ];
+        contract_names.sort_unstable();
 
         let paths = ProjectPathsConfig::builder()
             .root("../testdata")
@@ -1034,10 +1035,10 @@ mod tests {
         let mut known_contracts: BTreeMap<ArtifactId, (Abi, Vec<u8>)> = Default::default();
         let mut deployable_contracts: BTreeMap<String, (Abi, Bytes, Vec<Bytes>)> =
             Default::default();
-        assert_eq!(
-            &contracts.keys().map(|i| i.slug()).collect::<Vec<String>>()[..],
-            &contract_names[..]
-        );
+
+        let mut res = contracts.keys().map(|i| i.slug()).collect::<Vec<String>>();
+        res.sort_unstable();
+        assert_eq!(&res[..], &contract_names[..]);
 
         let lib_linked = hex::encode(
             &contracts

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -9,7 +9,10 @@ use ethers_core::{
     types::*,
 };
 use ethers_etherscan::Client;
-use ethers_solc::artifacts::{BytecodeObject, CompactBytecode, CompactContractBytecode};
+use ethers_solc::{
+    artifacts::{BytecodeObject, CompactBytecode, CompactContractBytecode},
+    ArtifactId,
+};
 use eyre::{Result, WrapErr};
 use serde::Deserialize;
 use std::{
@@ -84,6 +87,107 @@ impl fmt::Display for PossibleSigs {
         }
         Ok(())
     }
+}
+
+#[derive(Debug)]
+pub struct PostLinkInput<'a, T, U> {
+    pub contract: CompactContractBytecode,
+    pub known_contracts: &'a mut BTreeMap<ArtifactId, T>,
+    pub id: ArtifactId,
+    pub extra: &'a mut U,
+    pub dependencies: Vec<ethers_core::types::Bytes>,
+}
+
+pub fn link<T, U>(
+    contracts: BTreeMap<ArtifactId, CompactContractBytecode>,
+    known_contracts: &mut BTreeMap<ArtifactId, T>,
+    sender: Address,
+    extra: &mut U,
+    link_key_construction: impl Fn(String, String) -> (String, String, String),
+    post_link: impl Fn(PostLinkInput<T, U>) -> eyre::Result<()>,
+) -> eyre::Result<()> {
+    // we dont use mainnet state for evm_opts.sender so this will always be 1
+    // I am leaving this here so that in the future if this needs to change,
+    // its easy to find.
+    let nonce = U256::one();
+
+    // create a mapping of fname => Vec<(fname, file, key)>,
+    let link_tree: BTreeMap<String, Vec<(String, String, String)>> = contracts
+        .iter()
+        .map(|(id, contract)| {
+            (
+                id.slug(),
+                contract
+                    .all_link_references()
+                    .iter()
+                    .flat_map(|(file, link)| {
+                        link.keys()
+                            .map(|key| link_key_construction(file.to_string(), key.to_string()))
+                    })
+                    .collect::<Vec<(String, String, String)>>(),
+            )
+        })
+        .collect();
+
+    let contracts_by_slug = contracts
+        .iter()
+        .map(|(i, c)| (i.slug(), c.clone()))
+        .collect::<BTreeMap<String, CompactContractBytecode>>();
+
+    for (id, contract) in contracts.into_iter() {
+        let (abi, maybe_deployment_bytes, maybe_runtime) = (
+            contract.abi.as_ref(),
+            contract.bytecode.as_ref(),
+            contract.deployed_bytecode.as_ref(),
+        );
+
+        if let (Some(abi), Some(bytecode), Some(runtime)) =
+            (abi, maybe_deployment_bytes, maybe_runtime)
+        {
+            // we are going to mutate, but library contract addresses may change based on
+            // the test so we clone
+            let mut target_bytecode = bytecode.clone();
+            let mut rt = runtime.clone();
+            let mut target_bytecode_runtime = rt.bytecode.expect("No target runtime").clone();
+
+            // instantiate a vector that gets filled with library deployment bytecode
+            let mut dependencies = vec![];
+
+            match bytecode.object {
+                BytecodeObject::Unlinked(_) => {
+                    // link needed
+                    recurse_link(
+                        id.slug(),
+                        (&mut target_bytecode, &mut target_bytecode_runtime),
+                        &contracts_by_slug,
+                        &link_tree,
+                        &mut dependencies,
+                        nonce,
+                        sender,
+                    );
+                }
+                BytecodeObject::Bytecode(ref bytes) => {
+                    if bytes.as_ref().is_empty() {
+                        // abstract, skip
+                        continue
+                    }
+                }
+            }
+
+            rt.bytecode = Some(target_bytecode_runtime);
+            let tc = CompactContractBytecode {
+                abi: Some(abi.clone()),
+                bytecode: Some(target_bytecode),
+                deployed_bytecode: Some(rt),
+            };
+
+            let post_link_input =
+                PostLinkInput { contract: tc, known_contracts, id, extra, dependencies };
+
+            post_link(post_link_input)?;
+        }
+    }
+    Ok(())
 }
 
 /// Recursively links bytecode given a target contract artifact name, the bytecode(s) to be linked,
@@ -183,7 +287,7 @@ impl<'a> IntoFunction for &'a str {
 
 /// Flattens a group of contracts into maps of all events and functions
 pub fn flatten_known_contracts(
-    contracts: &BTreeMap<String, (Abi, Vec<u8>)>,
+    contracts: &BTreeMap<ArtifactId, (Abi, Vec<u8>)>,
 ) -> (BTreeMap<[u8; 4], Function>, BTreeMap<H256, Event>, Abi) {
     let flattened_funcs: BTreeMap<[u8; 4], Function> = contracts
         .iter()
@@ -884,106 +988,6 @@ pub fn abi_to_solidity(contract_abi: &Abi, mut contract_name: &str) -> Result<St
     })
 }
 
-#[derive(Debug)]
-pub struct PostLinkInput<'a, T, U> {
-    pub contract: CompactContractBytecode,
-    pub known_contracts: &'a mut BTreeMap<String, T>,
-    pub fname: String,
-    pub extra: &'a mut U,
-    pub dependencies: Vec<ethers_core::types::Bytes>,
-}
-
-pub fn link<T, U>(
-    contracts: &BTreeMap<String, CompactContractBytecode>,
-    known_contracts: &mut BTreeMap<String, T>,
-    sender: Address,
-    extra: &mut U,
-    link_key_construction: impl Fn(String, String) -> (String, String, String),
-    post_link: impl Fn(PostLinkInput<T, U>) -> eyre::Result<()>,
-) -> eyre::Result<()> {
-    // we dont use mainnet state for evm_opts.sender so this will always be 1
-    // I am leaving this here so that in the future if this needs to change,
-    // its easy to find.
-    let nonce = U256::one();
-
-    // create a mapping of fname => Vec<(fname, file, key)>,
-    let link_tree: BTreeMap<String, Vec<(String, String, String)>> = contracts
-        .iter()
-        .map(|(fname, contract)| {
-            (
-                fname.to_string(),
-                contract
-                    .all_link_references()
-                    .iter()
-                    .flat_map(|(file, link)| {
-                        link.keys()
-                            .map(|key| link_key_construction(file.to_string(), key.to_string()))
-                    })
-                    .collect::<Vec<(String, String, String)>>(),
-            )
-        })
-        .collect();
-
-    for fname in contracts.keys() {
-        let (abi, maybe_deployment_bytes, maybe_runtime) = if let Some(c) = contracts.get(fname) {
-            (c.abi.as_ref(), c.bytecode.as_ref(), c.deployed_bytecode.as_ref())
-        } else {
-            (None, None, None)
-        };
-        if let (Some(abi), Some(bytecode), Some(runtime)) =
-            (abi, maybe_deployment_bytes, maybe_runtime)
-        {
-            // we are going to mutate, but library contract addresses may change based on
-            // the test so we clone
-            let mut target_bytecode = bytecode.clone();
-            let mut rt = runtime.clone();
-            let mut target_bytecode_runtime = rt.bytecode.expect("No target runtime").clone();
-
-            // instantiate a vector that gets filled with library deployment bytecode
-            let mut dependencies = vec![];
-
-            match bytecode.object {
-                BytecodeObject::Unlinked(_) => {
-                    // link needed
-                    recurse_link(
-                        fname.to_string(),
-                        (&mut target_bytecode, &mut target_bytecode_runtime),
-                        contracts,
-                        &link_tree,
-                        &mut dependencies,
-                        nonce,
-                        sender,
-                    );
-                }
-                BytecodeObject::Bytecode(ref bytes) => {
-                    if bytes.as_ref().is_empty() {
-                        // abstract, skip
-                        continue
-                    }
-                }
-            }
-
-            rt.bytecode = Some(target_bytecode_runtime);
-            let tc = CompactContractBytecode {
-                abi: Some(abi.clone()),
-                bytecode: Some(target_bytecode),
-                deployed_bytecode: Some(rt),
-            };
-
-            let post_link_input = PostLinkInput {
-                contract: tc,
-                known_contracts,
-                fname: fname.to_string(),
-                extra,
-                dependencies,
-            };
-
-            post_link(post_link_input)?;
-        }
-    }
-    Ok(())
-}
-
 /// Enables tracing
 #[cfg(any(feature = "test"))]
 pub fn init_tracing_subscriber() {
@@ -1024,15 +1028,23 @@ mod tests {
         let contracts = output
             .into_artifacts()
             .filter(|(i, _)| contract_names.contains(&i.slug().as_str()))
-            .map(|(i, c)| (i.slug(), c.into_contract_bytecode()))
-            .collect::<BTreeMap<String, CompactContractBytecode>>();
+            .map(|(id, c)| (id, c.into_contract_bytecode()))
+            .collect::<BTreeMap<ArtifactId, CompactContractBytecode>>();
 
-        let mut known_contracts: BTreeMap<String, (Abi, Vec<u8>)> = Default::default();
+        let mut known_contracts: BTreeMap<ArtifactId, (Abi, Vec<u8>)> = Default::default();
         let mut deployable_contracts: BTreeMap<String, (Abi, Bytes, Vec<Bytes>)> =
             Default::default();
-        assert_eq!(&contracts.keys().collect::<Vec<&String>>()[..], &contract_names[..]);
+        assert_eq!(
+            &contracts.keys().map(|i| i.slug()).collect::<Vec<String>>()[..],
+            &contract_names[..]
+        );
+
         let lib_linked = hex::encode(
-            &contracts["Lib.json:Lib"]
+            &contracts
+                .iter()
+                .find(|(i, _)| i.slug() == "Lib.json:Lib")
+                .unwrap()
+                .1
                 .bytecode
                 .clone()
                 .expect("library had no bytecode")
@@ -1040,7 +1052,11 @@ mod tests {
                 .into_bytes()
                 .expect("could not get bytecode as bytes"),
         );
-        let nested_lib_unlinked = &contracts["NestedLib.json:NestedLib"]
+        let nested_lib_unlinked = &contracts
+            .iter()
+            .find(|(i, _)| i.slug() == "NestedLib.json:NestedLib")
+            .unwrap()
+            .1
             .bytecode
             .as_ref()
             .expect("nested library had no bytecode")
@@ -1050,13 +1066,13 @@ mod tests {
             .to_string();
 
         link(
-            &contracts,
+            contracts,
             &mut known_contracts,
             Address::default(),
             &mut deployable_contracts,
             |file, key| (format!("{}.json:{}", key, key), file, key),
             |post_link_input| {
-                match post_link_input.fname.as_str() {
+                match post_link_input.id.slug().as_str() {
                     "DSTest.json:DSTest" => {
                         assert_eq!(post_link_input.dependencies.len(), 0);
                     }


### PR DESCRIPTION
Sometimes contracts were not identified in traces because there were multiple contracts with the same name and `known_contracts` (which we use for lookups) was indexed by the contract name and nothing more.

First I thought we could just index by `artifact_id.slug()` but both of these contracts had the same slug as well, so now `known_contracts` is indexed by `ArtifactId`. This required changes in the linking step as well as the debugger.

Another issue mentioned in #1057 was that precompiles were not decoded, which will also be addressed in this PR.

**Remaining tasks**

- [x] Adjust `forge run` to new `known_contracts` type (blocked by https://github.com/gakonst/ethers-rs/pull/1080)
- [x] Decode precompile calls

Closes #1057 