### PR TITLE
feat(forge): Add support for multiple files verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs#15305eb6f5c361d95614fd9c5b3d90c2e7d31425"
+source = "git+https://github.com/gakonst/ethers-rs#247f08f1a929cacad89f01dfab5900cc58627806"
 dependencies = [
  "colored",
  "dunce",

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -35,6 +35,12 @@ pub struct VerifyArgs {
     #[clap(help = "your etherscan api key", env = "ETHERSCAN_API_KEY")]
     etherscan_key: String,
 
+    #[clap(
+        help = "flatten the source code. Make sure to use bytecodehash='ipfs'",
+        long = "flatten"
+    )]
+    flatten: bool,
+
     #[clap(flatten)]
     opts: CoreFlattenArgs,
 }
@@ -93,20 +99,35 @@ pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
     };
 
     let project = build_args.project()?;
-    let contract = project
-        .flatten(&project.root().join(args.contract.path.as_ref().unwrap()))
-        .map_err(|err| eyre::eyre!("Failed to flatten contract: {}", err))?;
+
+    let (source, contract_name) = if args.flatten {
+        // NOTE: user need to set bytecodehash='ipfs' for this otherwise verification won't work
+        // see: https://github.com/gakonst/foundry/issues/1236
+        (
+            project
+                .flatten(&project.root().join(args.contract.path.as_ref().unwrap()))
+                .map_err(|err| eyre::eyre!("Failed to flatten contract: {}", err))?,
+            args.contract.name.clone(),
+        )
+    } else {
+        (
+            project
+                .standard_json_input(&project.root().join(args.contract.path.as_ref().unwrap()))
+                .map_err(|err| eyre::eyre!("Failed to get standard json input: {}", err))?,
+            format!(
+                "{}:{}",
+                &project.root().join(args.contract.path.as_ref().unwrap()).to_string_lossy(),
+                args.contract.name.clone()
+            ),
+        )
+    };
 
     let etherscan = Client::new(args.chain_id.try_into()?, &args.etherscan_key)
         .map_err(|err| eyre::eyre!("Failed to create etherscan client: {}", err))?;
 
-    let mut verify_args = VerifyContract::new(
-        args.address,
-        args.contract.name.clone(),
-        contract,
-        args.compiler_version.clone(),
-    )
-    .constructor_arguments(args.constructor_args.clone());
+    let mut verify_args =
+        VerifyContract::new(args.address, contract_name, source, args.compiler_version.clone())
+            .constructor_arguments(args.constructor_args.clone());
 
     if let Some(optimizations) = args.num_of_optimizations {
         verify_args = verify_args.optimization(true).runs(optimizations);

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -110,10 +110,13 @@ pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
             args.contract.name.clone(),
         )
     } else {
+        let input = project
+            .standard_json_input(&project.root().join(args.contract.path.as_ref().unwrap()))
+            .map_err(|err| eyre::eyre!("Failed to get standard json input: {}", err))?;
+
         (
-            project
-                .standard_json_input(&project.root().join(args.contract.path.as_ref().unwrap()))
-                .map_err(|err| eyre::eyre!("Failed to get standard json input: {}", err))?,
+            serde_json::to_string(&input)
+                .map_err(|err| eyre::eyre!("Failed to parse standard json input: {}", err)),
             format!(
                 "{}:{}",
                 &project.root().join(args.contract.path.as_ref().unwrap()).to_string_lossy(),

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -116,7 +116,7 @@ pub async fn run_verify(args: &VerifyArgs) -> eyre::Result<()> {
 
         (
             serde_json::to_string(&input)
-                .map_err(|err| eyre::eyre!("Failed to parse standard json input: {}", err)),
+                .map_err(|err| eyre::eyre!("Failed to parse standard json input: {}", err))?,
             format!(
                 "{}:{}",
                 &project.root().join(args.contract.path.as_ref().unwrap()).to_string_lossy(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/gakonst/foundry/issues/1012

and this bug

https://github.com/gakonst/foundry/issues/1236


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This changes will allows `forge` to submit contract verification using `standard-input-json` by default.

It puts the file flattening behind `--flatten` flag.

Example of verified contract https://rinkeby.etherscan.io/address/0x824436cf3d2cd06de925586490aa4c0e83345276#code

--

Blocked by https://github.com/gakonst/ethers-rs/pull/1126