### PR TITLE
fix/forge: return empty vector on failing to decode input

### DIFF
--- a/evm/src/trace/decoder.rs
+++ b/evm/src/trace/decoder.rs
@@ -238,11 +238,12 @@ impl CallTraceDecoder {
                                         .collect()
                                 })
                             } else {
-                                func.decode_input(&bytes[4..])
-                                    .expect("bad function input decode")
-                                    .iter()
-                                    .map(|token| self.apply_label(token))
-                                    .collect()
+                                match func.decode_input(&bytes[4..]) {
+                                    Ok(v) => {
+                                        v.iter().map(|token| self.apply_label(token)).collect()
+                                    }
+                                    Err(_) => Vec::new(),
+                                }
                             }
                         } else {
                             Vec::new()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Decoding a malformed function input was crashing the decoder. eg:

```solidity
pragma solidity 0.8.12;

contract Contract  {

   function testme(uint[] memory vars) public { }
   function run() public {
        address(this).call(abi.encodeWithSelector(this.testme.selector, 1));
   }
}
``` 

Results in:

```
Traces:
The application panicked (crashed).
Message:  bad function input decode: InvalidData
Location: evm/src/trace/decoder.rs:242

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
[1]    60639 IOT instruction (core dumped)  forge run C.sol -vvvv
```


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Replace `expect` with `match` and return an empty vector

```
Traces:
  [991] Contract::run() 
    ├─ [242] Contract::testme() 
    │   └─ ← ()
    └─ ← ()


Script ran successfully.
Gas used: 991
== Logs ==
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
