### PR TITLE
fix: cheatcode depth fixes

### DIFF
--- a/evm/src/executor/inspector/cheatcodes/expect.rs
+++ b/evm/src/executor/inspector/cheatcodes/expect.rs
@@ -169,7 +169,7 @@ pub fn apply<DB: Database>(
         }
         HEVMCalls::ExpectEmit(inner) => {
             state.expected_emits.push(ExpectedEmit {
-                depth: data.subroutine.depth(),
+                depth: data.subroutine.depth() - 1,
                 checks: [inner.0, inner.1, inner.2, inner.3],
                 ..Default::default()
             });

--- a/evm/src/executor/inspector/cheatcodes/mod.rs
+++ b/evm/src/executor/inspector/cheatcodes/mod.rs
@@ -219,7 +219,9 @@ where
 
         // Clean up pranks
         if let Some(prank) = &self.prank {
-            data.env.tx.caller = prank.prank_origin;
+            if data.subroutine.depth() == prank.depth {
+                data.env.tx.caller = prank.prank_origin;
+            }
             if prank.single_call {
                 std::mem::take(&mut self.prank);
             }
@@ -322,7 +324,9 @@ where
     ) -> (Return, Option<Address>, Gas, Bytes) {
         // Clean up pranks
         if let Some(prank) = &self.prank {
-            data.env.tx.caller = prank.prank_origin;
+            if data.subroutine.depth() == prank.depth {
+                data.env.tx.caller = prank.prank_origin;
+            }
             if prank.single_call {
                 std::mem::take(&mut self.prank);
             }

--- a/testdata/cheats/ExpectEmit.t.sol
+++ b/testdata/cheats/ExpectEmit.t.sol
@@ -51,6 +51,9 @@ contract Emitter {
         inner.emitEvent(topic1, topic2, topic3, data);
     }
 
+    /// Ref: issue #1214
+    function doesNothing() public pure {}
+
     /// Ref: issue #760
     function emitSomethingElse(uint256 data) public {
         emit SomethingElse(data);
@@ -227,5 +230,23 @@ contract ExpectEmitTest is DSTest {
         // and in the `Emitter` contract have differing
         // amounts of indexed topics.
         emitter.emitSomethingElse(1);
+    }
+
+    /// This test will fail if we check that all expected logs were emitted
+    /// after every call from the same depth as the call that invoked the cheatcode.
+    ///
+    /// Expected emits should only be checked when the call from which the cheatcode
+    /// was invoked ends.
+    ///
+    /// Ref: issue #1214
+    function testExpectEmitIsCheckedWhenCurrentCallTerminates() public {
+        cheats.expectEmit(true, true, true, true);
+        emitter.doesNothing();
+        emit Something(1, 2, 3, 4);
+
+        // This should fail since `SomethingElse` in the test
+        // and in the `Emitter` contract have differing
+        // amounts of indexed topics.
+        emitter.emitEvent(1, 2, 3, 4);
     }
 }

--- a/testdata/cheats/Prank.t.sol
+++ b/testdata/cheats/Prank.t.sol
@@ -304,4 +304,23 @@ contract PrankTest is DSTest {
 
         pranker.completePrank(victim);
     }
+
+    /// Checks that `tx.origin` is set for all subcalls of a `prank`.
+    ///
+    /// Ref: issue #1210
+    function testTxOriginInNestedPrank(address sender, address origin) public {
+        address oldSender = msg.sender;
+        address oldOrigin = tx.origin;
+
+        Victim innerVictim = new Victim();
+        NestedVictim victim = new NestedVictim(innerVictim);
+
+        cheats.prank(sender, origin);
+        victim.assertCallerAndOrigin(
+            sender,
+            "msg.sender was not set correctly",
+            origin,
+            "tx.origin was not set correctly"
+        );
+    }
 }


### PR DESCRIPTION
### Reasoning about depth

- `call` is called *before* the depth is increased. This effectively means that `depth` in `call` is the depth of the *current* call, and `depth + 1` is the depth of the call we are *about to execute*.
- `call_end` is called *after* the depth is decreased. This effectively means that `depth + 1` is the depth of the call that *just finished executing*

Implications:

- If `depth == 0`, then the *root call* (depth 1 during execution, but depth 0 in `call`/`call_end`) is terminating
- `depth + 1` represents the depth of the *call that is about to execute* in `call`, and the depth of the call that just finished executing in `call_end`
- `depth - 1` represents the depth at which the *current call will terminate* in `call` and `call_end`
- The call that is about to execute will terminate at `depth`
- `depth` in calls to cheatcodes represent the depth of the *current call*, not the depth of the call to the cheatcode.

Illustrated, if you have:

```solidity
function testSomething() {
  vm.expectRevert();
  somewhere.something();
}
```

Then:

- Inspectors' `call` methods are invoked with `depth == 0` when we first call `testSomething`
- Inspectors' `call` methods are invoked with `depth == 1` when we call the cheatcode
- Inspectors' `call_end` methods are invoked with `depth == 1` when the call to the cheatcode has finished
- Inspectors' `call` methods are invoked with `depth == 1` when we call `somewhere.something()`
- Inspectors' `call_end` methods are invoked with `depth == 1` when the `somewhere.something()` call has finished
- Inspectors' `call_end` methods are invoked with `depth == 0` when the `testSomething` call has finished

### `expectEmit` bug (https://github.com/gakonst/foundry/issues/1214)

This means that if we do:

```solidity
function testSomeEmit() {
  vm.expectEmit(..);
  emit Something(somewhere.someValue());
  emitter.emit();
}
```

Then:

- Inspectors' `call` methods are invoked with `depth == 0` when we first call `testSomeEmit`
- Inspectors' `call` methods are invoked with `depth == 1` when we call the cheatcode
  - We then push an expected emit at `depth == 1`
- Inspectors' `call_end` methods are invoked with `depth == 1` when the call to the cheatcode has finished
  - The expected emit is ignored by the `call_end` handler since we just exited a cheatcode call
- Inspectors' `call` methods are invoked with `depth == 1` when we call `somewhere.someValue()`
- Inspectors' `call_end` methods are invoked with `depth == 1` when the `somewhere.someValue()` call has finished
  - The expected emit is checked, and we revert, even when we should not.

In fact we should test for the expected emit at `depth - 1`. In other words, when the call from which the cheatcode was invoked ends.

### `tx.origin` bug (https://github.com/gakonst/foundry/issues/1210)

Whenever `call` is invoked, we check if the depth is greater than or equal to the depth at which the cheatcode was invoked. If it is, then we check:

- If `depth` is **exactly** the depth at which the cheatcode was invoked, then we set `msg.sender`. This is sound because we only want to prank the first `msg.sender`, not the nested ones in case of nesting. If the depth is greater than or equal to the depth at which the cheatcode was invoked, we set `tx.origin`, which is sound, because we want this to persist even in the case of nesting.

Whenever `call_end` is invoked, we check if we have an ongoing prank. If we do, then we check if the prank is for one call only. If it is, then we erase the prank from memory, so we don't set `msg.sender` in subsequent calls. This is sound. However, we *always* reset `tx.origin` to the original value, regardless of the depth of the call that is terminating. This is sound when we use `startPrank`, since it will just continually reapply `tx.origin`, but for `prank` this is unsound. We should only do that when we are back at the depth at which the prank was started.

Closes #1214 
Closes #1210 