### PR TITLE
fix/forge: update address value from trace on `create_end`

### DIFF
--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -45,13 +45,23 @@ impl Tracer {
         ));
     }
 
-    pub fn fill_trace(&mut self, success: bool, cost: u64, output: Vec<u8>) {
+    pub fn fill_trace(
+        &mut self,
+        success: bool,
+        cost: u64,
+        output: Vec<u8>,
+        address: Option<Address>,
+    ) {
         let trace = &mut self.traces.arena
             [self.trace_stack.pop().expect("more traces were filled than started")]
         .trace;
         trace.success = success;
         trace.gas_cost = cost;
         trace.output = RawOrDecodedReturnData::Raw(output);
+
+        if let Some(address) = address {
+            trace.address = address;
+        }
     }
 }
 
@@ -99,6 +109,7 @@ where
                 matches!(status, return_ok!()),
                 gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
                 retdata.to_vec(),
+                None,
             );
         }
 
@@ -147,6 +158,7 @@ where
             matches!(status, return_ok!()),
             gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
             code,
+            address,
         );
 
         (status, address, gas, retdata)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The `prank` cheatcode is only applied to a contract creation after starting the trace which leads to recording the contract address wrongly. And consequently messing up the labeling/decoding further on.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Make sure to update the address on `create_end()`

before:
```
[PASS] testScenario() (gas: 501392)
Traces:
  [501392] NestVestTest::testScenario() 
    ├─ [0] VM::prank(0x0000000000000000000000000000000000001337, 0x0000000000000000000000000000000000001337) 
    │   └─ ← ()
    ├─ [460706] → new NestVest@0xce71065d4017f316ec606fe4422e11eb2c47c246
    │   └─ ← 2188 bytes of code
    ├─ [2625] 0x03f1…73f5::claimable() [staticcall]
    │   └─ ← 499999999999999993344000
    └─ ← ()

Test result: ok. 1 passed; 0 failed; finished in 867.52ms
```
after:
```
[PASS] testScenario() (gas: 501392)
Traces:
  [501392] NestVestTest::testScenario() 
    ├─ [0] VM::prank(0x0000000000000000000000000000000000001337, 0x0000000000000000000000000000000000001337) 
    │   └─ ← ()
    ├─ [460706] → new NestVest@0x03f1b4380995fbf41652f75a38c9f74ad8ad73f5
    │   └─ ← 2188 bytes of code
    ├─ [2625] NestVest::claimable() [staticcall]
    │   └─ ← 499999999999999993344000
    └─ ← ()

Test result: ok. 1 passed; 0 failed; finished in 351.25ms
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
