### PR TITLE
fix(evm): backend shutdown sequence

### DIFF
--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -24,6 +24,8 @@ pub use revm::SpecId;
 /// Executor database trait
 pub use revm::db::DatabaseRef;
 
+pub use revm::Env;
+
 use self::inspector::{InspectorData, InspectorStackConfig};
 use crate::{debug::DebugArena, trace::CallTraceArena, CALLER};
 use bytes::Bytes;
@@ -36,7 +38,7 @@ use foundry_utils::IntoFunction;
 use hashbrown::HashMap;
 use revm::{
     db::{CacheDB, DatabaseCommit, EmptyDB},
-    return_ok, Account, BlockEnv, CreateScheme, Env, Return, TransactOut, TransactTo, TxEnv, EVM,
+    return_ok, Account, BlockEnv, CreateScheme, Return, TransactOut, TransactTo, TxEnv, EVM,
 };
 use std::collections::BTreeMap;
 
@@ -161,7 +163,7 @@ pub struct Executor<DB: DatabaseRef> {
     // Also, if we stored the VM here we would still need to
     // take `&mut self` when we are not committing to the database, since
     // we need to set `evm.env`.
-    pub(crate) db: CacheDB<DB>,
+    pub db: CacheDB<DB>,
     env: Env,
     inspector_config: InspectorStackConfig,
     /// The gas limit for calls and deployments. This is different from the gas limit imposed by

--- a/evm/src/executor/opts.rs
+++ b/evm/src/executor/opts.rs
@@ -2,7 +2,6 @@ use ethers::{
     providers::{Middleware, Provider},
     types::{Address, U256},
 };
-use foundry_utils::RuntimeOrHandle;
 use revm::{BlockEnv, CfgEnv, SpecId, TxEnv};
 use serde::{Deserialize, Serialize};
 
@@ -37,18 +36,13 @@ pub struct EvmOpts {
 }
 
 impl EvmOpts {
-    pub fn evm_env(&self) -> revm::Env {
+    pub async fn evm_env(&self) -> revm::Env {
         if let Some(ref fork_url) = self.fork_url {
-            let rt = RuntimeOrHandle::new();
             let provider =
                 Provider::try_from(fork_url.as_str()).expect("could not instantiated provider");
-            let fut =
-                environment(&provider, self.env.chain_id, self.fork_block_number, self.sender);
-            match rt {
-                RuntimeOrHandle::Runtime(runtime) => runtime.block_on(fut),
-                RuntimeOrHandle::Handle(handle) => handle.block_on(fut),
-            }
-            .expect("could not instantiate forked environment")
+            environment(&provider, self.env.chain_id, self.fork_block_number, self.sender)
+                .await
+                .expect("could not instantiate forked environment")
         } else {
             revm::Env {
                 block: BlockEnv {

--- a/forge/src/lib.rs
+++ b/forge/src/lib.rs
@@ -35,6 +35,7 @@ pub mod test_helpers {
         fuzz::FuzzedExecutor,
         CALLER,
     };
+    use foundry_utils::RuntimeOrHandle;
     use std::str::FromStr;
 
     pub static PROJECT: Lazy<Project> = Lazy::new(|| {
@@ -62,10 +63,8 @@ pub mod test_helpers {
     });
 
     pub fn test_executor() -> Executor<Backend> {
-        ExecutorBuilder::new()
-            .with_cheatcodes(false)
-            .with_config((*EVM_OPTS).evm_env())
-            .build(Backend::simple())
+        let env = RuntimeOrHandle::new().block_on((*EVM_OPTS).evm_env());
+        ExecutorBuilder::new().with_cheatcodes(false).with_config(env).build(Backend::simple())
     }
 
     pub fn fuzz_executor<DB: DatabaseRef>(executor: &Executor<DB>) -> FuzzedExecutor<DB> {

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -9,7 +9,7 @@ use eyre::Result;
 use foundry_evm::executor::{
     builder::Backend, opts::EvmOpts, DatabaseRef, Executor, ExecutorBuilder, Fork, SpecId,
 };
-use foundry_utils::PostLinkInput;
+use foundry_utils::{PostLinkInput, RuntimeOrHandle};
 use proptest::test_runner::TestRunner;
 use rayon::prelude::*;
 use std::{collections::BTreeMap, marker::Sync, path::Path, sync::mpsc::Sender};
@@ -191,10 +191,11 @@ impl MultiContractRunner {
         stream_result: Option<Sender<(String, SuiteResult)>>,
         include_fuzz_tests: bool,
     ) -> Result<BTreeMap<String, SuiteResult>> {
-        let env = self.evm_opts.evm_env();
+        let runtime = RuntimeOrHandle::new();
+        let env = runtime.block_on(self.evm_opts.evm_env());
 
         // the db backend that serves all the data
-        let db = Backend::new(self.fork.take(), &env);
+        let db = runtime.block_on(Backend::new(self.fork.take(), &env));
 
         let results = self
             .contracts


### PR DESCRIPTION
@mattsse could you please test this?

at least with central tokio runtime inited in main (my setup), it's no problem to rely on BackendHandler::drop.
if it is necessary to distinguish between "all work finished" vs RapidUnscheduledDisassembly, we can set a flag in `poll`.