### PR TITLE
fix: decode different events with same topic 0

### DIFF
--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -121,7 +121,7 @@ impl CallTraceDecoder {
                 .collect::<BTreeMap<[u8; 4], Vec<Function>>>(),
             events: CONSOLE_ABI
                 .events()
-                .map(|event| ((event.signature(), indexed_inputs(&event)), vec![event.clone()]))
+                .map(|event| ((event.signature(), indexed_inputs(event)), vec![event.clone()]))
                 .collect::<BTreeMap<(H256, usize), Vec<Event>>>(),
             errors: Abi::default(),
         }
@@ -163,7 +163,7 @@ impl CallTraceDecoder {
 
                 // Flatten events from all ABIs
                 abi.events()
-                    .map(|event| ((event.signature(), indexed_inputs(&event)), event.clone()))
+                    .map(|event| ((event.signature(), indexed_inputs(event)), event.clone()))
                     .for_each(|(sig, event)| {
                         self.events.entry(sig).or_default().push(event);
                     });

--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -29,7 +29,7 @@ pub struct CallTraceDecoder {
     /// A mapping of addresses to their known functions
     pub functions: BTreeMap<[u8; 4], Vec<Function>>,
     /// All known events
-    pub events: BTreeMap<H256, Event>,
+    pub events: BTreeMap<(H256, usize), Vec<Event>>,
     /// All known errors
     pub errors: Abi,
 }
@@ -121,8 +121,8 @@ impl CallTraceDecoder {
                 .collect::<BTreeMap<[u8; 4], Vec<Function>>>(),
             events: CONSOLE_ABI
                 .events()
-                .map(|event| (event.signature(), event.clone()))
-                .collect::<BTreeMap<H256, Event>>(),
+                .map(|event| ((event.signature(), indexed_inputs(&event)), vec![event.clone()]))
+                .collect::<BTreeMap<(H256, usize), Vec<Event>>>(),
             errors: Abi::default(),
         }
     }
@@ -162,11 +162,11 @@ impl CallTraceDecoder {
                     .for_each(|(sig, func)| self.functions.entry(sig).or_default().push(func));
 
                 // Flatten events from all ABIs
-                abi.events().map(|event| (event.signature(), event.clone())).for_each(
-                    |(sig, event)| {
-                        self.events.insert(sig, event);
-                    },
-                );
+                abi.events()
+                    .map(|event| ((event.signature(), indexed_inputs(&event)), event.clone()))
+                    .for_each(|(sig, event)| {
+                        self.events.entry(sig).or_default().push(event);
+                    });
 
                 // Flatten errors from all ABIs
                 abi.errors().for_each(|error| {
@@ -296,16 +296,21 @@ impl CallTraceDecoder {
             // Decode events
             node.logs.iter_mut().for_each(|log| {
                 if let RawOrDecodedLog::Raw(raw_log) = log {
-                    if let Some(event) = self.events.get(&raw_log.topics[0]) {
-                        if let Ok(decoded) = event.parse_log(raw_log.clone()) {
-                            *log = RawOrDecodedLog::Decoded(
-                                event.name.clone(),
-                                decoded
-                                    .params
-                                    .into_iter()
-                                    .map(|param| (param.name, self.apply_label(&param.value)))
-                                    .collect(),
-                            )
+                    if let Some(events) =
+                        self.events.get(&(raw_log.topics[0], raw_log.topics.len() - 1))
+                    {
+                        for event in events {
+                            if let Ok(decoded) = event.parse_log(raw_log.clone()) {
+                                *log = RawOrDecodedLog::Decoded(
+                                    event.name.clone(),
+                                    decoded
+                                        .params
+                                        .into_iter()
+                                        .map(|param| (param.name, self.apply_label(&param.value)))
+                                        .collect(),
+                                );
+                                break
+                            }
                         }
                     }
                 }
@@ -358,4 +363,8 @@ where
             state_mutability: ethers::abi::StateMutability::Pure,
         },
     )
+}
+
+fn indexed_inputs(event: &Event) -> usize {
+    event.inputs.iter().filter(|param| param.indexed).count()
 }


### PR DESCRIPTION
## Motivation

Events can share the same topic 0 but have different indexed parameters. This is due to the fact that event 0 is `<event name>(<comma-separated parameter types>)`, e.g. `Transfer(address,address,uint256)`.

The issue with this is that logs that share the same topic 0 might be encoded and decoded in different ways depending on the indexed parameters. For example, ERC720's `Transfer` event has all parameters indexed, but ERC20's `Transfer` event only has the first two parameters indexed.

For codebases that have both ERC20s and ERC721s this presents an issue: only some of the `Transfer` events are decoded.

## Solution

Solutions I've explored:

### `BTreeMap<H256, Vec<Event>>`

Would result in a lot of duplicate events

### `BTreeMap<(H256, usize), Event>`

Consider these events:

```solidity
event MyEvent(
  uint256,
  uint256 indexed,
  uint256 indexed,
  uint256 indexed
)
```

```solidity
event MyEvent(
  uint256 indexed,
  uint256 indexed,
  uint256 indexed
  uint256,
)
```

They would share the same keyspace and overwrite each other.

### Chosen: `BTreeMap<(H256, usize), Vec<Event>>`

The events in the previous proposed solution would be pushed into a `Vec`. The map is indexed by `(topic 0, indexed events)`.