### PR TITLE
feat(foundryup): warn users if already installed via cargo

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -129,11 +129,11 @@ main() {
     say "installed - $($FOUNDRY_BIN_DIR/cast --version)"
     say "done"
     
-    if [[ "$(which forge)" =~ "cargo" ]]
+    if [[ "$(which forge)" =~ "cargo" ]]; then
       warn "it appears your system has already has forge installed via cargo. you may need to run `rm $(which forge)` to allow foundryup to take precedence!"
     fi
     
-    if [[ "$(which cast)" =~ "cargo" ]]
+    if [[ "$(which cast)" =~ "cargo" ]]; then
       warn "it appears your system has already has cast installed via cargo. you may need to run `rm $(which cast)` to allow foundryup to take precedence!"
     fi
   else

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -128,6 +128,14 @@ main() {
     say "installed - $($FOUNDRY_BIN_DIR/forge --version)"
     say "installed - $($FOUNDRY_BIN_DIR/cast --version)"
     say "done"
+    
+    if [[ "$(which forge)" =~ "cargo" ]]
+      warn "it appears your system has already has forge installed via cargo. you may need to run `rm $(which forge)` to allow foundryup to take precedence!"
+    fi
+    
+    if [[ "$(which cast)" =~ "cargo" ]]
+      warn "it appears your system has already has cast installed via cargo. you may need to run `rm $(which cast)` to allow foundryup to take precedence!"
+    fi
   else
     need_cmd cargo
     FOUNDRYUP_BRANCH=${FOUNDRYUP_BRANCH-master}

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -129,12 +129,12 @@ main() {
     say "installed - $($FOUNDRY_BIN_DIR/cast --version)"
     say "done"
     
-    if [[ "$(which forge)" =~ "cargo" ]]; then
-      warn "it appears your system has already has forge installed via cargo. you may need to run `rm $(which forge)` to allow foundryup to take precedence!"
+    if [[ $(which forge) =~ "cargo" ]]; then
+      warn "it appears your system has already has forge installed via cargo. you may need to run 'rm $(which forge)' to allow foundryup to take precedence!"
     fi
     
-    if [[ "$(which cast)" =~ "cargo" ]]; then
-      warn "it appears your system has already has cast installed via cargo. you may need to run `rm $(which cast)` to allow foundryup to take precedence!"
+    if [[ $(which cast) =~ "cargo" ]]; then
+      warn "it appears your system has already has cast installed via cargo. you may need to run 'rm $(which cast)' to allow foundryup to take precedence!"
     fi
   else
     need_cmd cargo


### PR DESCRIPTION
## Motivation

Users often get confused if they previously installed forge/cast via cargo and now run foundryup to seemingly have no effect (because cargo bin takes priority)

<img width="573" alt="Screen Shot 2022-03-31 at 8 15 23 AM" src="https://user-images.githubusercontent.com/26209401/161089849-1862b343-fda9-4a29-b3c1-2df8f0c3d597.png">

## Solution

Warn users if the location of the forge/cast binaries have cargo in them