### PR TITLE
ci: create rpc cache based on tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,9 @@ jobs:
           path: ~/.foundry/cache
           key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
 
+      - name: Force use of HTTPS for submodules
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: cargo test
         run: cargo test --locked --workspace --features external-integration-tests --test '*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,8 @@ jobs:
   external-integration:
     name: external integration tests
     runs-on: ubuntu-latest
+    env:
+      ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -94,7 +96,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.foundry/cache
-          key: forge-rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
+          key: rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
 
       - name: cargo test
         run: cargo test --locked --workspace --features external-integration-tests --test '*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.foundry/cache
-          key: forge-rpc-cache
+          key: forge-rpc-cache-${{ hashFiles('cli/tests/it/integration.rs') }}
 
       - name: cargo test
         run: cargo test --locked --workspace --features external-integration-tests --test '*'

--- a/cli/tests/it/integration.rs
+++ b/cli/tests/it/integration.rs
@@ -7,9 +7,7 @@ forgetest_external!(stringutils, "Arachnid/solidity-stringutils");
 forgetest_external!(multicall, "makerdao/multicall", &["--block-number", "1"]);
 forgetest_external!(lootloose, "gakonst/lootloose");
 forgetest_external!(lil_web3, "m1guelpf/lil-web3");
-// Disabled until they fix their submodules: one of them is using SSH which our GitHub action can't
-// figure out
-// forgetest_external!(maple_loan, "maple-labs/loan");
+forgetest_external!(maple_loan, "maple-labs/loan");
 
 // Forking tests
 forgetest_external!(drai, "mds1/drai", 13633752, &["--chain-id", "99"]);


### PR DESCRIPTION
Currently the cache is never rebuilt. Usually you would rebuild if a lockfile changed but we don't really have that, so instead we rebuild the RPC cache if the external integration tests change