### PR TITLE
chore(docs) add docker section in readme, --commit example in foundryup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ cargo build --release
 
 Or via `cargo install --git https://github.com/gakonst/foundry --locked`
 
+### Installing via Docker
+
+Foundry maintains a [Docker image repository](https://github.com/gakonst/foundry/pkgs/container/foundry).
+
+You can pull the latest release image like so:  
+```sh
+docker pull ghcr.io/gakonst/foundry:latest
+```
+For examples and guides on using this image, see the [Docker section](https://onbjerg.github.io/foundry-book/tutorials/foundry-docker.html) in the book.
+
 ### Releases
 
 You can manually download nightly releases

--- a/foundryup/README.md
+++ b/foundryup/README.md
@@ -46,6 +46,11 @@ To install from a **specific Pull Request**:
 foundryup --pr 1071
 ```
 
+To install from a **specific commit**:
+```sh
+foundryup -C 94bfdb2
+```
+
 To install a local directory or repository (e.g. one located at `~/git/foundry`, assuming you're in the home directory)
 ##### Note: --branch, --repo, and --version flags are ignored during local installations. 
 


### PR DESCRIPTION
## Motivation
We need some basic documentation around the Docker image. Closes #1080.

## Solution
Add Docker image info to Readme and link to a more detailed writeup in the book.
Also includes a separate documentation change that adds a `-C` example in the `foundryup` readme. 