### PR TITLE
fix: handle snapshot check with no gas information

### DIFF
--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -93,7 +93,7 @@ impl fmt::Display for TestKindGas {
                 write!(f, "(gas: {})", gas)
             }
             TestKindGas::Fuzz { runs, include_fuzz_test_gas, mean, median } => {
-                if *include_fuzz_test_gas {
+                if *include_fuzz_test_gas && (*mean != 0 || *median != 0) {
                     write!(f, "(runs: {}, μ: {}, ~: {})", runs, mean, median)
                 } else {
                     write!(f, "(runs: {})", runs)
@@ -109,7 +109,13 @@ impl TestKindGas {
         match self {
             TestKindGas::Standard(gas) => *gas,
             // We use the median for comparisons
-            TestKindGas::Fuzz { median, .. } => *median,
+            TestKindGas::Fuzz { median, include_fuzz_test_gas, runs, .. } => {
+                if *include_fuzz_test_gas {
+                    *median
+                } else {
+                    (*runs).try_into().unwrap()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

When trying to check a snapshot with fuzz tests and no gas information on it, an error was raised as follows:

```log
Error: 
   0: Could not extract Snapshot Entry for PoolLibTest:testFuzzAddRemoveAll(uint8[12]) (runs: 6666)

Location:
   cli/src/cmd/forge/snapshot.rs:236
```

This error was introduced by #1086. 

## Solution

A new regex string was created allowing fuzz tests with or without gas information.
When no gas information is provided the snapshot entry is validated through the number of tests run.


