### PR TITLE
fix: Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN wget -q -O ${GLIBC_KEY_FILE} ${GLIBC_KEY} \
     && apk add glibc.apk --force
 COPY --from=build-environment /opt/foundry/target/release/forge /usr/local/bin/forge
 COPY --from=build-environment /opt/foundry/target/release/cast /usr/local/bin/cast
-ENTRYPOINT ["/bin/sh -c"]
+ENTRYPOINT ["/bin/sh", "-c"]


### PR DESCRIPTION
## Motivation
I fat-fingered the docker file and had "/bin/sh -c" as as single entrypoint command, which prevents the better UX of being able to pass a string of a full foundry command directly to the image via stdin.

Prior Experience
```sh
$> docker run foundry:nightly 'cast --rpc-url $RPC_URL vitalik.eth'
docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/bin/sh -c": stat /bin/sh -c: no such file or directory: unknown.
ERRO[0000] error waiting for container: context canceled
```

Prior Workaround:
```sh
$> docker run --entrypoint cast foundry:nightly 'resolve-name' --rpc-url $RPC_URL vitalik.eth
0xd8da6bf26964af9d7eed9e03e53415d37aa96045
```

New Experience w/ Fix
```sh 
$>docker run foundry:nightly 'cast resolve-name --rpc-url $RPC_URL vitalik.eth'
0xd8da6bf26964af9d7eed9e03e53415d37aa96045
```
## Solution
Correctly configure the entrypoint to be `["/bin/sh", "-c"]` so that the image can directly accept a full foundry command as a string

**If` a maintainer could manually trigger the "Build and Publish Docker" action after this merges, I would appreciate it :)**