### PR TITLE
fix: filter on func signature instead of test name

### DIFF
--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -179,7 +179,7 @@ impl MultiContractRunner {
                     filter.matches_contract(name)
             })
             .flat_map(|(_, (abi, _, _))| {
-                abi.functions().filter(|func| filter.matches_test(&func.name))
+                abi.functions().filter(|func| filter.matches_test(func.signature()))
             })
             .count()
     }
@@ -201,7 +201,9 @@ impl MultiContractRunner {
                 filter.matches_path(&self.source_paths.get(*name).unwrap()) &&
                     filter.matches_contract(name)
             })
-            .filter(|(_, (abi, _, _))| abi.functions().any(|func| filter.matches_test(&func.name)))
+            .filter(|(_, (abi, _, _))| {
+                abi.functions().any(|func| filter.matches_test(func.signature()))
+            })
             .map(|(name, (abi, deploy_code, libs))| {
                 let mut builder = ExecutorBuilder::new()
                     .with_cheatcodes(self.evm_opts.ffi)

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -266,7 +266,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             .contract
             .functions()
             .into_iter()
-            .filter(|func| func.name.starts_with("test") && filter.matches_test(&func.name))
+            .filter(|func| func.name.starts_with("test") && filter.matches_test(func.signature()))
             .map(|func| (func, func.name.starts_with("testFail")))
             .collect();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently `forge test --debug testSomeFunc` does not work if you have two `testSomeFunc`s like `testSomeFunc()` and `testSomeFunc(uint256)` since it filters on the function name, not the signature.

## Solution

Filter on the signature of the function. Note, however, since we're using regex, the UX for this is kind of lame since you need to escape the parenthesis:

```
forge test --debug "testSomeFunc\(uint256\)"
```