### PR TITLE
feat(config): make sparse mode opt in

### DIFF
--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -354,8 +354,12 @@ pub fn custom_run(mut args: TestArgs, include_fuzz_tests: bool) -> eyre::Result<
 
     // Set up the project
     let project = config.project()?;
-
-    let output = ProjectCompiler::default().compile(&project)?;
+    let compiler = ProjectCompiler::default();
+    let output = if config.sparse_mode {
+        compiler.compile_sparse(&project, args.filter.clone())
+    } else {
+        compiler.compile(&project)
+    }?;
 
     // Determine print verbosity and executor verbosity
     let verbosity = evm_opts.verbosity;

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -81,6 +81,7 @@ forgetest!(can_extract_config_values, |prj: TestProject, mut cmd: TestCommand| {
         },
         no_storage_caching: true,
         bytecode_hash: Default::default(),
+        sparse_mode: true,
         __non_exhaustive: (),
     };
     prj.write_config(input.clone());

--- a/config/README.md
+++ b/config/README.md
@@ -102,6 +102,9 @@ rpc_storage_caching = { chains = "all", endpoints = "all" }
 no_storage_caching = false
 # don't include the metadata hash, to allow for deterministic code: https://docs.soliditylang.org/en/latest/metadata.html, solc's default is "ipfs"
 bytecode_hash = "none"
+# If this option is enabled, Solc is instructed to generate output (bytecode) only for the required contracts
+# this can reduce compile time for `forge test` a bit but is considered experimental at this point.
+sparse_mode = false
 ```
 
 ##### Additional Optimizer settings

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -217,6 +217,12 @@ pub struct Config {
     /// The metadata hash is machine dependent. By default, this is set to [BytecodeHash::None] to allow for deterministic code, See: <https://docs.soliditylang.org/en/latest/metadata.html>
     #[serde(with = "from_str_lowercase")]
     pub bytecode_hash: BytecodeHash,
+    /// Whether to compile in sparse mode
+    ///
+    /// If this option is enabled, only the required contracts/files will be selected to be
+    /// included in solc's output selection, see also
+    /// [OutputSelection](ethers_solc::artifacts::output_selection::OutputSelection)
+    pub sparse_mode: bool,
     /// The root path where the config detection started from, `Config::with_root`
     #[doc(hidden)]
     //  We're skipping serialization here, so it won't be included in the [`Config::to_string()`]
@@ -921,6 +927,7 @@ impl Default for Config {
             rpc_storage_caching: Default::default(),
             no_storage_caching: false,
             bytecode_hash: BytecodeHash::None,
+            sparse_mode: false,
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
add a config value to set sparse compile mode
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
a `--sparse` argument flag was deliberately not added because eventually we can make this the default. rn it's opt in via config file.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
