### PR TITLE
forge snapshot: don't execute fuzz tests at all by default

### DIFF
--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -114,7 +114,7 @@ impl Cmd for SnapshotArgs {
                 std::process::exit(1)
             }
         } else {
-            write_to_snapshot_file(&tests, self.snap, self.include_fuzz_tests, self.format)?;
+            write_to_snapshot_file(&tests, self.snap, self.format)?;
         }
         Ok(())
     }
@@ -249,16 +249,10 @@ fn read_snapshot(path: impl AsRef<Path>) -> eyre::Result<Vec<SnapshotEntry>> {
 fn write_to_snapshot_file(
     tests: &[Test],
     path: impl AsRef<Path>,
-    include_fuzz_tests: bool,
     _format: Option<Format>,
 ) -> eyre::Result<()> {
     let mut out = String::new();
     for test in tests {
-        // Ignore fuzz tests if we're not including fuzz tests in the snapshot.
-        if matches!(test.result.kind, TestKind::Fuzz(..)) && !include_fuzz_tests {
-            continue
-        }
-
         writeln!(
             out,
             "{}:{} {}",

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -11,7 +11,7 @@ use crate::cmd::{
 use ansi_term::Colour;
 use clap::{Parser, ValueHint};
 use eyre::Context;
-use forge::{TestKindGas};
+use forge::TestKindGas;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -4,7 +4,7 @@ use crate::cmd::{
     forge::{
         build::BuildArgs,
         test,
-        test::{Test, TestOutcome},
+        test::{custom_run, Test, TestOutcome},
     },
     Cmd,
 };
@@ -97,7 +97,7 @@ impl Cmd for SnapshotArgs {
     type Output = ();
 
     fn run(self) -> eyre::Result<()> {
-        let outcome = self.test.run()?;
+        let outcome = custom_run(self.test, self.include_fuzz_tests)?;
         outcome.ensure_ok()?;
         let tests = self.config.apply(outcome);
 

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -11,7 +11,7 @@ use crate::cmd::{
 use ansi_term::Colour;
 use clap::{Parser, ValueHint};
 use eyre::Context;
-use forge::{TestKind, TestKindGas};
+use forge::{TestKindGas};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -127,7 +127,7 @@ pub struct TestArgs {
     debug: Option<Regex>,
 
     /// Print a gas report.
-    #[clap(long = "gas-report")]
+    #[clap(long, env = "FORGE_GAS_REPORT")]
     gas_report: bool,
 
     /// Force the process to exit with code 0, even if the tests fail.

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -127,12 +127,8 @@ pub struct TestArgs {
     debug: Option<Regex>,
 
     /// Print a gas report.
-    #[clap(long, env = "FORGE_GAS_REPORT")]
+    #[clap(long = "gas-report")]
     gas_report: bool,
-
-    /// Include the mean and median gas use of fuzz tests in the output.
-    #[clap(long, env = "FORGE_INCLUDE_FUZZ_TEST_GAS")]
-    pub include_fuzz_test_gas: bool,
 
     /// Force the process to exit with code 0, even if the tests fail.
     #[clap(long, env = "FORGE_ALLOW_FAILURE")]
@@ -239,7 +235,7 @@ impl Cmd for TestArgs {
                     };
                     debugger.run()?;
 
-                    Ok(TestOutcome::new(results, self.allow_failure, self.include_fuzz_test_gas))
+                    Ok(TestOutcome::new(results, self.allow_failure))
                 }
                 n =>
                     Err(
@@ -255,7 +251,7 @@ impl Cmd for TestArgs {
                 filter,
                 self.json,
                 self.allow_failure,
-                (self.include_fuzz_test_gas, self.gas_report, config.gas_reports),
+                (self.gas_report, config.gas_reports),
             )
         }
     }
@@ -275,7 +271,7 @@ pub struct Test {
 
 impl Test {
     pub fn gas_used(&self) -> u64 {
-        self.result.kind.gas_used(true).gas()
+        self.result.kind.gas_used().gas()
     }
 
     /// Returns the contract name of the artifact id
@@ -293,19 +289,13 @@ impl Test {
 pub struct TestOutcome {
     /// Whether failures are allowed
     pub allow_failure: bool,
-    /// Whether to include fuzz test gas usage in the output
-    pub include_fuzz_test_gas: bool,
     /// Results for each suite of tests `contract -> SuiteResult`
     pub results: BTreeMap<String, SuiteResult>,
 }
 
 impl TestOutcome {
-    fn new(
-        results: BTreeMap<String, SuiteResult>,
-        allow_failure: bool,
-        include_fuzz_test_gas: bool,
-    ) -> Self {
-        Self { results, include_fuzz_test_gas, allow_failure }
+    fn new(results: BTreeMap<String, SuiteResult>, allow_failure: bool) -> Self {
+        Self { results, allow_failure }
     }
 
     /// Iterator over all succeeding tests and their names
@@ -334,14 +324,14 @@ impl TestOutcome {
     }
 
     /// Checks if there are any failures and failures are disallowed
-    pub fn ensure_ok(&self, include_fuzz_test_gas: bool) -> eyre::Result<()> {
+    pub fn ensure_ok(&self) -> eyre::Result<()> {
         if !self.allow_failure {
             let failures = self.failures().count();
             if failures > 0 {
                 println!();
                 println!("Failed tests:");
                 for (name, result) in self.failures() {
-                    short_test_result(name, include_fuzz_test_gas, result);
+                    short_test_result(name, result);
                 }
                 println!();
 
@@ -377,7 +367,7 @@ impl TestOutcome {
     }
 }
 
-fn short_test_result(name: &str, include_fuzz_test_gas: bool, result: &forge::TestResult) {
+fn short_test_result(name: &str, result: &forge::TestResult) {
     let status = if result.success {
         Colour::Green.paint("[PASS]")
     } else {
@@ -397,7 +387,7 @@ fn short_test_result(name: &str, include_fuzz_test_gas: bool, result: &forge::Te
         Colour::Red.paint(txt)
     };
 
-    println!("{} {} {}", status, name, result.kind.gas_used(include_fuzz_test_gas));
+    println!("{} {} {}", status, name, result.kind.gas_used());
 }
 
 /// Runs all the tests
@@ -407,12 +397,12 @@ fn test(
     filter: Filter,
     json: bool,
     allow_failure: bool,
-    (include_fuzz_test_gas, gas_reporting, gas_reports): (bool, bool, Vec<String>),
+    (gas_reporting, gas_reports): (bool, Vec<String>),
 ) -> eyre::Result<TestOutcome> {
     if json {
         let results = runner.test(&filter, None)?;
         println!("{}", serde_json::to_string(&results)?);
-        Ok(TestOutcome::new(results, allow_failure, include_fuzz_test_gas))
+        Ok(TestOutcome::new(results, allow_failure))
     } else {
         let local_identifier = LocalTraceIdentifier::new(&runner.known_contracts);
         let (tx, rx) = channel::<(String, SuiteResult)>();
@@ -429,7 +419,7 @@ fn test(
                 println!("Running {} {} for {}", tests.len(), term, contract_name);
             }
             for (name, result) in &mut tests {
-                short_test_result(name, include_fuzz_test_gas, result);
+                short_test_result(name, result);
 
                 // We only display logs at level 2 and above
                 if verbosity >= 2 {
@@ -492,7 +482,6 @@ fn test(
             let block_outcome = TestOutcome::new(
                 [(contract_name.clone(), suite_result.clone())].into(),
                 allow_failure,
-                include_fuzz_test_gas,
             );
             println!("{}", block_outcome.summary());
             results.insert(contract_name, suite_result);
@@ -505,6 +494,6 @@ fn test(
         // reattach the thread
         let _ = handle.join();
 
-        Ok(TestOutcome::new(results, allow_failure, include_fuzz_test_gas))
+        Ok(TestOutcome::new(results, allow_failure))
     }
 }

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -20,9 +20,8 @@ fn main() -> eyre::Result<()> {
             if cmd.build_args().is_watch() {
                 utils::block_on(watch::watch_test(cmd))?;
             } else {
-                let include_fuzz_test_gas = cmd.include_fuzz_test_gas;
                 let outcome = cmd.run()?;
-                outcome.ensure_ok(include_fuzz_test_gas)?;
+                outcome.ensure_ok()?;
             }
         }
         Subcommands::Bind(cmd) => {

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -189,6 +189,7 @@ impl MultiContractRunner {
         &mut self,
         filter: &(impl TestFilter + Send + Sync),
         stream_result: Option<Sender<(String, SuiteResult)>>,
+        include_fuzz_tests: bool,
     ) -> Result<BTreeMap<String, SuiteResult>> {
         let env = self.evm_opts.evm_env();
 
@@ -222,6 +223,7 @@ impl MultiContractRunner {
                     deploy_code.clone(),
                     libs,
                     filter,
+                    include_fuzz_tests,
                 )?;
                 Ok((id.identifier(), result))
             })
@@ -252,6 +254,7 @@ impl MultiContractRunner {
         deploy_code: Bytes,
         libs: &[Bytes],
         filter: &impl TestFilter,
+        include_fuzz_tests: bool,
     ) -> Result<SuiteResult> {
         let mut runner = ContractRunner::new(
             executor,
@@ -262,7 +265,7 @@ impl MultiContractRunner {
             self.errors.as_ref(),
             libs,
         );
-        runner.run_tests(filter, self.fuzzer.clone())
+        runner.run_tests(filter, self.fuzzer.clone(), include_fuzz_tests)
     }
 }
 
@@ -351,7 +354,7 @@ mod tests {
     #[test]
     fn test_core() {
         let mut runner = runner();
-        let results = runner.test(&Filter::new(".*", ".*", ".*core"), None).unwrap();
+        let results = runner.test(&Filter::new(".*", ".*", ".*core"), None, true).unwrap();
 
         assert_multiple(
             &results,
@@ -400,7 +403,7 @@ mod tests {
     #[test]
     fn test_logs() {
         let mut runner = runner();
-        let results = runner.test(&Filter::new(".*", ".*", ".*logs"), None).unwrap();
+        let results = runner.test(&Filter::new(".*", ".*", ".*logs"), None, true).unwrap();
 
         assert_multiple(
             &results,
@@ -464,7 +467,7 @@ mod tests {
     #[test]
     fn test_cheats() {
         let mut runner = runner();
-        let suite_result = runner.test(&Filter::new(".*", ".*", ".*cheats"), None).unwrap();
+        let suite_result = runner.test(&Filter::new(".*", ".*", ".*cheats"), None, true).unwrap();
 
         for (_, SuiteResult { test_results, .. }) in suite_result {
             for (test_name, result) in test_results {
@@ -483,7 +486,7 @@ mod tests {
     #[test]
     fn test_fuzz() {
         let mut runner = runner();
-        let suite_result = runner.test(&Filter::new(".*", ".*", ".*fuzz"), None).unwrap();
+        let suite_result = runner.test(&Filter::new(".*", ".*", ".*fuzz"), None, true).unwrap();
 
         for (_, SuiteResult { test_results, .. }) in suite_result {
             for (test_name, result) in test_results {
@@ -512,7 +515,7 @@ mod tests {
     #[test]
     fn test_trace() {
         let mut runner = tracing_runner();
-        let suite_result = runner.test(&Filter::new(".*", ".*", ".*trace"), None).unwrap();
+        let suite_result = runner.test(&Filter::new(".*", ".*", ".*trace"), None, true).unwrap();
 
         // TODO: This trace test is very basic - it is probably a good candidate for snapshot
         // testing.
@@ -549,7 +552,8 @@ mod tests {
     #[test]
     fn test_doesnt_run_abstract_contract() {
         let mut runner = runner();
-        let results = runner.test(&Filter::new(".*", ".*", ".*core/Abstract.t.sol"), None).unwrap();
+        let results =
+            runner.test(&Filter::new(".*", ".*", ".*core/Abstract.t.sol"), None, true).unwrap();
         assert!(results.get("core/Abstract.t.sol:AbstractTestBase").is_none());
         assert!(results.get("core/Abstract.t.sol:AbstractTest").is_some());
     }

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -222,8 +222,7 @@ impl MultiContractRunner {
                     executor,
                     deploy_code.clone(),
                     libs,
-                    filter,
-                    include_fuzz_tests,
+                    (filter, include_fuzz_tests),
                 )?;
                 Ok((id.identifier(), result))
             })
@@ -253,8 +252,7 @@ impl MultiContractRunner {
         executor: Executor<DB>,
         deploy_code: Bytes,
         libs: &[Bytes],
-        filter: &impl TestFilter,
-        include_fuzz_tests: bool,
+        (filter, include_fuzz_tests): (&impl TestFilter, bool),
     ) -> Result<SuiteResult> {
         let mut runner = ContractRunner::new(
             executor,

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -83,7 +83,7 @@ impl TestResult {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum TestKindGas {
     Standard(u64),
-    Fuzz { runs: usize, include_fuzz_test_gas: bool, mean: u64, median: u64 },
+    Fuzz { runs: usize, mean: u64, median: u64 },
 }
 
 impl fmt::Display for TestKindGas {
@@ -92,12 +92,8 @@ impl fmt::Display for TestKindGas {
             TestKindGas::Standard(gas) => {
                 write!(f, "(gas: {})", gas)
             }
-            TestKindGas::Fuzz { runs, include_fuzz_test_gas, mean, median } => {
-                if *include_fuzz_test_gas {
-                    write!(f, "(runs: {}, μ: {}, ~: {})", runs, mean, median)
-                } else {
-                    write!(f, "(runs: {})", runs)
-                }
+            TestKindGas::Fuzz { runs, mean, median } => {
+                write!(f, "(runs: {}, μ: {}, ~: {})", runs, mean, median)
             }
         }
     }
@@ -127,12 +123,11 @@ pub enum TestKind {
 
 impl TestKind {
     /// The gas consumed by this test
-    pub fn gas_used(&self, include_fuzz_test_gas: bool) -> TestKindGas {
+    pub fn gas_used(&self) -> TestKindGas {
         match self {
             TestKind::Standard(gas) => TestKindGas::Standard(*gas),
             TestKind::Fuzz(fuzzed) => TestKindGas::Fuzz {
                 runs: fuzzed.cases().len(),
-                include_fuzz_test_gas,
                 median: fuzzed.median_gas(false),
                 mean: fuzzed.mean_gas(false),
             },

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -260,6 +260,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
         &mut self,
         filter: &impl TestFilter,
         fuzzer: Option<TestRunner>,
+        include_fuzz_tests: bool,
     ) -> Result<SuiteResult> {
         tracing::info!("starting tests");
         let start = Instant::now();
@@ -291,7 +292,11 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             .contract
             .functions()
             .into_iter()
-            .filter(|func| func.name.starts_with("test") && filter.matches_test(func.signature()))
+            .filter(|func| {
+                func.name.starts_with("test") &&
+                    filter.matches_test(func.signature()) &&
+                    (include_fuzz_tests || func.inputs.is_empty())
+            })
             .map(|func| (func, func.name.starts_with("testFail")))
             .collect();
 


### PR DESCRIPTION
closes https://github.com/gakonst/foundry/issues/1136

this is a significant speedup for solmate, from ~5.1s -> <1s