### PR TITLE
feat(forge): json output option for forge create

### DIFF
--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -74,13 +74,12 @@ impl Cmd for CreateArgs {
     fn run(self) -> Result<Self::Output> {
         // Find Project & Compile
         let project = self.opts.project()?;
-        let compiled;
-        if self.json {
-            // Supress compilation stdout messages if outputting json
-            compiled = compile::suppress_compile(&project)?;
+        let compiled = if self.json {
+            // Supress compile stdout messages when printing json output
+            compile::suppress_compile(&project)?
         } else {
-            compiled = compile::compile(&project, self.opts.names, self.opts.sizes)?;
-        }
+            compile::compile(&project, self.opts.names, self.opts.sizes)?
+        };
 
         // Get ABI and BIN
         let (abi, bin, _) =
@@ -195,7 +194,7 @@ impl CreateArgs {
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;
         if self.json {
             let output = json!({"deployer": deployer_address, "deployedTo": deployed_contract.address(), "transactionHash": receipt.transaction_hash});
-            println!("{}", output.to_string());
+            println!("{}", output);
         } else {
             println!("Deployer: {:?}", deployer_address);
             println!("Deployed to: {:?}", deployed_contract.address());

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -18,8 +18,7 @@ use std::fs;
 use crate::{compile, opts::forge::ContractInfo};
 use clap::{Parser, ValueHint};
 use std::{path::PathBuf, sync::Arc};
-
-use serde_json;
+use serde_json::{json, to_string};
 
 #[derive(Debug, Clone, Parser)]
 pub struct CreateArgs {
@@ -189,8 +188,8 @@ impl CreateArgs {
 
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;
         if self.json {
-            let output = serde_json::json!({"deployer": deployer_address, "deployedTo": deployed_contract.address(), "transactionHash": receipt.transaction_hash});
-            println!("{}", serde_json::to_string(&output).unwrap());
+            let output = json!({"deployer": deployer_address, "deployedTo": deployed_contract.address(), "transactionHash": receipt.transaction_hash});
+            println!("{}", to_string(&output).unwrap());
         } else {
             println!("Deployer: {:?}", deployer_address);
             println!("Deployed to: {:?}", deployed_contract.address());


### PR DESCRIPTION
[## Motivation
Addresses #1255

## Solution
Add a `--json` argument, matching the behavior for `cast` commands, to the `forge create` args.


Without `--json`
```sh
$> forge create --private-key $PRIVATE_KEY src/Contract.sol:Contract
[⠊] Compiling...
No files changed, compilation skipped
Deployer: 0x496e09fcb240c33b8fda3b4b74d81697c03b6b3d
Deployed to: 0x878354b96c2736d527ddb40bc3f4f30fc1a71b7c
Transaction hash: 0xefe1577d0b37a6403ea653e2a65f0a7d3f3b5dbf47708fbffcb4595e108a2090
```
With `--json`
```sh
$>  forge create --private-key $PRIVATE_KEY --json src/Contract.sol:Contract
{"deployedTo":"0x3836857cec81c98e105ec0309ddeb0b08e2d7b96","deployer":"0x496e09fcb240c33b8fda3b4b74d81697c03b6b3d","transactionHash":"0x8e07c35e7daf2439663f3283a5d652b9a722ba41c55f461246769aa044ac1b67"}
```

Example usage with `jq`
```sh
$> forge create --private-key $PRIVATE_KEY --json src/Contract.sol:Contract | jq '.' | cat
{
  "deployedTo": "0x7164163bbcdd75b48bdd64b29f986aec25917ddb",
  "deployer": "0x496e09fcb240c33b8fda3b4b74d81697c03b6b3d",
  "transactionHash": "0x0d8a7bf3bef2fbdece79da13dfbb1594e81e1ce61c2952baa7082fe0286e2c9c"
}
```