### PR TITLE
cast: s/build_tx/TxBuilder/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -475,6 +475,7 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 name = "cast"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "chrono 0.2.25",
  "ethers-core",
  "ethers-etherscan",
@@ -485,7 +486,10 @@ dependencies = [
  "futures",
  "hex",
  "rustc-hex",
+ "serde",
  "serde_json",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/cast/Cargo.toml
+++ b/cast/Cargo.toml
@@ -19,6 +19,12 @@ serde_json = "1.0.67"
 chrono = "0.2"
 hex = "0.4.3"
 
+[dev-dependencies]
+async-trait = "0.1.53"
+serde = "1.0.136"
+tokio = "1.17.0"
+thiserror = "1.0.30"
+
 [features]
 default = ["ledger", "trezor"]
 ledger = ["ethers-signers/ledger"]

--- a/cast/src/tx.rs
+++ b/cast/src/tx.rs
@@ -1,0 +1,174 @@
+use ethers_core::{
+    abi::Function,
+    types::{
+        transaction::eip2718::TypedTransaction, Chain, Eip1559TransactionRequest, NameOrAddress,
+        TransactionRequest, H160, U256,
+    },
+};
+use ethers_providers::Middleware;
+
+use eyre::{eyre, Result};
+use foundry_utils::{encode_args, get_func, get_func_etherscan};
+use futures::future::join_all;
+
+use crate::strip_0x;
+
+pub struct TxBuilder {
+    pub from: H160,
+    pub to: H160,
+    pub chain: Chain,
+    pub tx: TypedTransaction,
+    pub func: Option<Function>,
+    pub etherscan_api_key: Option<String>,
+}
+
+impl TxBuilder {
+    pub async fn new<M: Middleware, F: Into<NameOrAddress>, T: Into<NameOrAddress>>(
+        provider: &M,
+        from: F,
+        to: T,
+        chain: Chain,
+        legacy: bool,
+    ) -> Result<TxBuilder> {
+        let from_addr = resolve_ens(provider, from).await?;
+        let to_addr = resolve_ens(provider, foundry_utils::resolve_addr(to, chain)?).await?;
+
+        let tx: TypedTransaction = if chain.is_legacy() || legacy {
+            TransactionRequest::new().from(from_addr).to(to_addr).into()
+        } else {
+            Eip1559TransactionRequest::new().from(from_addr).to(to_addr).into()
+        };
+
+        Ok(TxBuilder {
+            from: from_addr,
+            to: to_addr,
+            chain,
+            tx,
+            func: None,
+            etherscan_api_key: None,
+        })
+    }
+    pub fn set_gas<'a>(&'a mut self, v: U256) -> &'a mut TxBuilder {
+        self.tx.set_gas(v);
+        self
+    }
+    pub fn gas<'a>(&'a mut self, v: Option<U256>) -> &'a mut TxBuilder {
+        match v {
+            Some(x) => self.set_gas(x),
+            None => self,
+        }
+    }
+
+    pub fn set_gas_price<'a>(&'a mut self, v: U256) -> &'a mut TxBuilder {
+        self.tx.set_gas_price(v);
+        self
+    }
+
+    pub fn gas_price<'a>(&'a mut self, v: Option<U256>) -> &'a mut TxBuilder {
+        match v {
+            Some(x) => self.set_gas_price(x),
+            None => self,
+        }
+    }
+
+    pub fn set_value<'a>(&'a mut self, v: U256) -> &'a mut TxBuilder {
+        self.tx.set_value(v);
+        self
+    }
+    pub fn value<'a>(&'a mut self, v: Option<U256>) -> &'a mut TxBuilder {
+        match v {
+            Some(x) => self.set_value(x),
+            None => self,
+        }
+    }
+    pub fn set_nonce<'a>(&'a mut self, v: U256) -> &'a mut TxBuilder {
+        self.tx.set_nonce(v);
+        self
+    }
+    pub fn nonce<'a>(&'a mut self, v: Option<U256>) -> &'a mut TxBuilder {
+        match v {
+            Some(x) => self.set_nonce(x),
+            None => self,
+        }
+    }
+
+    pub fn set_etherscan_api_key<'a>(&'a mut self, v: String) -> &'a mut TxBuilder {
+        self.etherscan_api_key = Some(v);
+        self
+    }
+    pub fn etherscan_api_key<'a>(&'a mut self, v: Option<String>) -> &'a mut TxBuilder {
+        match v {
+            Some(x) => self.set_etherscan_api_key(x),
+            None => self,
+        }
+    }
+
+    pub async fn set_args<'a, M: Middleware>(
+        &'a mut self,
+        provider: &M,
+        sig: &str,
+        args: Vec<String>,
+    ) -> Result<&'a mut TxBuilder> {
+        let args = resolve_name_args(&args, provider).await;
+
+        let func = if sig.contains('(') {
+            get_func(&sig)?
+        } else if sig.starts_with("0x") {
+            // if only calldata is provided, returning a dummy function
+            get_func("x()")?
+        } else {
+            get_func_etherscan(
+                &sig,
+                self.to,
+                &args,
+                self.chain,
+                self.etherscan_api_key.as_ref().expect("Must set ETHERSCAN_API_KEY"),
+            )
+            .await?
+        };
+
+        let data = if sig.starts_with("0x") {
+            hex::decode(strip_0x(&sig))?
+        } else {
+            encode_args(&func, &args)?
+        };
+
+        self.tx.set_data(data.into());
+        self.func = Some(func);
+        Ok(self)
+    }
+    pub async fn args<'a, M: Middleware>(
+        &'a mut self,
+        provider: &M,
+        value: Option<(&str, Vec<String>)>,
+    ) -> Result<&'a mut TxBuilder> {
+        match value {
+            Some((sig, args)) => self.set_args(provider, sig, args).await,
+            None => Ok(self),
+        }
+    }
+}
+
+async fn resolve_ens<M: Middleware, T: Into<NameOrAddress>>(provider: &M, addr: T) -> Result<H160> {
+    let from_addr = match addr.into() {
+        NameOrAddress::Name(ref ens_name) => provider.resolve_name(ens_name).await,
+        NameOrAddress::Address(addr) => Ok(addr),
+    }
+    .map_err(|x| eyre!("Failed to resolve ENS name: {}", x))?;
+    return Ok(from_addr);
+}
+
+async fn resolve_name_args<M: Middleware>(args: &[String], provider: &M) -> Vec<String> {
+    join_all(args.iter().map(|arg| async {
+        if arg.contains('.') {
+            let addr = provider.resolve_name(arg).await;
+            match addr {
+                Ok(addr) => format!("0x{}", hex::encode(addr.as_bytes())),
+                Err(_) => arg.to_string(),
+            }
+        } else {
+            arg.to_string()
+        }
+    }))
+    .await
+}

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -160,7 +160,7 @@ async fn main() -> eyre::Result<()> {
                 false,
             )
             .await?;
-            builder.set_args(&provider, &sig, args);
+            builder.set_args(&provider, &sig, args).await?;
 
             println!("{}", Cast::new(provider).access_list(&builder, block, to_json).await?);
         }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -369,7 +369,7 @@ pub async fn get_func_etherscan(
     contract: Address,
     args: &[String],
     chain: Chain,
-    etherscan_api_key: String,
+    etherscan_api_key: &String,
 ) -> Result<Function> {
     let client = Client::new(chain, etherscan_api_key)?;
     let metadata = &client.contract_source_code(contract).await?.items[0];

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -369,7 +369,7 @@ pub async fn get_func_etherscan(
     contract: Address,
     args: &[String],
     chain: Chain,
-    etherscan_api_key: &String,
+    etherscan_api_key: &str,
 ) -> Result<Function> {
     let client = Client::new(chain, etherscan_api_key)?;
     let metadata = &client.contract_source_code(contract).await?.items[0];


### PR DESCRIPTION
Refactoring to move away from function-with-hundred-arguments to a Builder pattern

Fixes https://github.com/gakonst/foundry/issues/937

TxBuilder constructs the tx on the fly, that's why the interface is not super consistent (`args()` returns a future result, while other setters return &mut self), and provider needs to be passed to some of the setters. 

Alternatively, I can change TxBuilder to be just a glorified bag-of-arguments, and leave the actual transaction building in lib.tx. The downsides will be: 1) we'll still have 1 gigantic function that need to handle every field in TxBuilder; 2) it'll use a bit more memory

I'm not 100% confident in my Rust, so plz check for dumb things