### PR TITLE
fix: persist cheatcode state from setup

### DIFF
--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -5,7 +5,11 @@ use revm::{
 };
 use std::path::PathBuf;
 
-use super::{fork::SharedBackend, inspector::InspectorStackConfig, Executor};
+use super::{
+    fork::SharedBackend,
+    inspector::{Cheatcodes, InspectorStackConfig},
+    Executor,
+};
 
 use ethers::types::{H160, H256, U256};
 
@@ -135,8 +139,9 @@ impl ExecutorBuilder {
     /// Enables cheatcodes on the executor.
     #[must_use]
     pub fn with_cheatcodes(mut self, ffi: bool) -> Self {
-        self.inspector_config.cheatcodes = true;
-        self.inspector_config.ffi = ffi;
+        let mut cheatcodes = Cheatcodes::default();
+        cheatcodes.ffi = ffi;
+        self.inspector_config.cheatcodes = Some(cheatcodes);
         self
     }
 

--- a/evm/src/executor/builder.rs
+++ b/evm/src/executor/builder.rs
@@ -139,9 +139,7 @@ impl ExecutorBuilder {
     /// Enables cheatcodes on the executor.
     #[must_use]
     pub fn with_cheatcodes(mut self, ffi: bool) -> Self {
-        let mut cheatcodes = Cheatcodes::default();
-        cheatcodes.ffi = ffi;
-        self.inspector_config.cheatcodes = Some(cheatcodes);
+        self.inspector_config.cheatcodes = Some(Cheatcodes::new(ffi, self.env.block.clone()));
         self
     }
 

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -31,10 +31,10 @@ use std::collections::BTreeMap;
 ///
 /// Cheatcodes can be called by contracts during execution to modify the VM environment, such as
 /// mocking addresses, signatures and altering call reverts.
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Cheatcodes {
     /// Whether FFI is enabled or not
-    ffi: bool,
+    pub ffi: bool,
 
     /// The block environment
     ///

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -40,7 +40,7 @@ impl InspectorStackConfig {
             InspectorStack { logs: Some(LogCollector::default()), ..Default::default() };
 
         stack.cheatcodes = self.cheatcodes.clone();
-        if let Some(cheatcodes) = &mut stack.cheatcodes {
+        if let Some(ref mut cheatcodes) = stack.cheatcodes {
             cheatcodes.block = Some(self.block.clone());
         }
 

--- a/evm/src/executor/inspector/mod.rs
+++ b/evm/src/executor/inspector/mod.rs
@@ -20,10 +20,9 @@ use revm::BlockEnv;
 
 #[derive(Default, Clone, Debug)]
 pub struct InspectorStackConfig {
+    /// The cheatcode inspector and its state, if cheatcodes are enabled.
     /// Whether or not cheatcodes are enabled
-    pub cheatcodes: bool,
-    /// Whether or not the FFI cheatcode is enabled
-    pub ffi: bool,
+    pub cheatcodes: Option<Cheatcodes>,
     /// The block environment
     ///
     /// Used in the cheatcode handler to overwrite the block environment separately from the
@@ -40,9 +39,11 @@ impl InspectorStackConfig {
         let mut stack =
             InspectorStack { logs: Some(LogCollector::default()), ..Default::default() };
 
-        if self.cheatcodes {
-            stack.cheatcodes = Some(Cheatcodes::new(self.ffi, self.block.clone()));
+        stack.cheatcodes = self.cheatcodes.clone();
+        if let Some(cheatcodes) = &mut stack.cheatcodes {
+            cheatcodes.block = Some(self.block.clone());
         }
+
         if self.tracing {
             stack.tracer = Some(Tracer::default());
         }

--- a/evm/src/executor/inspector/stack.rs
+++ b/evm/src/executor/inspector/stack.rs
@@ -25,6 +25,7 @@ pub struct InspectorData {
     pub labels: BTreeMap<Address, String>,
     pub traces: Option<CallTraceArena>,
     pub debug: Option<DebugArena>,
+    pub cheatcodes: Option<Cheatcodes>,
 }
 
 /// An inspector that calls multiple inspectors in sequence.
@@ -43,9 +44,14 @@ impl InspectorStack {
     pub fn collect_inspector_states(self) -> InspectorData {
         InspectorData {
             logs: self.logs.map(|logs| logs.logs).unwrap_or_default(),
-            labels: self.cheatcodes.map(|cheatcodes| cheatcodes.labels).unwrap_or_default(),
+            labels: self
+                .cheatcodes
+                .as_ref()
+                .map(|cheatcodes| cheatcodes.labels.clone())
+                .unwrap_or_default(),
             traces: self.tracer.map(|tracer| tracer.traces),
             debug: self.debugger.map(|debugger| debugger.arena),
+            cheatcodes: self.cheatcodes,
         }
     }
 }

--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -302,10 +302,15 @@ where
             _ => Bytes::default(),
         };
 
+        let InspectorData { logs, labels, traces, debug, cheatcodes } =
+            inspector.collect_inspector_states();
+
         // Persist the changed block environment
         self.inspector_config.block = evm.env.block.clone();
 
-        let InspectorData { logs, labels, traces, debug } = inspector.collect_inspector_states();
+        // Persist cheatcode state
+        self.inspector_config.cheatcodes = cheatcodes;
+
         Ok(RawCallResult {
             status,
             reverted: !matches!(status, return_ok!()),
@@ -404,7 +409,8 @@ where
             _ => Bytes::default(),
         };
 
-        let InspectorData { logs, labels, traces, debug } = inspector.collect_inspector_states();
+        let InspectorData { logs, labels, traces, debug, .. } =
+            inspector.collect_inspector_states();
         Ok(RawCallResult {
             status,
             reverted: !matches!(status, return_ok!()),
@@ -439,7 +445,14 @@ where
             // regarding deployments in general
             _ => eyre::bail!("deployment failed: {:?}", status),
         };
-        let InspectorData { logs, traces, debug, .. } = inspector.collect_inspector_states();
+        let InspectorData { logs, traces, debug, cheatcodes, .. } =
+            inspector.collect_inspector_states();
+
+        // Persist the changed block environment
+        self.inspector_config.block = evm.env.block.clone();
+
+        // Persist cheatcode state
+        self.inspector_config.cheatcodes = cheatcodes;
 
         Ok(DeployResult { address, gas, logs, traces, debug })
     }

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -456,10 +456,13 @@ mod tests {
 
         for (_, SuiteResult { test_results, .. }) in suite_result {
             for (test_name, result) in test_results {
+                let logs = decode_console_logs(&result.logs);
                 assert!(
                     result.success,
-                    "Test {} did not pass as expected.\nReason: {:?}",
-                    test_name, result.reason
+                    "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                    test_name,
+                    result.reason,
+                    logs.join("\n")
                 );
             }
         }
@@ -472,16 +475,22 @@ mod tests {
 
         for (_, SuiteResult { test_results, .. }) in suite_result {
             for (test_name, result) in test_results {
+                let logs = decode_console_logs(&result.logs);
+
                 match test_name.as_ref() {
                     "testPositive(uint256)" | "testSuccessfulFuzz(uint128,uint128)" => assert!(
                         result.success,
-                        "Test {} did not pass as expected.\nReason: {:?}",
-                        test_name, result.reason
+                        "Test {} did not pass as expected.\nReason: {:?}\nLogs:\n{}",
+                        test_name,
+                        result.reason,
+                        logs.join("\n")
                     ),
                     _ => assert!(
                         !result.success,
-                        "Test {} did not fail as expected.\nReason: {:?}",
-                        test_name, result.reason
+                        "Test {} did not fail as expected.\nReason: {:?}\nLogs:\n{}",
+                        test_name,
+                        result.reason,
+                        logs.join("\n")
                     ),
                 }
             }

--- a/testdata/cheats/Setup.t.sol
+++ b/testdata/cheats/Setup.t.sol
@@ -4,18 +4,29 @@ pragma solidity >=0.8.0;
 import "ds-test/test.sol";
 import "./Cheats.sol";
 
+contract Victim {
+    function assertSender(address sender) external {
+        require(msg.sender == sender, "sender was not pranked");
+    }
+}
+
 contract CheatsSetupTest is DSTest {
     Cheats constant cheats = Cheats(HEVM_ADDRESS);
+    Victim victim;
 
     function setUp() public {
-      cheats.warp(10);
-      cheats.roll(100);
-      cheats.fee(1000);
+        victim = new Victim();
+
+        cheats.warp(10);
+        cheats.roll(100);
+        cheats.fee(1000);
+        cheats.startPrank(address(1337));
     }
 
     function testCheatEnvironment() public {
         assertEq(block.timestamp, 10, "block timestamp was not persisted from setup");
         assertEq(block.number, 100, "block number was not persisted from setup");
         assertEq(block.basefee, 1000, "basefee was not persisted from setup");
+        victim.assertSender(address(1337));
     }
 }


### PR DESCRIPTION
Persist cheatcode state from `setUp` and constructor to allow for patterns like:

```solidity
contract MyTest is DSTest {
  // ...

  function setUp() {
    cheats.startPrank(address(1));
  }
}
```