### PR TITLE
fix(test): update test to match new init behavior

### DIFF
--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -2,13 +2,13 @@
 use ansi_term::Colour;
 use ethers::solc::{artifacts::Metadata, ConfigurableContractArtifact};
 use foundry_cli_test_utils::{
-    ethers_solc::{remappings::Remapping, PathStyle},
+    ethers_solc::PathStyle,
     forgetest, forgetest_ignore, forgetest_init,
     util::{pretty_err, read_string, TestCommand, TestProject},
 };
 use foundry_config::{parse_with_profile, BasicConfig, Config, SolidityErrorCode};
 use pretty_assertions::assert_eq;
-use std::{env, fs, str::FromStr};
+use std::{env, fs};
 
 // import forge utils as mod
 #[allow(unused)]
@@ -30,24 +30,18 @@ forgetest!(can_clean_non_existing, |prj: TestProject, mut cmd: TestCommand| {
 
 // checks that init works
 forgetest!(can_init_repo_with_config, |prj: TestProject, mut cmd: TestCommand| {
+    cmd.set_current_dir(prj.root());
     let foundry_toml = prj.root().join(Config::FILE_NAME);
     assert!(!foundry_toml.exists());
 
     cmd.args(["init", "--force"]).arg(prj.root());
     cmd.assert_non_empty_stdout();
 
-    cmd.set_current_dir(prj.root());
     let file = Config::find_config_file().unwrap();
     assert_eq!(foundry_toml, file);
 
     let s = read_string(&file);
-    let basic: BasicConfig = parse_with_profile(&s).unwrap().unwrap().1;
-    // check ds-test is detected
-    assert_eq!(
-        basic.remappings,
-        vec![Remapping::from_str("ds-test/=lib/ds-test/src/").unwrap().into()]
-    );
-    assert_eq!(basic, Config::load_with_root(prj.root()).into_basic());
+    let _config: BasicConfig = parse_with_profile(&s).unwrap().unwrap().1;
 
     // can detect root
     assert_eq!(prj.root(), forge_utils::find_project_root_path().unwrap());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
8f6d5a57b2e5f0d4 removed ds-test remappings which broke the `can_init_repo_with_config` this resulted in a SIGILL inside the `pretty_assert::assert_eq!`, which was caused by a panic inside a Display impl of a pretty_assert type. 
SIGILL usually happens when there's a panic inside the panic! message formatting. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
update the test to ignore remappings check
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
