### PR TITLE
fix: hex encode if we dont expect a string

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -67,8 +67,12 @@ pub fn handle_expect_revert(
             (
                 format!(
                     "Error != expected error: '{}' != '{}'",
-                    String::from_utf8_lossy(&decoded_data),
-                    String::from_utf8_lossy(expected_revert)
+                    String::from_utf8(decoded_data.to_vec())
+                        .ok()
+                        .unwrap_or_else(|| hex::encode(&decoded_data)),
+                    String::from_utf8(expected_revert.to_vec())
+                        .ok()
+                        .unwrap_or_else(|| hex::encode(&expected_revert))
                 )
                 .encode()
                 .into(),


### PR DESCRIPTION
## Motivation

If we expect a custom error but a call reverts with a string we get a bunch of replacement characters which is pretty unreadable. See #1007.

## Solution

Instead of doing `String::from_utf8_lossy` we instead fallback to encoding as hex if we get invalid UTF8. The alternative is passing ABIs to the executor, then to the cheatcode handler, and decoding that way

Closes #1007