### PR TITLE
meta: add local profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,27 @@ members = [
     "evm"
 ]
 
+[profile.dev]
+# Disabling debug info speeds up builds a bunch,
+# and we don't rely on it for debugging that much
+debug = 0
+
+[profile.dev.package]
+# These speed up local tests
+ethers-solc.opt-level = 3
+
+# local "release" mode
+[profile.local]
+inherits = "dev"
+opt-level = 3
+# Set this to 1 or 2 to get more useful backtraces
+debug = 0
+panic = 'unwind'
+# better recompile times
+incremental = true
+codegen-units = 16
+
+
 [profile.release]
 # Optimize for binary size, but keep loop vectorization
 opt-level = "s"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Compiling with release mode is absolutely abysmal because of size optimization, code genunits 1 etc., which makes testing locally with release conditions a bit tedious.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This adds another profile `local` that's more close to the default rust release profile but also allows incremental builds.
this is ~35% faster than release while also being opt.3

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
