### PR TITLE
fix: remove `setUp` from gas reports

### DIFF
--- a/forge/src/gas_report.rs
+++ b/forge/src/gas_report.rs
@@ -65,7 +65,9 @@ impl GasReport {
                         contract_report.size = bytes.len().into();
                     }
                     // TODO: More robust test contract filtering
-                    RawOrDecodedCall::Decoded(func, _) if !func.starts_with("test") => {
+                    RawOrDecodedCall::Decoded(func, _)
+                        if !func.starts_with("test") && func != "setUp" =>
+                    {
                         let function_report = contract_report
                             .functions
                             .entry(func.clone())


### PR DESCRIPTION
We still need more robust test contract filtering. It is not possible for us to do what we did before (i.e. filter out contracts that have an `IS_TEST`) because we just access decoded traces directly instead of ABIs.