### PR TITLE
chore: make ipfs the default bytecodehash again

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -100,8 +100,9 @@ block_difficulty = 0
 rpc_storage_caching = { chains = "all", endpoints = "all" }
 # this overrides `rpc_storage_caching` entirely
 no_storage_caching = false
-# don't include the metadata hash, to allow for deterministic code: https://docs.soliditylang.org/en/latest/metadata.html, solc's default is "ipfs"
-bytecode_hash = "none"
+# use ipfs method to generate the metadata hash, solc's default.
+# To not include the metadata hash, to allow for deterministic code: https://docs.soliditylang.org/en/latest/metadata.html, use "none"
+bytecode_hash = "ipfs"
 # If this option is enabled, Solc is instructed to generate output (bytecode) only for the required contracts
 # this can reduce compile time for `forge test` a bit but is considered experimental at this point.
 sparse_mode = false

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -937,7 +937,7 @@ impl Default for Config {
             via_ir: false,
             rpc_storage_caching: Default::default(),
             no_storage_caching: false,
-            bytecode_hash: BytecodeHash::None,
+            bytecode_hash: BytecodeHash::Ipfs,
             sparse_mode: false,
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
while bytecode hash None ensures deterministic builds it caused issues with etherscan verify with flattened code.
Since this is no configurable, I suggest we make the default `ipfs` just like solc.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
