### PR TITLE
Add "--recursive" When use "--template" flag

### DIFF
--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -77,7 +77,7 @@ impl Cmd for InitArgs {
             };
             p_println!(!quiet => "Initializing {} from {}...", root.display(), template);
             Command::new("git")
-                .args(&["clone --recursive", &template, &root.display().to_string()])
+                .args(&["clone", "--recursive", &template, &root.display().to_string()])
                 .stdout(Stdio::piped())
                 .spawn()?
                 .wait()?;

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -77,7 +77,7 @@ impl Cmd for InitArgs {
             };
             p_println!(!quiet => "Initializing {} from {}...", root.display(), template);
             Command::new("git")
-                .args(&["clone", &template, &root.display().to_string()])
+                .args(&["clone --recursive", &template, &root.display().to_string()])
                 .stdout(Stdio::piped())
                 .spawn()?
                 .wait()?;


### PR DESCRIPTION
When i follow the Official Example on
https://onbjerg.github.io/foundry-book/projects/creating-a-new-project.html

`forge init --template https://github.com/FrankieIsLost/forge-template hello_template`
`forge build`
Forge returns an error

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/33406415/160575895-26dd2e47-70f0-4e68-9b0d-120b6ad23ba2.png">

If other libraries are referenced in the template
Forge does not use recursion to clone the entire template

## Solution

Add `--recursive` flag in `cli/src/cmd/forge/init.rs`

<img width="701" alt="image" src="https://user-images.githubusercontent.com/33406415/160577341-637a7f44-c117-4613-ab23-ea50c34f2f8a.png">
