### PR TITLE
feat(forge): print compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
- "ethers-addressbook 0.1.0 (git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time)",
+ "ethers-addressbook",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1251,17 +1251,6 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "0.1.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1278,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1296,7 +1285,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1318,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1332,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1358,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1372,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1395,7 +1384,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1427,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1450,7 +1439,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+source = "git+https://github.com/gakonst/ethers-rs#18dda9aa8322b22b9ae6d7e4fc61d1813923413d"
 dependencies = [
  "colored",
  "dunce",
@@ -1736,7 +1725,7 @@ name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
  "ethers",
- "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-addressbook",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
- "ethers-addressbook",
+ "ethers-addressbook 0.1.0 (git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time)",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1251,6 +1251,17 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "0.1.0"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1267,7 +1278,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1285,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1307,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1321,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1347,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1361,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1384,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1416,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1439,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#f402f134a34ea514c5abd5d8272687ac7772b3cb"
+source = "git+https://github.com/ecmendenhall/ethers-rs?branch=horsefacts/report-compile-time#b4991f940326f70c0c6dddf64b5b8a6704ba6b4a"
 dependencies = [
  "colored",
  "dunce",
@@ -1725,7 +1736,7 @@ name = "foundry-utils"
 version = "0.2.0"
 dependencies = [
  "ethers",
- "ethers-addressbook",
+ "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",
  "ethers-etherscan",
  "ethers-providers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,11 @@ codegen-units = 1
 panic = "abort"
 # We end up stripping away these symbols anyway
 debug = 0
+
+[patch."https://github.com/gakonst/ethers-rs"]
+ethers = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
+ethers-core = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
+ethers-providers = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
+ethers-signers = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
+ethers-etherscan = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
+ethers-solc = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,3 @@ codegen-units = 1
 panic = "abort"
 # We end up stripping away these symbols anyway
 debug = 0
-
-[patch."https://github.com/gakonst/ethers-rs"]
-ethers = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
-ethers-core = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
-ethers-providers = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
-ethers-signers = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
-ethers-etherscan = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }
-ethers-solc = { git = "https://github.com/ecmendenhall/ethers-rs", branch = "horsefacts/report-compile-time" }

--- a/cli/src/term.rs
+++ b/cli/src/term.rs
@@ -17,6 +17,7 @@ use std::{
         mpsc::{self, TryRecvError},
         Arc, Mutex,
     },
+    time::Duration,
 };
 
 /// Some spinners
@@ -228,8 +229,15 @@ impl Reporter for SpinnerReporter {
         self.solc_io_report.log_compiler_input(input);
     }
 
-    fn on_solc_success(&self, _solc: &Solc, _version: &Version, output: &CompilerOutput) {
+    fn on_solc_success(
+        &self,
+        _solc: &Solc,
+        _version: &Version,
+        output: &CompilerOutput,
+        duration: &Duration,
+    ) {
         self.solc_io_report.log_compiler_output(output);
+        self.send_msg(format!("Solc finished in {:.2?}", duration));
     }
 
     /// Invoked before a new [`Solc`] bin is installed


### PR DESCRIPTION
## Motivation

Resolves #1125 

Print time spent compiling the project.

![t-rec_3](https://user-images.githubusercontent.com/1131633/160957538-091e5271-6e95-43fe-aa0c-2593aebddf0c.gif)

## Solution

Print duration passed to `SpinnerReporter`. Depends on [gakonst/ethers-rs/#1098](https://github.com/gakonst/ethers-rs/pull/1098). 

This does look a little odd: when there is a lot of compiler output to display, the spinner will keep spinning for a few seconds, even though compilation is finished. (See the GIF above).