### PR TITLE
fix: proper cwd locking in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,6 +1669,7 @@ dependencies = [
  "ethers-solc",
  "foundry-config",
  "once_cell",
+ "parking_lot 0.12.0",
  "serde_json",
  "tempfile",
  "walkdir",

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -13,3 +13,4 @@ walkdir = "2.3.2"
 once_cell = "1.9.0"
 foundry-config = { path = "../../config" }
 serde_json = "1.0.67"
+parking_lot = "0.12.0"

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -266,8 +266,7 @@ impl Drop for TestCommand {
                 None => std::env::remove_var(key),
             }
         }
-        drop(self.current_dir_lock.take());
-        let _lock = CURRENT_DIR_LOCK.lock();
+        let _lock = self.current_dir_lock.take().unwrap_or_else(|| CURRENT_DIR_LOCK.lock());
         let _ = std::env::set_current_dir(&self.saved_cwd);
     }
 }

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -5,6 +5,7 @@ use ethers_solc::{
 };
 use foundry_config::Config;
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use std::{
     collections::HashMap,
     env,
@@ -17,10 +18,9 @@ use std::{
     process::{self, Command},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc
+        Arc,
     },
 };
-use parking_lot::Mutex;
 
 static CURRENT_DIR_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
fix a race condition related to the cwd.
when creating a new `forgetest!` we acquire the cwd so that we can rest it after the test is dropped so that we can set the cwd in tests (useful for tests working with Config). 
However cwd is a shared across all tests so if we do ` cmd.set_current_dir(prj.root());` the cwd is now the project root, which gets wiped once the project is dropped but tests that get created in the meantime are directed to that dir.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* use the cwd lock before creating a new forgetest! 
* use parking_lot Mutex to prevent that poisoned mutex blows up all tests regardless.

**Note**
as a side-effect, tests that make use of cwd are now effectively executed sequentially 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
