### PR TITLE
add libusb warning for users with mac os

### DIFF
--- a/foundryup/install
+++ b/foundryup/install
@@ -43,5 +43,10 @@ if [[ ":$PATH:" != *":${FOUNDRY_BIN_DIR}:"* ]]; then
     echo >> $PROFILE && echo "export PATH=\"\$PATH:$FOUNDRY_BIN_DIR\"" >> $PROFILE
 fi
 
+# Warn MacOS users that they may need to manually install libusb via Homebrew:
+if [[ "$OSTYPE" =~ ^darwin && ! -f /usr/local/opt/libusb/lib/libusb-1.0.0.dylib ]]; then
+    echo && echo "warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install libusb)."
+fi
+
 echo && echo "Detected your preferred shell is ${PREF_SHELL} and added foundryup to PATH. Run 'source ${PROFILE}' or start a new terminal session to use foundryup."
 echo "Then, simply run 'foundryup' to install Foundry."


### PR DESCRIPTION
## Motivation

- resolves https://github.com/gakonst/foundry/issues/1169
- macos users may not have the required `libusb` dependency.
- per comments here: https://github.com/gakonst/foundry/pull/501#discussion_r840603359

## Solution

This pr checks for mac's darwin os & prints a warning to install libusb if it is currently missing.
Example warning below:

```zsh
Installing foundryup...
###################################################################################################### 100.0%

warning: libusb not found. You may need to install it manually on MacOS via Homebrew (brew install libusb).

Detected your preferred shell is zsh and added foundryup to PATH. Run 'source ~/.zshrc' or start a new terminal session to use foundryup.
Then, simply run 'foundryup' to install Foundry.
```
