### PR TITLE
fix: correctly set `msg.sender`'s balance

### DIFF
--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -225,7 +225,11 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
             .deploy(self.sender, self.code.0.clone(), 0u32.into())
             .expect("couldn't deploy");
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)).into_iter());
+
+        // Now we set the contracts initial balance, and we also reset `self.sender`s balance to
+        // the initial balance we want
         self.executor.set_balance(address, self.initial_balance);
+        self.executor.set_balance(self.sender, self.initial_balance);
 
         // Optionally call the `setUp` function
         Ok(if setup {


### PR DESCRIPTION
## Motivation

If you transferred eth in a fuzz test, and it happened to send to `msg.sender` of the test contract, then the test would fail, since the payment would overflow. This happens because we set the balance to `U256::MAX`.

Final bug for https://github.com/Rari-Capital/solmate/issues/182

## Solution

Set the balance of `msg.sender` for the test contract to `self.initial_balance` in the contract runner. I am not sure if this lines up with DappTools