### PR TITLE
ci: use nightly-2022-03-20 before ring regression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          # nightly regression https://github.com/rust-lang/rust/issues/95267
+          toolchain: nightly-2022-03-20
           profile: minimal
           components: rustfmt, clippy
           override: true
@@ -91,7 +92,7 @@ jobs:
           cache-on-failure: true
 
       - name: cargo fmt
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +nightly-2022-03-20 fmt --all -- --check
 
       - name: cargo clippy
-        run: cargo +nightly clippy --all --all-features -- -D warnings
+        run: cargo +nightly-2022-03-20 clippy --all --all-features -- -D warnings


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
ring is not compatible with current nightly, this pins nightly toolchain to a version prior to that
https://github.com/rust-lang/rust/issues/95267
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
