### PR TITLE
meta: remove test profile settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,6 @@ members = [
     "evm"
 ]
 
-[profile.test]
-# Speeds up build
-debug = 0
-# Speeds up tests
-opt-level = 3
-
 [profile.release]
 # Optimize for binary size, but keep loop vectorization
 opt-level = "s"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
no need for customizing test profile.
opt-level 3 slows testing down so much that testing locally becomes unbearable 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
