### PR TITLE
chore(docs): update console.log link to hardhat repo 

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -312,7 +312,7 @@ We support the logging functionality from Hardhat's `console.log`.
 
 If you are on a hardhat project, `import hardhat/console.sol` should just work if you use `forge test --hh`.
 
-If no, there is an implementation contract [here](https://github.com/gakonst/foundry/blob/master/evm-adapters/testdata/console.sol). We currently recommend that you copy this contract, place it in your `test` folder, and import it into the contract where you wish to use `console.log`, though there should be more streamlined functionality soon.
+If no, there is an implementation contract [here](https://raw.githubusercontent.com/NomicFoundation/hardhat/master/packages/hardhat-core/console.sol). We currently recommend that you copy this contract, place it in your `test` folder, and import it into the contract where you wish to use `console.log`, though there should be more streamlined functionality soon.
 
 Usage follows the same format as [Hardhat](https://hardhat.org/hardhat-network/reference/#console-log):
 ```solidity


### PR DESCRIPTION
Switch to revm removed foundry's copy of console.log. This updates the readme to point to Hardhat's copy.
