### PR TITLE
chore: remove pretty_assertions in favor of core assert_eq

### DIFF
--- a/cli/tests/cmd.rs
+++ b/cli/tests/cmd.rs
@@ -7,7 +7,6 @@ use foundry_cli_test_utils::{
     util::{pretty_err, read_string, TestCommand, TestProject},
 };
 use foundry_config::{parse_with_profile, BasicConfig, Config, SolidityErrorCode};
-use pretty_assertions::assert_eq;
 use std::{env, fs};
 
 // import forge utils as mod

--- a/cli/tests/config.rs
+++ b/cli/tests/config.rs
@@ -13,7 +13,6 @@ use foundry_config::{
     caching::{CachedChains, CachedEndpoints, StorageCachingConfig},
     Config, OptimizerDetails, SolcReq,
 };
-use pretty_assertions::assert_eq;
 use std::{fs, path::PathBuf, str::FromStr};
 
 // import forge utils as mod


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
while pretty_assertions is helpful for debugging locally, it is a constant issue within CI with failing tests and SIGILL, which happens because `pretty_assertions` error messages that get formatted within a panic can panic themselves.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
