### PR TITLE
fix(forge/run): fix branching for if no target contract specified

### DIFF
--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -294,13 +294,15 @@ impl RunArgs {
                 } = post_link_input;
 
                 // if it's the target contract, grab the info
-                if extra.no_target_name && id.source == std::path::Path::new(&extra.target_fname) {
-                    if extra.matched {
-                        eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `-t ContractName`")
+                if extra.no_target_name {
+                    if id.source == std::path::Path::new(&extra.target_fname) {
+                        if extra.matched {
+                            eyre::bail!("Multiple contracts in the target path. Please specify the contract name with `-t ContractName`")
+                        }
+                        *extra.dependencies = dependencies;
+                        *extra.contract = contract.clone();
+                        extra.matched = true;
                     }
-                    *extra.dependencies = dependencies;
-                    *extra.contract = contract.clone();
-                    extra.matched = true;
                 } else {
                     let split: Vec<&str> = extra.target_fname.split(':').collect();
                     let path = std::path::Path::new(split[0]);


### PR DESCRIPTION
There's a bug in branching. `forge run ./some.sol` won't work without a `--target-contract` being specified even in cases when the sol file would only have one contract. If the whole repo only contains a single solidity file, it'll work, if there are multiple and you happen to start iterating over artifacts on any other contract it will fall into the else branch which assumes target contract is specified and will panic with index out of bounds. 