### PR TITLE
fix(run): use correct condition to compare contract paths

### DIFF
--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -293,10 +293,8 @@ impl RunArgs {
                     dependencies,
                 } = post_link_input;
 
-                // if its the target contract, grab the info
-                if extra.no_target_name &&
-                    id.path.file_stem().unwrap().to_string_lossy() == extra.target_fname
-                {
+                // if it's the target contract, grab the info
+                if extra.no_target_name && id.source == std::path::Path::new(&extra.target_fname) {
                     if extra.matched {
                         eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `-t ContractName`")
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
In #1067 we used ArtifactId in forge run, but the condition for finding the target contract is not correct for forge run without target contract.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
