### PR TITLE
fix: raise gas limit while limiting evm mem size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.2.0"
-source = "git+https://github.com/bluealloy/revm#eb3282dfa37bb4e97145037303dcc1853d88fe34"
+source = "git+https://github.com/onbjerg/revm?branch=onbjerg/memory-limit#0d60faad4a667883082df7b955080f9f467c56d1"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "0.4.0"
-source = "git+https://github.com/bluealloy/revm#eb3282dfa37bb4e97145037303dcc1853d88fe34"
+source = "git+https://github.com/onbjerg/revm?branch=onbjerg/memory-limit#0d60faad4a667883082df7b955080f9f467c56d1"
 dependencies = [
  "bytes",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "1.2.0"
-source = "git+https://github.com/onbjerg/revm?branch=onbjerg/memory-limit#0d60faad4a667883082df7b955080f9f467c56d1"
+source = "git+https://github.com/bluealloy/revm#211c83ba85518d82a1674eb6e5520cf3efbc617a"
 dependencies = [
  "arrayref",
  "auto_impl",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "revm_precompiles"
 version = "0.4.0"
-source = "git+https://github.com/onbjerg/revm?branch=onbjerg/memory-limit#0d60faad4a667883082df7b955080f9f467c56d1"
+source = "git+https://github.com/bluealloy/revm#211c83ba85518d82a1674eb6e5520cf3efbc617a"
 dependencies = [
  "bytes",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ codegen-units = 1
 panic = "abort"
 # We end up stripping away these symbols anyway
 debug = 0
-
-[patch."https://github.com/bluealloy/revm"]
-revm = { git = "https://github.com/onbjerg/revm", branch = "onbjerg/memory-limit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ codegen-units = 1
 panic = "abort"
 # We end up stripping away these symbols anyway
 debug = 0
+
+[patch."https://github.com/bluealloy/revm"]
+revm = { git = "https://github.com/onbjerg/revm", branch = "onbjerg/memory-limit" }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -898,12 +898,7 @@ impl Default for Config {
             block_number: 0,
             fork_block_number: None,
             chain_id: None,
-            // We want the gas limit to be high, but if we pick a value that is too high we end up
-            // allowing `mstore`s and `mload`s at very high memory regions, which may cause a panic.
-            //
-            // 80m gas was arbitrarily chosen, but corresponds to about 16MiB of memory if only
-            // used for `mload`/`mstore`.
-            gas_limit: 80_000_000,
+            gas_limit: u64::MAX / 2,
             gas_price: 0,
             block_base_fee_per_gas: 0,
             block_coinbase: Address::zero(),

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1.9.0"
 # EVM
 bytes = "1.1.0"
 hashbrown = "0.12"
-revm = { package = "revm", git = "https://github.com/bluealloy/revm", default-features = false, features = ["std", "k256", "with-serde"] }
+revm = { package = "revm", git = "https://github.com/bluealloy/revm", default-features = false, features = ["std", "k256", "with-serde", "memory_limit"] }
 
 # Fuzzer
 proptest = "1.0.0"

--- a/evm/src/executor/fork/init.rs
+++ b/evm/src/executor/fork/init.rs
@@ -24,6 +24,8 @@ pub async fn environment<M: Middleware>(
     Ok(Env {
         cfg: CfgEnv {
             chain_id: override_chain_id.unwrap_or(rpc_chain_id.as_u64()).into(),
+            // 16 MiB
+            memory_limit: 2u64.pow(24),
             ..Default::default()
         },
         block: BlockEnv {

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -63,6 +63,8 @@ impl EvmOpts {
                     chain_id: self.env.chain_id.unwrap_or(99).into(),
                     spec_id: SpecId::LONDON,
                     perf_all_precompiles_have_balance: false,
+                    // 16 MiB
+                    memory_limit: 2u64.pow(24),
                 },
                 tx: TxEnv {
                     gas_price: self.env.gas_price.into(),


### PR DESCRIPTION
Raises the gas limit to a high number again but limits memory expansion to prevent memory allocation errors.

Companion PR: https://github.com/bluealloy/revm/pull/86