### PR TITLE
fix/forge: save address codes for decoding later

### DIFF
--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -100,6 +100,13 @@ where
                 gas_used(data.env.cfg.spec_id, gas.spend(), gas.refunded() as u64),
                 retdata.to_vec(),
             );
+
+            if !self.traces.codes.contains_key(&call.context.code_address) {
+                let account = data.db.basic(call.context.code_address);
+                if let Some(code) = account.code {
+                    self.traces.codes.insert(call.context.code_address, code.to_vec());
+                }
+            }
         }
 
         (status, gas, retdata)

--- a/evm/src/executor/inspector/tracer.rs
+++ b/evm/src/executor/inspector/tracer.rs
@@ -101,12 +101,14 @@ where
                 retdata.to_vec(),
             );
 
-            if !self.traces.codes.contains_key(&call.context.code_address) {
+            self.traces.codes.entry(call.context.code_address).or_insert_with(|| {
                 let account = data.db.basic(call.context.code_address);
                 if let Some(code) = account.code {
-                    self.traces.codes.insert(call.context.code_address, code.to_vec());
+                    code.to_vec()
+                } else {
+                    vec![]
                 }
-            }
+            });
         }
 
         (status, gas, retdata)

--- a/evm/src/trace/mod.rs
+++ b/evm/src/trace/mod.rs
@@ -14,18 +14,22 @@ use ethers::{
     types::U256,
 };
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Write};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Write},
+};
 
 /// An arena of [CallTraceNode]s
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallTraceArena {
     /// The arena of nodes
     pub arena: Vec<CallTraceNode>,
+    pub codes: BTreeMap<Address, Vec<u8>>,
 }
 
 impl Default for CallTraceArena {
     fn default() -> Self {
-        CallTraceArena { arena: vec![Default::default()] }
+        CallTraceArena { arena: vec![Default::default()], codes: BTreeMap::default() }
     }
 }
 
@@ -69,7 +73,7 @@ impl CallTraceArena {
                     None
                 }
             } else {
-                None
+                self.codes.get(&node.trace.address)
             };
 
             (&node.trace.address, code)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

When running tests against a mainnet fork, we were not decoding contract addresses with the same or similar bytecode as built locally. It used to work on 0.1.0 and it's quite useful.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Saving  {contract_address => code} in the call trace arena. Adds memory bloat, but the `DB` is not accessible anymore when decoding the traces...

before:
```
[PASS] testScenario() (gas: 13255)
Traces:
  [13255] NestVestTest::testScenario() 
    ├─ [5045] 0xfeaa…5bee::18160ddd() [staticcall]
    │   ├─ [2341] 0x5bc1…9796::18160ddd(766573746564464c590000000000000000000000000000000000000000000000766573746564464c5900000000000000000000000000000000000000000000001278ea3fef1c1f07348199bf44f45b803b9b0dbe28000000006255000f0000000064368543c899b9992397601c5e84ff238ac9dca286b6dac60079) [delegatecall]
    │   │   └─ ← 0x000000000000000000000000000000000000000000084595161401484a000000
    │   └─ ← 0x000000000000000000000000000000000000000000084595161401484a000000
    ├─ [2385] 0x78ea…be28::18160ddd() [staticcall]
    │   └─ ← 0x0000000000000000000000000000000000000000000dda161b3f4529f6f1fa79
    └─ ← ()

Test result: ok. 1 passed; 0 failed; finished in 349.82ms
```

after:
```
[PASS] testScenario() (gas: 13255)
Traces:
  [13255] NestVestTest::testScenario() 
    ├─ [5045] 0xfeaa…5bee::totalSupply() [staticcall]
    │   ├─ [2341] VestedERC20::totalSupply() [delegatecall]
    │   │   └─ ← 10000000000000000000000000
    │   └─ ← 10000000000000000000000000
    ├─ [2385] 0x78ea…be28::totalSupply() [staticcall]
    │   └─ ← 16745919339989392633756281
    └─ ← ()

Test result: ok. 1 passed; 0 failed; finished in 256.28ms
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
