### PR TITLE
fix: enable `ETH_RPC_URL`

### DIFF
--- a/cli/src/opts/evm.rs
+++ b/cli/src/opts/evm.rs
@@ -118,6 +118,10 @@ impl Provider for EvmArgs {
             dict.insert("no_storage_caching".to_string(), self.no_storage_caching.into());
         }
 
+        if let Some(fork_url) = &self.fork_url {
+            dict.insert("eth_rpc_url".to_string(), fork_url.clone().into());
+        }
+
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }

--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -170,8 +170,10 @@ macro_rules! forgetest_external {
             ]);
             cmd.set_env("FOUNDRY_FUZZ_RUNS", "1");
             if $fork_block > 0 {
-                cmd.set_env("FOUNDRY_ETH_RPC_URL", std::env::var("ETH_RPC_URL").unwrap());
                 cmd.set_env("FOUNDRY_FORK_BLOCK_NUMBER", stringify!($fork_block));
+            } else {
+                // Clear out `ETH_RPC_URL` so non-forking tests do not end up forking anyway
+                cmd.temp_unset_env("ETH_RPC_URL");
             }
             cmd.assert_non_empty_stdout();
         }

--- a/cli/test-utils/src/macros.rs
+++ b/cli/test-utils/src/macros.rs
@@ -173,7 +173,7 @@ macro_rules! forgetest_external {
                 cmd.set_env("FOUNDRY_FORK_BLOCK_NUMBER", stringify!($fork_block));
             } else {
                 // Clear out `ETH_RPC_URL` so non-forking tests do not end up forking anyway
-                cmd.temp_unset_env("ETH_RPC_URL");
+                cmd.unset_env("ETH_RPC_URL");
             }
             cmd.assert_non_empty_stdout();
         }

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -368,6 +368,17 @@ impl TestCommand {
         std::env::set_var(key, v.to_string());
     }
 
+    /// Unsets the environment variable `k`. The variable will be re-added
+    /// when the command is dropped.
+    pub fn temp_unset_env(&mut self, k: impl AsRef<str>) {
+        let key = k.as_ref();
+        if !self.saved_env_vars.contains_key(OsStr::new(key)) {
+            self.saved_env_vars.insert(key.into(), std::env::var_os(key));
+        }
+
+        std::env::remove_var(key);
+    }
+
     /// Unsets the environment variable `k`
     pub fn unset_env(&mut self, k: impl AsRef<str>) {
         let key = k.as_ref();

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -7,9 +7,8 @@ use foundry_config::Config;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use std::{
-    collections::HashMap,
     env,
-    ffi::{OsStr, OsString},
+    ffi::{OsStr},
     fmt::Display,
     fs,
     fs::File,
@@ -205,7 +204,6 @@ impl TestProject {
         TestCommand {
             project: self.clone(),
             cmd,
-            saved_env_vars: HashMap::new(),
             current_dir_lock: None,
             saved_cwd: pretty_err("<current dir>", std::env::current_dir()),
         }
@@ -219,7 +217,6 @@ impl TestProject {
         TestCommand {
             project: self.clone(),
             cmd,
-            saved_env_vars: HashMap::new(),
             current_dir_lock: None,
             saved_cwd: pretty_err("<current dir>", std::env::current_dir()),
         }
@@ -260,12 +257,6 @@ impl TestProject {
 
 impl Drop for TestCommand {
     fn drop(&mut self) {
-        for (key, value) in self.saved_env_vars.iter() {
-            match value {
-                Some(val) => std::env::set_var(key, val),
-                None => std::env::remove_var(key),
-            }
-        }
         let _lock = self.current_dir_lock.take().unwrap_or_else(|| CURRENT_DIR_LOCK.lock());
         let _ = std::env::set_current_dir(&self.saved_cwd);
     }
@@ -301,7 +292,6 @@ pub struct TestCommand {
     project: TestProject,
     /// The actual command we use to control the process.
     cmd: Command,
-    saved_env_vars: HashMap<OsString, Option<OsString>>,
     current_dir_lock: Option<parking_lot::lock_api::MutexGuard<'static, parking_lot::RawMutex, ()>>,
 }
 
@@ -357,33 +347,14 @@ impl TestCommand {
         self.arg("--root").arg(root)
     }
 
-    /// Set the environment variable `k` to value `v`. The variable will be
-    /// removed when the command is dropped.
-    pub fn set_env(&mut self, k: impl AsRef<str>, v: impl Display) {
-        let key = k.as_ref();
-        if !self.saved_env_vars.contains_key(OsStr::new(key)) {
-            self.saved_env_vars.insert(key.into(), std::env::var_os(key));
-        }
-
-        std::env::set_var(key, v.to_string());
+    /// Set the environment variable `k` to value `v` for the command.
+    pub fn set_env(&mut self, k: impl AsRef<OsStr>, v: impl Display) {
+        self.cmd.env(k, v.to_string());
     }
 
-    /// Unsets the environment variable `k`. The variable will be re-added
-    /// when the command is dropped.
-    pub fn temp_unset_env(&mut self, k: impl AsRef<str>) {
-        let key = k.as_ref();
-        if !self.saved_env_vars.contains_key(OsStr::new(key)) {
-            self.saved_env_vars.insert(key.into(), std::env::var_os(key));
-        }
-
-        std::env::remove_var(key);
-    }
-
-    /// Unsets the environment variable `k`
-    pub fn unset_env(&mut self, k: impl AsRef<str>) {
-        let key = k.as_ref();
-        let _ = self.saved_env_vars.remove(OsStr::new(key));
-        std::env::remove_var(key);
+    /// Unsets the environment variable `k` for the command.
+    pub fn unset_env(&mut self, k: impl AsRef<OsStr>) {
+        self.cmd.env_remove(k);
     }
 
     /// Set the working directory for this command.

--- a/cli/test-utils/src/util.rs
+++ b/cli/test-utils/src/util.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use std::{
     env,
-    ffi::{OsStr},
+    ffi::OsStr,
     fmt::Display,
     fs,
     fs::File,
@@ -369,7 +369,7 @@ impl TestCommand {
 
     /// Returns the `Config` as spit out by `forge config`
     pub fn config(&mut self) -> Config {
-        self.forge_fuse().args(["config", "--json"]);
+        self.cmd.args(["config", "--json"]);
         let output = self.output();
         let c = String::from_utf8_lossy(&output.stdout);
         let config = serde_json::from_str(c.as_ref()).unwrap();

--- a/cli/tests/it/config.rs
+++ b/cli/tests/it/config.rs
@@ -136,7 +136,7 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
     );
 
     // env vars work
-    cmd.set_env("DAPP_REMAPPINGS", "ds-test/=lib/ds-test/from-env/");
+    std::env::set_var("DAPP_REMAPPINGS", "ds-test/=lib/ds-test/from-env/");
     let config = forge_utils::load_config();
     assert_eq!(
         format!("ds-test/={}/", prj.root().join("lib/ds-test/from-env").display()),
@@ -156,7 +156,7 @@ forgetest_init!(can_override_config, |prj: TestProject, mut cmd: TestCommand| {
         Remapping::from(config.remappings[1].clone()).to_string()
     );
 
-    cmd.unset_env("DAPP_REMAPPINGS");
+    std::env::remove_var("DAPP_REMAPPINGS");
     pretty_err(&remappings_txt, fs::remove_file(&remappings_txt));
 
     cmd.set_cmd(prj.forge_bin()).args(["config", "--basic"]);
@@ -192,7 +192,7 @@ forgetest_init!(can_get_evm_opts, |prj: TestProject, mut cmd: TestCommand| {
     assert_eq!(config.eth_rpc_url, Some(url.to_string()));
     assert!(config.ffi);
 
-    cmd.set_env("FOUNDRY_ETH_RPC_URL", url);
+    std::env::set_var("FOUNDRY_ETH_RPC_URL", url);
     let figment = Config::figment_with_root(prj.root()).merge(("debug", false));
     let evm_opts: EvmOpts = figment.extract().unwrap();
     assert_eq!(evm_opts.fork_url, Some(url.to_string()));

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -808,7 +808,7 @@ impl From<Config> for Figment {
             .merge(Env::prefixed("DAPP_").ignore(&["REMAPPINGS", "LIBRARIES"]).global())
             .merge(Env::prefixed("DAPP_TEST_").global())
             .merge(DappEnvCompatProvider)
-            .merge(Env::raw().only(&["ETHERSCAN_API_KEY"]))
+            .merge(Env::raw().only(&["ETH_RPC_URL", "ETHERSCAN_API_KEY"]))
             .merge(
                 Env::prefixed("FOUNDRY_").ignore(&["PROFILE", "REMAPPINGS", "LIBRARIES"]).global(),
             )


### PR DESCRIPTION
Adds support for `ETH_RPC_URL` in place of `--fork-url`, but does not break integration tests this time