### PR TITLE
chore: improve output of `-h/--help`

### DIFF
--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -391,8 +391,8 @@ async fn main() -> eyre::Result<()> {
         Subcommands::AbiEncode { sig, args } => {
             println!("{}", SimpleCast::abi_encode(&sig, &args)?);
         }
-        Subcommands::Index { from_type, to_type, from_value, slot_number } => {
-            let encoded = SimpleCast::index(&from_type, &to_type, &from_value, &slot_number)?;
+        Subcommands::Index { key_type, value_type, key, slot_number } => {
+            let encoded = SimpleCast::index(&key_type, &value_type, &key, &slot_number)?;
             println!("{}", encoded);
         }
         Subcommands::FourByte { selector } => {

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -133,7 +133,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::ToUnit { value, unit } => {
             let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::to_unit(val, unit.unwrap_or_else(|| String::from("wei")))?);
+            println!("{}", SimpleCast::to_unit(val, unit));
         }
         Subcommands::ToWei { value, unit } => {
             let val = unwrap_or_stdin(value)?;

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -133,7 +133,7 @@ async fn main() -> eyre::Result<()> {
         }
         Subcommands::ToUnit { value, unit } => {
             let val = unwrap_or_stdin(value)?;
-            println!("{}", SimpleCast::to_unit(val, unit));
+            println!("{}", SimpleCast::to_unit(val, unit)?);
         }
         Subcommands::ToWei { value, unit } => {
             let val = unwrap_or_stdin(value)?;

--- a/cli/src/cast.rs
+++ b/cli/src/cast.rs
@@ -159,7 +159,7 @@ async fn main() -> eyre::Result<()> {
             let provider = Provider::try_from(eth.rpc_url()?)?;
             let mut builder = TxBuilder::new(
                 &provider,
-                eth.from.unwrap_or(Address::zero()),
+                eth.wallet.from.unwrap_or(Address::zero()),
                 address,
                 eth.chain,
                 false,
@@ -322,7 +322,7 @@ async fn main() -> eyre::Result<()> {
                         .await?;
                     }
                 }
-            } else if let Some(from) = eth.from {
+            } else if let Some(from) = eth.wallet.from {
                 if resend {
                     nonce = Some(provider.get_transaction_count(from, None).await?);
                 }
@@ -669,7 +669,6 @@ async fn main() -> eyre::Result<()> {
                 // TODO: Figure out better way to get wallet only.
                 let wallet = EthereumOpts {
                     wallet,
-                    from: None,
                     rpc_url: Some("http://localhost:8545".to_string()),
                     flashbots: false,
                     chain: Chain::Mainnet,
@@ -690,7 +689,6 @@ async fn main() -> eyre::Result<()> {
                 // TODO: Figure out better way to get wallet only.
                 let wallet = EthereumOpts {
                     wallet,
-                    from: None,
                     rpc_url: Some("http://localhost:8545".to_string()),
                     flashbots: false,
                     chain: Chain::Mainnet,

--- a/cli/src/cmd/cast/call.rs
+++ b/cli/src/cmd/cast/call.rs
@@ -49,7 +49,7 @@ impl figment::Provider for CallArgs {
             dict.insert("eth_rpc_url".to_string(), Value::from(rpc_url.to_string()));
         }
 
-        if let Some(from) = self.eth.from {
+        if let Some(from) = self.eth.wallet.from {
             dict.insert("sender".to_string(), Value::from(format!("{:?}", from)));
         }
 

--- a/cli/src/cmd/forge/bind.rs
+++ b/cli/src/cmd/forge/bind.rs
@@ -40,7 +40,7 @@ pub struct BindArgs {
 
     #[clap(
         long = "crate-name",
-        help = "The name of the rust crate to generate. This should be a valid crates.io crate name. However, it is not currently validated by this command.",
+        help = "The name of the Rust crate to generate. This should be a valid crates.io crate name. However, it is not currently validated by this command.",
         default_value = DEFAULT_CRATE_NAME,
     )]
     #[serde(skip)]
@@ -48,7 +48,7 @@ pub struct BindArgs {
 
     #[clap(
         long = "crate-version",
-        help = "The version of the rust crate to generate. This should be a standard semver version string. However, it is not currently validated by this command.",
+        help = "The version of the Rust crate to generate. This should be a standard semver version string. However, it is not currently validated by this command.",
         default_value = DEFAULT_CRATE_VERSION,
     )]
     #[serde(skip)]
@@ -59,7 +59,7 @@ pub struct BindArgs {
 
     #[clap(
         long = "overwrite",
-        help = "Overwrite existing generated bindings. If set to false, the command will check that the bindings are correct, and then exit. If set to true, it will instead delete and overwrite the bindings."
+        help = "Overwrite existing generated bindings. By default, the command will check that the bindings are correct, and then exit. If --overwrite is passed, it will instead delete and overwrite the bindings."
     )]
     #[serde(skip)]
     overwrite: bool,

--- a/cli/src/cmd/forge/build.rs
+++ b/cli/src/cmd/forge/build.rs
@@ -63,11 +63,20 @@ impl<'a> From<&'a CoreBuildArgs> for Config {
 
 #[derive(Debug, Clone, Parser, Serialize)]
 pub struct CoreBuildArgs {
-    #[clap(help = "Clear the cache and artifacts folder and recompile.", long)]
+    #[clap(
+        help_heading = "CACHE OPTIONS",
+        help = "Clear the cache and artifacts folder and recompile.",
+        long
+    )]
     #[serde(skip)]
     pub force: bool,
 
-    #[clap(help = "Set pre-linked libraries.", long, env = "DAPP_LIBRARIES")]
+    #[clap(
+        help_heading = "LINKER OPTIONS",
+        help = "Set pre-linked libraries.",
+        long,
+        env = "DAPP_LIBRARIES"
+    )]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub libraries: Vec<String>,
 

--- a/cli/src/cmd/forge/build.rs
+++ b/cli/src/cmd/forge/build.rs
@@ -83,14 +83,6 @@ impl<'a> From<&'a BuildArgs> for Config {
 // `figment::Provider` implementation
 #[derive(Debug, Clone, Parser, Serialize)]
 pub struct BuildArgs {
-    #[clap(flatten)]
-    #[serde(flatten)]
-    pub project_paths: ProjectPathsArgs,
-
-    #[clap(flatten)]
-    #[serde(flatten)]
-    pub compiler: CompilerArgs,
-
     #[clap(help = "print compiled contract names", long = "names")]
     #[serde(skip)]
     pub names: bool,
@@ -137,10 +129,6 @@ pub struct BuildArgs {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub libraries: Vec<String>,
 
-    #[clap(flatten)]
-    #[serde(skip)]
-    pub watch: WatchArgs,
-
     #[clap(
         help = "if set to true, changes compilation pipeline to go through the Yul intermediate representation.",
         long
@@ -155,6 +143,27 @@ pub struct BuildArgs {
     )]
     #[serde(skip)]
     pub config_path: Option<PathBuf>,
+
+    #[clap(flatten, next_help_heading = "COMPILER OPTIONS")]
+    #[serde(flatten)]
+    pub compiler: CompilerArgs,
+
+    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    #[serde(flatten)]
+    pub project_paths: ProjectPathsArgs,
+
+    #[clap(
+        help = "The path to the contract artifacts folder.",
+        long = "out",
+        short,
+        value_hint = ValueHint::DirPath
+    )]
+    #[serde(rename = "out", skip_serializing_if = "Option::is_none")]
+    pub out_path: Option<PathBuf>,
+
+    #[clap(flatten, next_help_heading = "WATCH OPTIONS")]
+    #[serde(skip)]
+    pub watch: WatchArgs,
 }
 
 impl Cmd for BuildArgs {
@@ -296,15 +305,6 @@ pub struct ProjectPathsArgs {
     )]
     #[serde(rename = "libs", skip_serializing_if = "Vec::is_empty")]
     pub lib_paths: Vec<PathBuf>,
-
-    #[clap(
-        help = "The path to the contract artifacts folder.",
-        long = "out",
-        short,
-        value_hint = ValueHint::DirPath
-    )]
-    #[serde(rename = "out", skip_serializing_if = "Option::is_none")]
-    pub out_path: Option<PathBuf>,
 
     #[clap(
         help = "Use the Hardhat-style project layout.",

--- a/cli/src/cmd/forge/build.rs
+++ b/cli/src/cmd/forge/build.rs
@@ -23,8 +23,8 @@ use serde::Serialize;
 use watchexec::config::{InitConfig, RuntimeConfig};
 
 // Loads project's figment and merges the build cli arguments into it
-impl<'a> From<&'a BuildArgs> for Figment {
-    fn from(args: &'a BuildArgs) -> Self {
+impl<'a> From<&'a CoreBuildArgs> for Figment {
+    fn from(args: &'a CoreBuildArgs) -> Self {
         let figment = if let Some(ref config_path) = args.config_path {
             if !config_path.exists() {
                 panic!("error: config-path `{}` does not exist", config_path.display())
@@ -48,8 +48,8 @@ impl<'a> From<&'a BuildArgs> for Figment {
     }
 }
 
-impl<'a> From<&'a BuildArgs> for Config {
-    fn from(args: &'a BuildArgs) -> Self {
+impl<'a> From<&'a CoreBuildArgs> for Config {
+    fn from(args: &'a CoreBuildArgs) -> Self {
         let figment: Figment = args.into();
         let mut config = Config::from_provider(figment).sanitized();
         // if `--config-path` is set we need to adjust the config's root path to the actual root
@@ -58,6 +58,145 @@ impl<'a> From<&'a BuildArgs> for Config {
             config.__root = args.project_paths.project_root().into();
         }
         config
+    }
+}
+
+#[derive(Debug, Clone, Parser, Serialize)]
+pub struct CoreBuildArgs {
+    #[clap(help = "Clear the cache and artifacts folder and recompile.", long)]
+    #[serde(skip)]
+    pub force: bool,
+
+    #[clap(help = "Set pre-linked libraries.", long, env = "DAPP_LIBRARIES")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub libraries: Vec<String>,
+
+    #[clap(flatten, next_help_heading = "COMPILER OPTIONS")]
+    #[serde(flatten)]
+    pub compiler: CompilerArgs,
+
+    #[clap(help_heading = "COMPILER OPTIONS", help = "Ignore solc warnings by error code.", long)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ignored_error_codes: Vec<u64>,
+
+    #[clap(help_heading = "COMPILER OPTIONS", help = "Do not auto-detect solc.", long)]
+    #[serde(skip)]
+    pub no_auto_detect: bool,
+
+    #[clap(
+        help_heading = "COMPILER OPTIONS",
+        help = "specify the solc version or path to a local solc to run with.\
+        This accepts values of the form `x.y.z`, `solc:x.y.z` or `path/to/existing/solc`",
+        value_name = "use",
+        long = "use"
+    )]
+    #[serde(skip)]
+    pub use_solc: Option<String>,
+
+    #[clap(
+        help_heading = "COMPILER OPTIONS",
+        help = "Do not access the network.",
+        long_help = "Do not access the network. Missing solc versions will not be installed.",
+        long
+    )]
+    #[serde(skip)]
+    pub offline: bool,
+
+    #[clap(
+        help_heading = "COMPILER OPTIONS",
+        help = "Use the Yul intermediate representation compilation pipeline.",
+        long
+    )]
+    #[serde(skip)]
+    pub via_ir: bool,
+
+    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    #[serde(flatten)]
+    pub project_paths: ProjectPathsArgs,
+
+    #[clap(
+        help_heading = "PROJECT OPTIONS",
+        help = "The path to the contract artifacts folder.",
+        long = "out",
+        short,
+        value_hint = ValueHint::DirPath
+    )]
+    #[serde(rename = "out", skip_serializing_if = "Option::is_none")]
+    pub out_path: Option<PathBuf>,
+
+    #[clap(
+        help_heading = "PROJECT OPTIONS",
+        help = "Path to the config file.",
+        long = "config-path",
+        value_hint = ValueHint::FilePath
+    )]
+    #[serde(skip)]
+    pub config_path: Option<PathBuf>,
+}
+
+impl CoreBuildArgs {
+    /// Returns the `Project` for the current workspace
+    ///
+    /// This loads the `foundry_config::Config` for the current workspace (see
+    /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
+    /// [`foundry_config::Config::project()`]
+    pub fn project(&self) -> eyre::Result<Project> {
+        let config: Config = self.into();
+        Ok(config.project()?)
+    }
+
+    /// Returns the remappings to add to the config
+    #[deprecated(note = "Use ProjectPathsArgs::get_remappings() instead")]
+    pub fn get_remappings(&self) -> Vec<Remapping> {
+        self.project_paths.get_remappings()
+    }
+}
+
+impl Provider for CoreBuildArgs {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("Core Build Args Provider")
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
+        let value = Value::serialize(self)?;
+        let error = InvalidType(value.to_actual(), "map".into());
+        let mut dict = value.into_dict().ok_or(error)?;
+
+        if self.no_auto_detect {
+            dict.insert("auto_detect_solc".to_string(), false.into());
+        }
+
+        if let Some(ref solc) = self.use_solc {
+            dict.insert("solc".to_string(), solc.trim_start_matches("solc:").into());
+        }
+
+        if self.offline {
+            dict.insert("offline".to_string(), true.into());
+        }
+
+        if self.via_ir {
+            dict.insert("via_ir".to_string(), true.into());
+        }
+
+        if self.force {
+            dict.insert("force".to_string(), self.force.into());
+        }
+
+        if self.compiler.optimize {
+            dict.insert("optimizer".to_string(), self.compiler.optimize.into());
+        }
+
+        if let Some(ref extra) = self.compiler.extra_output {
+            let selection: Vec<_> = extra.iter().map(|s| s.to_string()).collect();
+            dict.insert("extra_output".to_string(), selection.into());
+        }
+
+        if let Some(ref extra) = self.compiler.extra_output_files {
+            let selection: Vec<_> = extra.iter().map(|s| s.to_string()).collect();
+            dict.insert("extra_output_files".to_string(), selection.into());
+        }
+
+        Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }
 
@@ -83,83 +222,17 @@ impl<'a> From<&'a BuildArgs> for Config {
 // `figment::Provider` implementation
 #[derive(Debug, Clone, Parser, Serialize)]
 pub struct BuildArgs {
-    #[clap(help = "print compiled contract names", long = "names")]
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub args: CoreBuildArgs,
+
+    #[clap(help = "Print compiled contract names.", long = "names")]
     #[serde(skip)]
     pub names: bool,
 
-    #[clap(help = "print compiled contract sizes", long = "sizes")]
+    #[clap(help = "Print compiled contract sizes.", long = "sizes")]
     #[serde(skip)]
     pub sizes: bool,
-
-    #[clap(help = "ignore warnings with specific error codes", long)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub ignored_error_codes: Vec<u64>,
-
-    #[clap(
-        help = "if set to true, skips auto-detecting solc and uses what is in the user's $PATH ",
-        long
-    )]
-    #[serde(skip)]
-    pub no_auto_detect: bool,
-
-    #[clap(
-        help = "specify the solc version or path to a local solc to run with.\
-        This accepts values of the form `x.y.z`, `solc:x.y.z` or `path/to/existing/solc`",
-        value_name = "use",
-        long = "use"
-    )]
-    #[serde(skip)]
-    pub use_solc: Option<String>,
-
-    #[clap(
-        help = "if set to true, runs without accessing the network (missing solc versions will not be installed)",
-        long
-    )]
-    #[serde(skip)]
-    pub offline: bool,
-
-    #[clap(
-        help = "force recompilation of the project, deletes the cache and artifacts folders",
-        long
-    )]
-    #[serde(skip)]
-    pub force: bool,
-
-    #[clap(help = "add linked libraries", long, env = "DAPP_LIBRARIES")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub libraries: Vec<String>,
-
-    #[clap(
-        help = "if set to true, changes compilation pipeline to go through the Yul intermediate representation.",
-        long
-    )]
-    #[serde(skip)]
-    pub via_ir: bool,
-
-    #[clap(
-        help = "path to the foundry.toml",
-        long = "config-path",
-        value_hint = ValueHint::FilePath
-    )]
-    #[serde(skip)]
-    pub config_path: Option<PathBuf>,
-
-    #[clap(flatten, next_help_heading = "COMPILER OPTIONS")]
-    #[serde(flatten)]
-    pub compiler: CompilerArgs,
-
-    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
-    #[serde(flatten)]
-    pub project_paths: ProjectPathsArgs,
-
-    #[clap(
-        help = "The path to the contract artifacts folder.",
-        long = "out",
-        short,
-        value_hint = ValueHint::DirPath
-    )]
-    #[serde(rename = "out", skip_serializing_if = "Option::is_none")]
-    pub out_path: Option<PathBuf>,
 
     #[clap(flatten, next_help_heading = "WATCH OPTIONS")]
     #[serde(skip)]
@@ -181,8 +254,7 @@ impl BuildArgs {
     /// [`utils::find_project_root_path`] and merges the cli `BuildArgs` into it before returning
     /// [`foundry_config::Config::project()`]
     pub fn project(&self) -> eyre::Result<Project> {
-        let config: Config = self.into();
-        Ok(config.project()?)
+        self.args.project()
     }
 
     /// Returns whether `BuildArgs` was configured with `--watch`
@@ -195,12 +267,6 @@ impl BuildArgs {
     pub(crate) fn watchexec_config(&self) -> eyre::Result<(InitConfig, RuntimeConfig)> {
         // use the path arguments or if none where provided the `src` dir
         self.watch.watchexec_config(|| Config::from(self).src)
-    }
-
-    /// Returns the remappings to add to the config
-    #[deprecated(note = "Use ProjectPathsArgs::get_remappings() instead")]
-    pub fn get_remappings(&self) -> Vec<Remapping> {
-        self.project_paths.get_remappings()
     }
 }
 
@@ -215,22 +281,6 @@ impl Provider for BuildArgs {
         let error = InvalidType(value.to_actual(), "map".into());
         let mut dict = value.into_dict().ok_or(error)?;
 
-        if self.no_auto_detect {
-            dict.insert("auto_detect_solc".to_string(), false.into());
-        }
-
-        if let Some(ref solc) = self.use_solc {
-            dict.insert("solc".to_string(), solc.trim_start_matches("solc:").into());
-        }
-
-        if self.offline {
-            dict.insert("offline".to_string(), true.into());
-        }
-
-        if self.via_ir {
-            dict.insert("via_ir".to_string(), true.into());
-        }
-
         if self.names {
             dict.insert("names".to_string(), true.into());
         }
@@ -239,27 +289,11 @@ impl Provider for BuildArgs {
             dict.insert("sizes".to_string(), true.into());
         }
 
-        if self.force {
-            dict.insert("force".to_string(), self.force.into());
-        }
-
-        if self.compiler.optimize {
-            dict.insert("optimizer".to_string(), self.compiler.optimize.into());
-        }
-
-        if let Some(ref extra) = self.compiler.extra_output {
-            let selection: Vec<_> = extra.iter().map(|s| s.to_string()).collect();
-            dict.insert("extra_output".to_string(), selection.into());
-        }
-
-        if let Some(ref extra) = self.compiler.extra_output_files {
-            let selection: Vec<_> = extra.iter().map(|s| s.to_string()).collect();
-            dict.insert("extra_output_files".to_string(), selection.into());
-        }
-
         Ok(Map::from([(Config::selected_profile(), dict)]))
     }
 }
+
+impl_figment_convert!(BuildArgs, args);
 
 #[derive(Debug, Clone, Parser, Serialize)]
 pub struct ProjectPathsArgs {

--- a/cli/src/cmd/forge/build.rs
+++ b/cli/src/cmd/forge/build.rs
@@ -83,13 +83,10 @@ pub struct CoreBuildArgs {
     #[serde(skip)]
     pub no_auto_detect: bool,
 
-    #[clap(
-        help_heading = "COMPILER OPTIONS",
-        help = "specify the solc version or path to a local solc to run with.\
-        This accepts values of the form `x.y.z`, `solc:x.y.z` or `path/to/existing/solc`",
-        value_name = "use",
-        long = "use"
-    )]
+    /// Specify the solc version, or a path to a local solc, to build with.
+    ///
+    /// Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+    #[clap(help_heading = "COMPILER OPTIONS", value_name = "use", long = "use")]
     #[serde(skip)]
     pub use_solc: Option<String>,
 

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -1,24 +1,20 @@
 //! Create command
-
 use crate::{
-    cmd::{forge::build::BuildArgs, Cmd},
-    opts::{EthereumOpts, WalletType},
+    cmd::{forge::build::CoreBuildArgs, Cmd},
+    compile,
+    opts::{forge::ContractInfo, EthereumOpts, WalletType},
     utils::parse_u256,
 };
+use clap::{Parser, ValueHint};
 use ethers::{
     abi::{Abi, Constructor, Token},
     prelude::{artifacts::BytecodeObject, ContractFactory, Http, Middleware, Provider},
     types::{transaction::eip2718::TypedTransaction, Chain, U256},
 };
-
 use eyre::{Context, Result};
 use foundry_utils::parse_tokens;
-use std::fs;
-
-use crate::{compile, opts::forge::ContractInfo};
-use clap::{Parser, ValueHint};
 use serde_json::json;
-use std::{path::PathBuf, sync::Arc};
+use std::{fs, path::PathBuf, sync::Arc};
 
 #[derive(Debug, Clone, Parser)]
 pub struct CreateArgs {
@@ -41,7 +37,7 @@ pub struct CreateArgs {
     constructor_args_path: Option<PathBuf>,
 
     #[clap(flatten)]
-    opts: BuildArgs,
+    opts: CoreBuildArgs,
 
     #[clap(flatten)]
     eth: EthereumOpts,
@@ -81,7 +77,7 @@ impl Cmd for CreateArgs {
             // Supress compile stdout messages when printing json output
             compile::suppress_compile(&project)?
         } else {
-            compile::compile(&project, self.opts.names, self.opts.sizes)?
+            compile::compile(&project, false, false)?
         };
 
         // Get ABI and BIN

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -3,7 +3,7 @@ use crate::{
     cmd::{forge::build::CoreBuildArgs, Cmd},
     compile,
     opts::{forge::ContractInfo, EthereumOpts, WalletType},
-    utils::parse_ether_value,
+    utils::{parse_ether_value, parse_u256},
 };
 use clap::{Parser, ValueHint};
 use ethers::{

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -18,10 +18,13 @@ use std::{fs, path::PathBuf, sync::Arc};
 
 #[derive(Debug, Clone, Parser)]
 pub struct CreateArgs {
+    #[clap(help = "The contract identifier in the form `<path>:<contractname>`.")]
+    contract: ContractInfo,
+
     #[clap(
         long,
         multiple_values = true,
-        help = "constructor args calldata arguments",
+        help = "Constructor arguments.",
         name = "constructor_args",
         conflicts_with = "constructor_args_path"
     )]
@@ -29,41 +32,64 @@ pub struct CreateArgs {
 
     #[clap(
         long,
-        help = "path to a file containing the constructor args",
+        help = "The path to a file containing the constructor arguments.",
         value_hint = ValueHint::FilePath,
         name = "constructor_args_path",
         conflicts_with = "constructor_args",
     )]
     constructor_args_path: Option<PathBuf>,
 
-    #[clap(flatten)]
-    opts: CoreBuildArgs,
-
-    #[clap(flatten)]
-    eth: EthereumOpts,
-
-    #[clap(help = "contract source info `<path>:<contractname>` or `<contractname>`")]
-    contract: ContractInfo,
-
     #[clap(
         long,
-        help = "use legacy transactions instead of EIP1559 ones. this is auto-enabled for common networks without EIP1559"
+        help_heading = "TRANSACTION OPTIONS",
+        help = "Send a legacy transaction instead of an EIP1559 transaction.",
+        long_help = r#"Send a legacy transaction instead of an EIP1559 transaction.
+
+This is automatically enabled for common networks without EIP1559."#
     )]
     legacy: bool,
 
-    #[clap(long = "gas-price", help = "gas price for legacy txs or maxFeePerGas for EIP1559 txs", env = "ETH_GAS_PRICE", parse(try_from_str = parse_u256))]
+    #[clap(
+        long = "gas-price",
+        help_heading = "TRANSACTION OPTIONS",
+        help = "Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.",
+        env = "ETH_GAS_PRICE",
+        parse(try_from_str = parse_u256)
+    )]
     gas_price: Option<U256>,
 
-    #[clap(long = "gas-limit", help = "maximum amount of gas that can be consumed for txs", env = "ETH_GAS_LIMIT", parse(try_from_str = parse_u256))]
+    #[clap(
+        long = "gas-limit",
+        help_heading = "TRANSACTION OPTIONS",
+        help = "Gas limit for the transaction.",
+        env = "ETH_GAS_LIMIT",
+        parse(try_from_str = parse_u256)
+    )]
     gas_limit: Option<U256>,
 
-    #[clap(long = "priority-fee", help = "gas priority fee for EIP1559 txs", env = "ETH_GAS_PRIORITY_FEE", parse(try_from_str = parse_u256))]
+    #[clap(
+        long = "priority-fee", 
+        help_heading = "TRANSACTION OPTIONS",
+        help = "Gas priority fee for EIP1559 transactions.",
+        env = "ETH_GAS_PRIORITY_FEE", parse(try_from_str = parse_u256)
+    )]
     priority_fee: Option<U256>,
 
-    #[clap(long = "value", help = "value to send with the contract creation tx", env = "ETH_VALUE", parse(try_from_str = parse_u256))]
+    #[clap(
+        long,
+        help_heading = "TRANSACTION OPTIONS",
+        help = "Ether to send in the transaction in wei.",
+        parse(try_from_str = parse_u256)
+    )]
     value: Option<U256>,
 
-    #[clap(long = "json", help = "print the deployment information as json")]
+    #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
+    opts: CoreBuildArgs,
+
+    #[clap(flatten, next_help_heading = "ETHEREUM OPTIONS")]
+    eth: EthereumOpts,
+
+    #[clap(long = "json", help = "Print the deployment information as JSON.")]
     json: bool,
 }
 
@@ -197,10 +223,14 @@ impl CreateArgs {
 
         let (deployed_contract, receipt) = deployer.send_with_receipt().await?;
         if self.json {
-            let output = json!({"deployer": deployer_address, "deployedTo": deployed_contract.address(), "transactionHash": receipt.transaction_hash});
-            println!("{}", output);
+            let output = json!({
+                "deployer": deployer_address,
+                "deployedTo": deployed_contract.address(),
+                "transactionHash": receipt.transaction_hash
+            });
+            println!("{output}");
         } else {
-            println!("Deployer: {:?}", deployer_address);
+            println!("Deployer: {deployer_address:?}");
             println!("Deployed to: {:?}", deployed_contract.address());
             println!("Transaction hash: {:?}", receipt.transaction_hash);
         }

--- a/cli/src/cmd/forge/create.rs
+++ b/cli/src/cmd/forge/create.rs
@@ -3,7 +3,7 @@ use crate::{
     cmd::{forge::build::CoreBuildArgs, Cmd},
     compile,
     opts::{forge::ContractInfo, EthereumOpts, WalletType},
-    utils::parse_u256,
+    utils::parse_ether_value,
 };
 use clap::{Parser, ValueHint};
 use ethers::{
@@ -24,7 +24,7 @@ pub struct CreateArgs {
     #[clap(
         long,
         multiple_values = true,
-        help = "Constructor arguments.",
+        help = "The constructor arguments.",
         name = "constructor_args",
         conflicts_with = "constructor_args_path"
     )]
@@ -54,7 +54,7 @@ This is automatically enabled for common networks without EIP1559."#
         help_heading = "TRANSACTION OPTIONS",
         help = "Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.",
         env = "ETH_GAS_PRICE",
-        parse(try_from_str = parse_u256)
+        parse(try_from_str = parse_ether_value)
     )]
     gas_price: Option<U256>,
 
@@ -71,15 +71,17 @@ This is automatically enabled for common networks without EIP1559."#
         long = "priority-fee", 
         help_heading = "TRANSACTION OPTIONS",
         help = "Gas priority fee for EIP1559 transactions.",
-        env = "ETH_GAS_PRIORITY_FEE", parse(try_from_str = parse_u256)
+        env = "ETH_GAS_PRIORITY_FEE", parse(try_from_str = parse_ether_value)
     )]
     priority_fee: Option<U256>,
-
     #[clap(
         long,
         help_heading = "TRANSACTION OPTIONS",
-        help = "Ether to send in the transaction in wei.",
-        parse(try_from_str = parse_u256)
+        help = "Ether to send in the transaction.",
+        long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
+
+Examples: 1ether, 10gwei, 0.01ether"#,
+        parse(try_from_str = parse_ether_value)
     )]
     value: Option<U256>,
 
@@ -89,7 +91,11 @@ This is automatically enabled for common networks without EIP1559."#
     #[clap(flatten, next_help_heading = "ETHEREUM OPTIONS")]
     eth: EthereumOpts,
 
-    #[clap(long = "json", help = "Print the deployment information as JSON.")]
+    #[clap(
+        long = "json",
+        help_heading = "DISPLAY OPTIONS",
+        help = "Print the deployment information as JSON."
+    )]
     json: bool,
 }
 

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -20,7 +20,7 @@ pub struct FlattenArgs {
     )]
     pub output: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
     project_paths: ProjectPathsArgs,
 }
 
@@ -32,6 +32,7 @@ impl Cmd for FlattenArgs {
         // flatten is a subset of `BuildArgs` so we can reuse that to get the config
         let build_args = BuildArgs {
             project_paths,
+            out_path: Default::default(),
             compiler: Default::default(),
             names: false,
             sizes: false,

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -1,59 +1,10 @@
 use std::path::PathBuf;
 
-use ethers::solc::remappings::Remapping;
-
 use crate::cmd::{forge::build::BuildArgs, Cmd};
 use clap::{Parser, ValueHint};
 use foundry_config::Config;
 
-#[derive(Debug, Clone, Parser)]
-pub struct CoreFlattenArgs {
-    #[clap(
-        help = "The project's root path.",
-        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
-        long,
-        value_hint = ValueHint::DirPath
-    )]
-    pub root: Option<PathBuf>,
-
-    #[clap(
-        env = "DAPP_SRC",
-        help = "The contract's source directory, relative to the project root.",
-        long,
-        short,
-        value_hint = ValueHint::DirPath
-    )]
-    pub contracts: Option<PathBuf>,
-
-    #[clap(help = "The project's remappings.", long, short)]
-    pub remappings: Vec<Remapping>,
-
-    #[clap(long = "remappings-env", env = "DAPP_REMAPPINGS")]
-    pub remappings_env: Option<String>,
-
-    #[clap(
-        help = "The path to the compiler cache.",
-        long = "cache-path",
-        value_hint = ValueHint::DirPath
-    )]
-    pub cache_path: Option<PathBuf>,
-
-    #[clap(
-        help = "The path to the library folder.",
-        long,
-        value_hint = ValueHint::DirPath
-    )]
-    pub lib_paths: Vec<PathBuf>,
-
-    #[clap(
-        help = "Use the Hardhat-style project layout.",
-        long_help = "Use the Hardhat-style project layout.",
-        long,
-        conflicts_with = "contracts",
-        alias = "hh"
-    )]
-    pub hardhat: bool,
-}
+use super::build::ProjectPathsArgs;
 
 #[derive(Debug, Clone, Parser)]
 pub struct FlattenArgs {
@@ -70,23 +21,17 @@ pub struct FlattenArgs {
     pub output: Option<PathBuf>,
 
     #[clap(flatten)]
-    core_flatten_args: CoreFlattenArgs,
+    project_paths: ProjectPathsArgs,
 }
 
 impl Cmd for FlattenArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let FlattenArgs { target_path, output, core_flatten_args } = self;
+        let FlattenArgs { target_path, output, project_paths } = self;
 
         // flatten is a subset of `BuildArgs` so we can reuse that to get the config
         let build_args = BuildArgs {
-            root: core_flatten_args.root,
-            contracts: core_flatten_args.contracts,
-            remappings: core_flatten_args.remappings,
-            remappings_env: core_flatten_args.remappings_env,
-            cache_path: core_flatten_args.cache_path,
-            lib_paths: core_flatten_args.lib_paths,
-            out_path: None,
+            project_paths,
             compiler: Default::default(),
             names: false,
             sizes: false,
@@ -95,7 +40,6 @@ impl Cmd for FlattenArgs {
             use_solc: None,
             offline: false,
             force: false,
-            hardhat: core_flatten_args.hardhat,
             libraries: vec![],
             watch: Default::default(),
             via_ir: false,

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -1,10 +1,8 @@
-use std::path::PathBuf;
-
-use crate::cmd::{forge::build::BuildArgs, Cmd};
+use super::build::{CoreBuildArgs, ProjectPathsArgs};
+use crate::cmd::Cmd;
 use clap::{Parser, ValueHint};
 use foundry_config::Config;
-
-use super::build::ProjectPathsArgs;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Parser)]
 pub struct FlattenArgs {
@@ -30,19 +28,16 @@ impl Cmd for FlattenArgs {
         let FlattenArgs { target_path, output, project_paths } = self;
 
         // flatten is a subset of `BuildArgs` so we can reuse that to get the config
-        let build_args = BuildArgs {
+        let build_args = CoreBuildArgs {
             project_paths,
             out_path: Default::default(),
             compiler: Default::default(),
-            names: false,
-            sizes: false,
             ignored_error_codes: vec![],
             no_auto_detect: false,
             use_solc: None,
             offline: false,
             force: false,
             libraries: vec![],
-            watch: Default::default(),
             via_ir: false,
             config_path: None,
         };

--- a/cli/src/cmd/forge/flatten.rs
+++ b/cli/src/cmd/forge/flatten.rs
@@ -9,42 +9,45 @@ use foundry_config::Config;
 #[derive(Debug, Clone, Parser)]
 pub struct CoreFlattenArgs {
     #[clap(
-    help = "the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
-    long,
-    value_hint = ValueHint::DirPath
+        help = "The project's root path.",
+        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
+        long,
+        value_hint = ValueHint::DirPath
     )]
     pub root: Option<PathBuf>,
 
     #[clap(
-    env = "DAPP_SRC",
-    help = "the directory relative to the root under which the smart contracts are",
-    long,
-    short,
-    value_hint = ValueHint::DirPath
+        env = "DAPP_SRC",
+        help = "The contract's source directory, relative to the project root.",
+        long,
+        short,
+        value_hint = ValueHint::DirPath
     )]
     pub contracts: Option<PathBuf>,
 
-    #[clap(help = "the remappings", long, short)]
+    #[clap(help = "The project's remappings.", long, short)]
     pub remappings: Vec<Remapping>,
+
     #[clap(long = "remappings-env", env = "DAPP_REMAPPINGS")]
     pub remappings_env: Option<String>,
 
     #[clap(
-        help = "the path where cached compiled contracts are stored",
+        help = "The path to the compiler cache.",
         long = "cache-path",
         value_hint = ValueHint::DirPath
     )]
     pub cache_path: Option<PathBuf>,
 
     #[clap(
-    help = "the paths where your libraries are installed",
-    long,
-    value_hint = ValueHint::DirPath
+        help = "The path to the library folder.",
+        long,
+        value_hint = ValueHint::DirPath
     )]
     pub lib_paths: Vec<PathBuf>,
 
     #[clap(
-        help = "uses hardhat style project layout. This a convenience flag and is the same as `--contracts contracts --lib-paths node_modules`",
+        help = "Use the Hardhat-style project layout.",
+        long_help = "Use the Hardhat-style project layout.",
         long,
         conflicts_with = "contracts",
         alias = "hh"
@@ -54,10 +57,16 @@ pub struct CoreFlattenArgs {
 
 #[derive(Debug, Clone, Parser)]
 pub struct FlattenArgs {
-    #[clap(help = "the path to the contract to flatten", value_hint = ValueHint::FilePath)]
+    #[clap(help = "The path to the contract to flatten.", value_hint = ValueHint::FilePath)]
     pub target_path: PathBuf,
 
-    #[clap(long, short, help = "output path for the flattened contract", value_hint = ValueHint::FilePath)]
+    #[clap(
+        long,
+        short,
+        help = "The path to output the flattened contract.",
+        long_help = "The path to output the flattened contract. If not specified, the flattened contract will be output to stdout.",
+        value_hint = ValueHint::FilePath
+    )]
     pub output: Option<PathBuf>,
 
     #[clap(flatten)]
@@ -99,7 +108,7 @@ impl Cmd for FlattenArgs {
         let target_path = dunce::canonicalize(target_path)?;
         let flattened = paths
             .flatten(&target_path)
-            .map_err(|err| eyre::Error::msg(format!("failed to flatten the file: {}", err)))?;
+            .map_err(|err| eyre::Error::msg(format!("Failed to flatten the file: {}", err)))?;
 
         match output {
             Some(output) => {

--- a/cli/src/cmd/forge/init.rs
+++ b/cli/src/cmd/forge/init.rs
@@ -21,33 +21,33 @@ use std::{
 #[derive(Debug, Clone, Parser)]
 pub struct InitArgs {
     #[clap(
-    help = "the project's root path, default being the current working directory",
-    value_hint = ValueHint::DirPath
+        help = "The root directory of the new project. Defaults to the current working directory.",
+        value_hint = ValueHint::DirPath
     )]
     root: Option<PathBuf>,
-    #[clap(help = "optional solidity template to start from", long, short)]
+    #[clap(help = "The template to start from.", long, short)]
     template: Option<String>,
-    #[clap(
-        help = "initialize without creating a git repository",
-        conflicts_with = "template",
-        long
-    )]
+    #[clap(help = "Do not create a git repository.", conflicts_with = "template", long)]
     no_git: bool,
-    #[clap(help = "do not create initial commit", conflicts_with = "template", long)]
+    #[clap(help = "Do not create an initial commit.", conflicts_with = "template", long)]
     no_commit: bool,
-    #[clap(help = "do not print messages", short, long)]
+    #[clap(help = "Do not print any messages.", short, long)]
     quiet: bool,
     #[clap(
-        help = "run without installing libs from the network",
+        help = "Do not install dependencies from the network.",
         conflicts_with = "template",
         long,
         alias = "no-deps"
     )]
     offline: bool,
-    #[clap(help = "force init if project dir is not empty", conflicts_with = "template", long)]
+    #[clap(
+        help = "Create the project even if the specified root directory is not empty.",
+        conflicts_with = "template",
+        long
+    )]
     force: bool,
     #[clap(
-        help = "initialize .vscode/settings.json file with solidity settings and generate a remappings.txt file.",
+        help = "Create a .vscode/settings.json file with Solidity settings, and generate a remappings.txt file.",
         conflicts_with = "template",
         long
     )]

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -1,8 +1,6 @@
-use std::{fmt, str::FromStr};
-
 use crate::{
     cmd::{
-        forge::build::{self, BuildArgs},
+        forge::build::{self, CoreBuildArgs},
         Cmd,
     },
     compile,
@@ -13,6 +11,7 @@ use ethers::prelude::artifacts::output_selection::{
     ContractOutputSelection, EvmOutputSelection, EwasmOutputSelection,
 };
 use serde_json::{to_value, Value};
+use std::{fmt, str::FromStr};
 
 /// Contract level output selection
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -98,7 +97,7 @@ pub struct InspectArgs {
 
     /// All build arguments are supported
     #[clap(flatten)]
-    build: build::BuildArgs,
+    build: build::CoreBuildArgs,
 }
 
 impl Cmd for InspectArgs {
@@ -146,7 +145,7 @@ impl Cmd for InspectArgs {
         };
 
         // Build modified Args
-        let modified_build_args = BuildArgs {
+        let modified_build_args = CoreBuildArgs {
             compiler: CompilerArgs {
                 extra_output: Some(cos),
                 optimize: optimized,

--- a/cli/src/cmd/forge/inspect.rs
+++ b/cli/src/cmd/forge/inspect.rs
@@ -82,18 +82,18 @@ impl FromStr for ContractArtifactFields {
             "metadata" | "meta" => Ok(ContractArtifactFields::Metadata),
             "userdoc" | "userDoc" | "user-doc" => Ok(ContractArtifactFields::UserDoc),
             "ewasm" | "e-wasm" => Ok(ContractArtifactFields::Ewasm),
-            _ => Err(format!("Unknown mode: {}", s)),
+            _ => Err(format!("Unknown field: {}", s)),
         }
     }
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct InspectArgs {
-    #[clap(help = "the contract to inspect")]
+    #[clap(help = "The name of the contract to inspect.")]
     pub contract: String,
 
-    #[clap(help = "the contract artifact field to inspect")]
-    pub mode: ContractArtifactFields,
+    #[clap(help = "The contract artifact field to inspect.")]
+    pub field: ContractArtifactFields,
 
     /// All build arguments are supported
     #[clap(flatten)]
@@ -103,12 +103,12 @@ pub struct InspectArgs {
 impl Cmd for InspectArgs {
     type Output = ();
     fn run(self) -> eyre::Result<Self::Output> {
-        let InspectArgs { contract, mode, build } = self;
+        let InspectArgs { contract, field, build } = self;
 
-        // Map mode to ContractOutputSelection
+        // Map field to ContractOutputSelection
         let mut cos = build.compiler.extra_output.unwrap_or_default();
-        if !cos.iter().any(|&i| i.to_string() == mode.to_string()) {
-            match mode {
+        if !cos.iter().any(|&i| i.to_string() == field.to_string()) {
+            match field {
                 ContractArtifactFields::Abi => cos.push(ContractOutputSelection::Abi),
                 ContractArtifactFields::Bytecode => { /* Auto Generated */ }
                 ContractArtifactFields::DeployedBytecode => { /* Auto Generated */ }
@@ -138,7 +138,7 @@ impl Cmd for InspectArgs {
         }
 
         // Run Optimized?
-        let optimized = if let ContractArtifactFields::AssemblyOptimized = mode {
+        let optimized = if let ContractArtifactFields::AssemblyOptimized = field {
             true
         } else {
             build.compiler.optimize
@@ -167,7 +167,7 @@ impl Cmd for InspectArgs {
         })?;
 
         // Match on ContractArtifactFields and Pretty Print
-        match mode {
+        match field {
             ContractArtifactFields::Abi => {
                 println!("{}", serde_json::to_string_pretty(&to_value(&artifact.abi)?)?);
             }

--- a/cli/src/cmd/forge/install.rs
+++ b/cli/src/cmd/forge/install.rs
@@ -14,14 +14,22 @@ use std::{
 /// Command to install dependencies
 #[derive(Debug, Clone, Parser)]
 pub struct InstallArgs {
-    #[clap(
-        help = "Installs one or more dependencies as git submodules (will install existing dependencies if no arguments are provided)"
-    )]
+    /// The dependencies to install.
+    ///
+    /// A dependency can be a raw URL, or the path to a GitHub repository.
+    ///
+    /// Additionally, a ref can be provided by adding @ to the dependency path.
+    ///
+    /// A ref can be:  
+    /// - A branch: master
+    /// - A tag: v1.2.3
+    /// - A commit: 8e8128
     dependencies: Vec<Dependency>,
     #[clap(flatten)]
     opts: DependencyInstallOpts,
     #[clap(
-        help = "the project's root path. By default, this is the root directory of the current Git repository or the current working directory if it is not part of a Git repository",
+        help = "The project's root path.",
+        long_help = "The project's root path. By default, this is the root directory of the current Git repository, or the current working directory.",
         long,
         value_hint = ValueHint::DirPath
     )]
@@ -40,11 +48,11 @@ impl Cmd for InstallArgs {
 
 #[derive(Debug, Clone, Copy, Default, Parser)]
 pub struct DependencyInstallOpts {
-    #[clap(help = "install without creating a submodule repository", long)]
+    #[clap(help = "Install without adding the dependency as a submodule.", long)]
     pub no_git: bool,
-    #[clap(help = "do not create a commit", long)]
+    #[clap(help = "Do not create a commit.", long)]
     pub no_commit: bool,
-    #[clap(help = "do not print messages", short, long)]
+    #[clap(help = "Do not print any messages.", short, long)]
     pub quiet: bool,
 }
 

--- a/cli/src/cmd/forge/remappings.rs
+++ b/cli/src/cmd/forge/remappings.rs
@@ -9,17 +9,17 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone, Parser)]
 pub struct RemappingArgs {
     #[clap(
-        help = "the project's root path, default being the current working directory",
+        help = "The project's root path. Defaults to the current working directory.",
         long,
         value_hint = ValueHint::DirPath
     )]
     root: Option<PathBuf>,
     #[clap(
-        help = "the paths where your libraries are installed",
+        help = "The path to the library folder.",
         long,
         value_hint = ValueHint::DirPath
     )]
-    lib_paths: Vec<PathBuf>,
+    lib_path: Vec<PathBuf>,
 }
 
 impl Cmd for RemappingArgs {
@@ -29,13 +29,13 @@ impl Cmd for RemappingArgs {
         let root = self.root.unwrap_or_else(|| std::env::current_dir().unwrap());
         let root = dunce::canonicalize(root)?;
 
-        let lib_paths = if self.lib_paths.is_empty() {
+        let lib_path = if self.lib_path.is_empty() {
             ProjectPathsConfig::find_libs(&root)
         } else {
-            self.lib_paths
+            self.lib_path
         };
         let remappings: Vec<_> =
-            lib_paths.iter().flat_map(|lib| relative_remappings(lib, &root)).collect();
+            lib_path.iter().flat_map(|lib| relative_remappings(lib, &root)).collect();
         remappings.iter().for_each(|x| println!("{}", x));
         Ok(())
     }

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -46,11 +46,11 @@ pub struct RunArgs {
     pub args: Vec<String>,
 
     /// The name of the contract you want to run.
-    #[clap(long, short)]
+    #[clap(long, short, value_name = "CONTRACT_NAME")]
     pub target_contract: Option<String>,
 
     /// The signature of the function you want to call in the contract, or raw calldata.
-    #[clap(long, short, default_value = "run()")]
+    #[clap(long, short, default_value = "run()", value_name = "SIGNATURE")]
     pub sig: String,
 
     /// Open the script in the debugger.

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmd::{forge::build::BuildArgs, Cmd},
+    cmd::{forge::build::CoreBuildArgs, Cmd},
     compile,
     opts::evm::EvmArgs,
     utils,
@@ -58,7 +58,7 @@ pub struct RunArgs {
     pub debug: bool,
 
     #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
-    pub opts: BuildArgs,
+    pub opts: CoreBuildArgs,
 
     #[clap(flatten, next_help_heading = "EVM OPTIONS")]
     pub evm_opts: EvmArgs,

--- a/cli/src/cmd/forge/snapshot.rs
+++ b/cli/src/cmd/forge/snapshot.rs
@@ -1,8 +1,7 @@
 //! Snapshot command
-
 use crate::cmd::{
     forge::{
-        build::BuildArgs,
+        build::CoreBuildArgs,
         test,
         test::{custom_run, Test, TestOutcome},
     },
@@ -35,7 +34,7 @@ pub static RE_BASIC_SNAPSHOT_ENTRY: Lazy<Regex> = Lazy::new(|| {
 pub struct SnapshotArgs {
     /// All test arguments are supported
     #[clap(flatten)]
-    test: test::TestArgs,
+    pub(crate) test: test::TestArgs,
 
     /// Additional configs for test results
     #[clap(flatten)]
@@ -78,17 +77,17 @@ pub struct SnapshotArgs {
 impl SnapshotArgs {
     /// Returns whether `SnapshotArgs` was configured with `--watch`
     pub fn is_watch(&self) -> bool {
-        self.test.build_args().is_watch()
+        self.test.is_watch()
     }
 
     /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
     /// bootstrap a new [`watchexe::Watchexec`] loop.
     pub(crate) fn watchexec_config(&self) -> eyre::Result<(InitConfig, RuntimeConfig)> {
-        self.test.build_args().watchexec_config()
+        self.test.watchexec_config()
     }
 
-    /// Returns the nested [`BuildArgs`]
-    pub fn build_args(&self) -> &BuildArgs {
+    /// Returns the nested [`CoreBuildArgs`]
+    pub fn build_args(&self) -> &CoreBuildArgs {
         self.test.build_args()
     }
 }

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -162,7 +162,7 @@ pub struct TestArgs {
     #[clap(long, env = "FORGE_GAS_REPORT")]
     gas_report: bool,
 
-    /// Force the process to exit with code 0, even if the tests fail.
+    /// Exit with code 0 even if a test fails.
     #[clap(long, env = "FORGE_ALLOW_FAILURE")]
     allow_failure: bool,
 

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -1,7 +1,7 @@
 //! Test command
 use crate::{
     cmd::{
-        forge::{build::BuildArgs, run::RunArgs},
+        forge::{build::CoreBuildArgs, run::RunArgs, watch::WatchArgs},
         Cmd,
     },
     compile::ProjectCompiler,
@@ -31,6 +31,7 @@ use std::{
     thread,
     time::Duration,
 };
+use watchexec::config::{InitConfig, RuntimeConfig};
 
 #[derive(Debug, Clone, Parser)]
 pub struct Filter {
@@ -173,12 +174,15 @@ pub struct TestArgs {
     evm_opts: EvmArgs,
 
     #[clap(flatten, next_help_heading = "BUILD OPTIONS")]
-    opts: BuildArgs,
+    opts: CoreBuildArgs,
+
+    #[clap(flatten, next_help_heading = "WATCH OPTIONS")]
+    pub watch: WatchArgs,
 }
 
 impl TestArgs {
-    /// Returns the flattened [`BuildArgs`]
-    pub fn build_args(&self) -> &BuildArgs {
+    /// Returns the flattened [`CoreBuildArgs`]
+    pub fn build_args(&self) -> &CoreBuildArgs {
         &self.opts
     }
 
@@ -194,6 +198,17 @@ impl TestArgs {
         let evm_opts = figment.extract()?;
         let config = Config::from_provider(figment).sanitized();
         Ok((config, evm_opts))
+    }
+
+    /// Returns whether `BuildArgs` was configured with `--watch`
+    pub fn is_watch(&self) -> bool {
+        self.watch.watch.is_some()
+    }
+
+    /// Returns the [`watchexec::InitConfig`] and [`watchexec::RuntimeConfig`] necessary to
+    /// bootstrap a new [`watchexe::Watchexec`] loop.
+    pub(crate) fn watchexec_config(&self) -> eyre::Result<(InitConfig, RuntimeConfig)> {
+        self.watch.watchexec_config(|| Config::from(self).src)
     }
 }
 

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -167,7 +167,7 @@ pub struct TestArgs {
     allow_failure: bool,
 
     /// Output test results in JSON format.
-    #[clap(long, short)]
+    #[clap(long, short, help_heading = "DISPLAY OPTIONS")]
     json: bool,
 
     #[clap(flatten, next_help_heading = "EVM OPTIONS")]

--- a/cli/src/cmd/forge/tree.rs
+++ b/cli/src/cmd/forge/tree.rs
@@ -11,12 +11,12 @@ use ethers::solc::resolver::{Charset, TreeOptions};
 /// Command to display the project's dependency tree
 #[derive(Debug, Clone, Parser)]
 pub struct TreeArgs {
-    #[clap(flatten)]
-    opts: ProjectPathsArgs,
     #[clap(help = "Do not de-duplicate (repeats all shared dependencies)", long)]
     no_dedupe: bool,
     #[clap(help = "Character set to use in output: utf8, ascii", default_value = "utf8", long)]
     charset: Charset,
+    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    opts: ProjectPathsArgs,
 }
 
 impl Cmd for TreeArgs {

--- a/cli/src/cmd/forge/tree.rs
+++ b/cli/src/cmd/forge/tree.rs
@@ -1,6 +1,6 @@
 //! tree command
 
-use crate::cmd::{forge::build::BuildArgs, Cmd};
+use crate::cmd::{forge::build::ProjectPathsArgs, Cmd};
 use clap::Parser;
 use ethers::solc::Graph;
 use foundry_config::Config;
@@ -11,9 +11,8 @@ use ethers::solc::resolver::{Charset, TreeOptions};
 /// Command to display the project's dependency tree
 #[derive(Debug, Clone, Parser)]
 pub struct TreeArgs {
-    // TODO extract path related args from BuildArgs
     #[clap(flatten)]
-    opts: BuildArgs,
+    opts: ProjectPathsArgs,
     #[clap(help = "Do not de-duplicate (repeats all shared dependencies)", long)]
     no_dedupe: bool,
     #[clap(help = "Character set to use in output: utf8, ascii", default_value = "utf8", long)]

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -24,19 +24,23 @@ use super::build::ProjectPathsArgs;
 /// Verification arguments
 #[derive(Debug, Clone, Parser)]
 pub struct VerifyArgs {
-    #[clap(help = "the target contract address")]
+    #[clap(help = "The address of the contract to verify.")]
     address: Address,
 
-    #[clap(help = "the contract source info `<path>:<contractname>`")]
+    #[clap(help = "The contract identifier in the form `<path>:<contractname>`.")]
     contract: ContractInfo,
 
     #[clap(long, help = "the encoded constructor arguments")]
     constructor_args: Option<String>,
 
-    #[clap(long, help = "the compiler version used during build")]
+    #[clap(long, help = "The compiler version used to build the smart contract.")]
     compiler_version: String,
 
-    #[clap(alias = "optimizer-runs", long, help = "the number of optimization runs used")]
+    #[clap(
+        alias = "optimizer-runs",
+        long,
+        help = "The number of optimization runs used to build the smart contract."
+    )]
     num_of_optimizations: Option<u32>,
 
     #[clap(
@@ -48,25 +52,21 @@ pub struct VerifyArgs {
     )]
     chain: Chain,
 
-    #[clap(help = "your etherscan api key", env = "ETHERSCAN_API_KEY")]
+    #[clap(help = "Your Etherscan API key.", env = "ETHERSCAN_API_KEY")]
     etherscan_key: String,
 
-    #[clap(
-        help = "flatten the source code. Make sure to use bytecodehash='ipfs'",
-        long = "flatten"
-    )]
+    #[clap(help = "Flatten the source code before verifying.", long = "flatten")]
     flatten: bool,
-
-    #[clap(flatten)]
-    project_paths: ProjectPathsArgs,
 
     #[clap(
         short,
         long,
-        help = r#"usually the command will try to compile the flattened code locally first to ensure it's valid.
-This flag we skip that process and send the content directly to the endpoint."#
+        help = "Do not compile the flattened smart contract before verifying (if --flatten is passed)."
     )]
     force: bool,
+
+    #[clap(flatten, next_help_heading = "PROJECT OPTIONS")]
+    project_paths: ProjectPathsArgs,
 }
 
 impl VerifyArgs {
@@ -127,6 +127,7 @@ impl VerifyArgs {
     fn create_verify_request(&self) -> eyre::Result<VerifyContract> {
         let build_args = BuildArgs {
             project_paths: self.project_paths.clone(),
+            out_path: Default::default(),
             compiler: Default::default(),
             names: false,
             sizes: false,
@@ -227,7 +228,7 @@ impl VerifyArgs {
             eprintln!(
                 r#"Failed to compile the flattened code locally.
 This could be a bug, please inspect the outout of `forge flatten {}` and report an issue.
-To skip this solc dry, have a look at the  `--force` flag of this command.
+To skip this solc dry, pass `--force`.
 "#,
                 self.contract.path.as_ref().expect("Path is some;")
             );

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -1,9 +1,6 @@
 //! Verify contract source on etherscan
 
-use crate::{
-    cmd::forge::{build::BuildArgs, flatten::CoreFlattenArgs},
-    opts::forge::ContractInfo,
-};
+use crate::{cmd::forge::build::BuildArgs, opts::forge::ContractInfo};
 use clap::Parser;
 use ethers::{
     abi::Address,
@@ -21,6 +18,8 @@ use foundry_config::Chain;
 use semver::Version;
 use std::{collections::BTreeMap, path::Path};
 use tracing::{trace, warn};
+
+use super::build::ProjectPathsArgs;
 
 /// Verification arguments
 #[derive(Debug, Clone, Parser)]
@@ -59,7 +58,7 @@ pub struct VerifyArgs {
     flatten: bool,
 
     #[clap(flatten)]
-    opts: CoreFlattenArgs,
+    project_paths: ProjectPathsArgs,
 
     #[clap(
         short,
@@ -126,24 +125,8 @@ impl VerifyArgs {
     /// If `--flatten` is set to `true` then this will send with [`CodeFormat::SingleFile`]
     /// otherwise this will use the [`CodeFormat::StandardJsonInput`]
     fn create_verify_request(&self) -> eyre::Result<VerifyContract> {
-        let CoreFlattenArgs {
-            root,
-            contracts,
-            remappings,
-            remappings_env,
-            cache_path,
-            lib_paths,
-            hardhat,
-        } = self.opts.clone();
-
         let build_args = BuildArgs {
-            root,
-            contracts,
-            remappings,
-            remappings_env,
-            cache_path,
-            lib_paths,
-            out_path: None,
+            project_paths: self.project_paths.clone(),
             compiler: Default::default(),
             names: false,
             sizes: false,
@@ -152,7 +135,6 @@ impl VerifyArgs {
             use_solc: None,
             offline: false,
             force: false,
-            hardhat,
             libraries: vec![],
             watch: Default::default(),
             via_ir: false,

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -1,6 +1,7 @@
 //! Verify contract source on etherscan
 
-use crate::{cmd::forge::build::BuildArgs, opts::forge::ContractInfo};
+use super::build::{CoreBuildArgs, ProjectPathsArgs};
+use crate::opts::forge::ContractInfo;
 use clap::Parser;
 use ethers::{
     abi::Address,
@@ -18,8 +19,6 @@ use foundry_config::Chain;
 use semver::Version;
 use std::{collections::BTreeMap, path::Path};
 use tracing::{trace, warn};
-
-use super::build::ProjectPathsArgs;
 
 /// Verification arguments
 #[derive(Debug, Clone, Parser)]
@@ -125,19 +124,16 @@ impl VerifyArgs {
     /// If `--flatten` is set to `true` then this will send with [`CodeFormat::SingleFile`]
     /// otherwise this will use the [`CodeFormat::StandardJsonInput`]
     fn create_verify_request(&self) -> eyre::Result<VerifyContract> {
-        let build_args = BuildArgs {
+        let build_args = CoreBuildArgs {
             project_paths: self.project_paths.clone(),
             out_path: Default::default(),
             compiler: Default::default(),
-            names: false,
-            sizes: false,
             ignored_error_codes: vec![],
             no_auto_detect: false,
             use_solc: None,
             offline: false,
             force: false,
             libraries: vec![],
-            watch: Default::default(),
             via_ir: false,
             config_path: None,
         };

--- a/cli/src/cmd/forge/verify.rs
+++ b/cli/src/cmd/forge/verify.rs
@@ -47,7 +47,7 @@ pub struct VerifyArgs {
         long,
         alias = "chain-id",
         env = "CHAIN",
-        help = "the name or id of chain of the network you are verifying for",
+        help = "The chain ID the contract is deployed to.",
         default_value = "mainnet"
     )]
     chain: Chain,
@@ -242,19 +242,19 @@ To skip this solc dry, pass `--force`.
 /// Check verification status arguments
 #[derive(Debug, Clone, Parser)]
 pub struct VerifyCheckArgs {
-    #[clap(help = "the verification guid")]
+    #[clap(help = "The verification GUID.")]
     guid: String,
 
     #[clap(
         long,
         alias = "chain-id",
         env = "CHAIN",
-        help = "the name or id of chain of the network you are verifying for",
+        help = "The chain ID the contract is deployed to.",
         default_value = "mainnet"
     )]
     chain: Chain,
 
-    #[clap(help = "your etherscan api key", env = "ETHERSCAN_API_KEY")]
+    #[clap(help = "Your Etherscan API key.", env = "ETHERSCAN_API_KEY")]
     etherscan_key: String,
 }
 

--- a/cli/src/forge.rs
+++ b/cli/src/forge.rs
@@ -18,7 +18,7 @@ fn main() -> eyre::Result<()> {
     let opts = Opts::parse();
     match opts.sub {
         Subcommands::Test(cmd) => {
-            if cmd.build_args().is_watch() {
+            if cmd.is_watch() {
                 utils::block_on(watch::watch_test(cmd))?;
             } else {
                 let outcome = cmd.run()?;

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -421,7 +421,7 @@ pub enum Subcommands {
         )]
         block: Option<BlockId>,
         #[clap(help = "The account you want to query", parse(try_from_str = parse_name_or_address))]
-        account: NameOrAddress,
+        who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,
     },

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -313,27 +313,26 @@ pub enum Subcommands {
         eth: EthereumOpts,
     },
     #[clap(name = "--calldata-decode")]
-    #[clap(about = "Decode ABI-encoded hex input data. Use `--abi-decode` to decode output data")]
+    #[clap(about = "Decode ABI-encoded input data.")]
     CalldataDecode {
-        #[clap(
-            help = "the function signature you want to decode, in the format `<name>(<in-types>)(<out-types>)`"
-        )]
+        #[clap(help = "The function signature in the format `<name>(<in-types>)(<out-types>)`.")]
         sig: String,
-        #[clap(help = "the encoded calldata, in hex format")]
+        #[clap(help = "The ABI-encoded calldata.")]
         calldata: String,
     },
     #[clap(name = "--abi-decode")]
     #[clap(
-        about = "Decode ABI-encoded hex output data. Pass --input to decode as input, or use `--calldata-decode`"
+        about = "Decode ABI-encoded input or output data",
+        long_about = "Decode ABI-encoded input or output data.
+
+        Defaults to decoding output data. To decode input data pass --input or use cast --calldata-decode."
     )]
     AbiDecode {
-        #[clap(
-            help = "the function signature you want to decode, in the format `<name>(<in-types>)(<out-types>)`"
-        )]
+        #[clap(help = "The function signature in the format `<name>(<in-types>)(<out-types>)`.")]
         sig: String,
-        #[clap(help = "the encoded calldata, in hex format")]
+        #[clap(help = "The ABI-encoded calldata.")]
         calldata: String,
-        #[clap(long, short, help = "the encoded output, in hex format")]
+        #[clap(long, short, help = "The ABI-encoded output data.")]
         input: bool,
     },
     #[clap(name = "abi-encode")]
@@ -388,14 +387,18 @@ pub enum Subcommands {
         topic: String,
     },
     #[clap(name = "pretty-calldata")]
-    #[clap(about = "Pretty prints calldata, if available gets signature from 4byte.directory")]
+    #[clap(
+        about = "Pretty print calldata.",
+        long_about = "Pretty print calldata.
+
+        Tries to decode the calldata using 4byte.directory unless --offline is passed."
+    )]
     PrettyCalldata {
-        #[clap(help = "Hex encoded calldata")]
+        #[clap(help = "The calldata.")]
         calldata: String,
         #[clap(long, short, help = "Skip the 4byte directory lookup.")]
         offline: bool,
     },
-
     #[clap(name = "age")]
     #[clap(about = "Get the timestamp of a block.")]
     Age {

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -24,64 +24,70 @@ pub enum Subcommands {
     MaxUint,
     #[clap(aliases = &["--from-ascii"])]
     #[clap(name = "--from-utf8")]
-    #[clap(about = "Convert text data into hexdata")]
+    #[clap(about = "Convert UTF8 text to hex.")]
     FromUtf8 { text: Option<String> },
     #[clap(name = "--to-hex")]
-    #[clap(about = "Convert a decimal number into hex")]
+    #[clap(about = "Convert an integer to hex.")]
     ToHex { decimal: Option<String> },
     #[clap(name = "--concat-hex")]
     #[clap(about = "Concatencate hex strings")]
     ConcatHex { data: Vec<String> },
     #[clap(name = "--from-bin")]
-    #[clap(about = "Convert binary data into hex data")]
+    #[clap(about = "Convert binary data into hex data.")]
     FromBin,
     #[clap(name = "--to-hexdata")]
-    #[clap(about = r#"[<hex>|</path>|<@tag>]
-    Output lowercase, 0x-prefixed hex, converting from the
-    input, which can be:
+    #[clap(
+        about = "
+    Normalize the input to lowercase, 0x-prefixed hex. See --help for more info.",
+        long_about = "Normalize the input to lowercase, 0x-prefixed hex.
+
+    The input can be:
       - mixed case hex with or without 0x prefix
       - 0x prefixed hex, concatenated with a ':'
-      - absolute path to file
-      - @tag, where $TAG is defined in environment variables
-    "#)]
+      - an absolute path to file
+      - @tag, where the tag is defined in an environment variable
+    "
+    )]
     ToHexdata { input: Option<String> },
     #[clap(aliases = &["--to-checksum"])] // Compatibility with dapptools' cast
     #[clap(name = "--to-checksum-address")]
     #[clap(about = "Convert an address to a checksummed format (EIP-55)")]
     ToCheckSumAddress { address: Option<Address> },
     #[clap(name = "--to-ascii")]
-    #[clap(about = "Convert hex data to text data")]
+    #[clap(about = "Convert hex data to an ASCII string.")]
     ToAscii { hexdata: Option<String> },
     #[clap(name = "--from-fix")]
-    #[clap(about = "Convert fixed point into specified number of decimals")]
+    #[clap(about = "Convert a fixed point number into an integer.")]
     FromFix {
         decimals: Option<u128>,
         #[clap(allow_hyphen_values = true)] // negative values not yet supported internally
         value: Option<String>,
     },
     #[clap(name = "--to-bytes32")]
-    #[clap(about = "Right-pads a hex bytes string to 32 bytes")]
+    #[clap(about = "Right-pads hex data to 32 bytes.")]
     ToBytes32 { bytes: Option<String> },
     #[clap(name = "--to-dec")]
-    #[clap(about = "Convert hex value into decimal number")]
+    #[clap(about = "Convert hex value into a decimal number.")]
     ToDec { hexvalue: Option<String> },
     #[clap(name = "--to-fix")]
-    #[clap(about = "Convert integers into fixed point with specified decimals")]
+    #[clap(about = "Convert an integer into a fixed point number.")]
     ToFix {
         decimals: Option<u128>,
         #[clap(allow_hyphen_values = true)] // negative values not yet supported internally
         value: Option<String>,
     },
     #[clap(name = "--to-uint256")]
-    #[clap(about = "Convert a number into uint256 hex string with 0x prefix")]
+    #[clap(about = "Convert a number to a hex-encoded uint256.")]
     ToUint256 { value: Option<String> },
     #[clap(name = "--to-int256")]
-    #[clap(about = "Convert a number into int256 hex string with 0x prefix")]
+    #[clap(about = "Convert a number to a hex-encoded int256.")]
     ToInt256 { value: Option<String> },
     #[clap(name = "--to-unit")]
     #[clap(
-        about = r#"Convert an ETH amount into a specified unit: ether, gwei or wei (default: wei).
-    Usage:
+        about = "Convert an ETH amount into another unit (ether, gwei or wei).",
+        long_about = r#"Convert an ETH amount into another unit (ether, gwei or wei).
+
+    Examples:
       - 1ether wei     | converts 1 ether to wei
       - "1 ether" wei  | converts 1 ether to wei
       - 1ether         | converts 1 ether to wei
@@ -89,9 +95,13 @@ pub enum Subcommands {
       - 1gwei ether    | converts 1 gwei to ether
     "#
     )]
-    ToUnit { value: Option<String>, unit: Option<String> },
+    ToUnit {
+        value: Option<String>,
+        #[clap(help = "The unit to convert to (ether, gwei, wei).", default_value = "wei")]
+        unit: String,
+    },
     #[clap(name = "--to-wei")]
-    #[clap(about = "Convert an ETH amount into wei. Consider using --to-unit.")]
+    #[clap(about = "Convert an ETH amount to wei. Consider using --to-unit.")]
     ToWei {
         #[clap(allow_hyphen_values = true)] // negative values not yet supported internally
         value: Option<String>,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -570,7 +570,7 @@ pub enum Subcommands {
         #[clap(long, env = "ETHERSCAN_API_KEY")]
         etherscan_api_key: String,
     },
-    #[clap(name = "wallet", about = "Set of wallet management utilities")]
+    #[clap(name = "wallet", about = "Wallet management utilities.")]
     Wallet {
         #[clap(subcommand)]
         command: WalletSubcommands,
@@ -617,57 +617,57 @@ pub enum Subcommands {
 
 #[derive(Debug, Parser)]
 pub enum WalletSubcommands {
-    #[clap(name = "new", about = "Create and output a new random keypair")]
+    #[clap(name = "new", about = "Create a new random keypair.")]
     New {
-        #[clap(help = "If provided, then keypair will be written to encrypted json keystore")]
+        #[clap(help = "If provided, then keypair will be written to an encrypted JSON keystore.")]
         path: Option<String>,
         #[clap(
             long,
             short,
-            help = "Triggers a hidden password prompt for the json keystore",
+            help = "Triggers a hidden password prompt for the JSON keystore.",
             conflicts_with = "unsafe-password",
             requires = "path"
         )]
         password: bool,
         #[clap(
             long,
-            help = "Password for json keystore in cleartext. This is UNSAFE to use and we recommend using the --password parameter",
+            help = "Password for the JSON keystore in cleartext. This is UNSAFE to use and we recommend using the --password.",
             requires = "path",
             env = "CAST_PASSWORD"
         )]
         unsafe_password: Option<String>,
     },
-    #[clap(name = "vanity", about = "Generate a vanity address")]
+    #[clap(name = "vanity", about = "Generate a vanity address.")]
     Vanity {
-        #[clap(long, help = "Prefix for vanity address", required_unless_present = "ends-with")]
+        #[clap(long, help = "Prefix for vanity address.", required_unless_present = "ends-with")]
         starts_with: Option<String>,
-        #[clap(long, help = "Suffix for vanity address")]
+        #[clap(long, help = "Suffix for vanity address.")]
         ends_with: Option<String>,
         #[clap(
             long,
-            help = "Generate a vanity contract address created by the generated account with specified nonce"
+            help = "Generate a vanity contract address created by the generated account with specified nonce."
         )]
         nonce: Option<u64>, /* 2^64-1 is max possible nonce per https://eips.ethereum.org/EIPS/eip-2681 */
     },
-    #[clap(name = "address", about = "Convert a private key to an address")]
+    #[clap(name = "address", about = "Convert a private key to an address.")]
     Address {
         #[clap(flatten)]
         wallet: Wallet,
     },
-    #[clap(name = "sign", about = "Sign the message with provided private key")]
+    #[clap(name = "sign", about = "Sign a message.")]
     Sign {
         #[clap(help = "message to sign")]
         message: String,
         #[clap(flatten)]
         wallet: Wallet,
     },
-    #[clap(name = "verify", about = "Verify the signature on the message")]
+    #[clap(name = "verify", about = "Verify the signature of a message.")]
     Verify {
-        #[clap(help = "original message")]
+        #[clap(help = "The original message.")]
         message: String,
-        #[clap(help = "signature to verify")]
+        #[clap(help = "The signature to verify.")]
         signature: String,
-        #[clap(long, short, help = "pubkey of message signer")]
+        #[clap(long, short, help = "The public key of the message signer.")]
         address: String,
     },
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -366,11 +366,11 @@ pub enum Subcommands {
     #[clap(about = "Compute the storage slot for an entry in a mapping.")]
     Index {
         #[clap(help = "The mapping key type.")]
-        from_type: String,
+        key_type: String,
         #[clap(help = "The mapping value type.")]
-        to_type: String,
+        value_type: String,
         #[clap(help = "The mapping key.")]
-        from_value: String,
+        key: String,
         #[clap(help = "The storage slot of the mapping.")]
         slot_number: String,
     },

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -14,13 +14,13 @@ use std::{path::PathBuf, str::FromStr};
 #[clap(about = "Perform Ethereum RPC calls from the comfort of your command line.")]
 pub enum Subcommands {
     #[clap(name = "--max-int")]
-    #[clap(about = "Maximum i256 value")]
+    #[clap(about = "Get the maximum i256 value.")]
     MaxInt,
     #[clap(name = "--min-int")]
-    #[clap(about = "Minimum i256 value")]
+    #[clap(about = "Get the minimum i256 value.")]
     MinInt,
     #[clap(name = "--max-uint")]
-    #[clap(about = "Maximum u256 value")]
+    #[clap(about = "Get the maximum u256 value.")]
     MaxUint,
     #[clap(aliases = &["--from-ascii"])]
     #[clap(name = "--from-utf8")]
@@ -30,7 +30,7 @@ pub enum Subcommands {
     #[clap(about = "Convert an integer to hex.")]
     ToHex { decimal: Option<String> },
     #[clap(name = "--concat-hex")]
-    #[clap(about = "Concatencate hex strings")]
+    #[clap(about = "Concatencate hex strings.")]
     ConcatHex { data: Vec<String> },
     #[clap(name = "--from-bin")]
     #[clap(about = "Convert binary data into hex data.")]
@@ -51,7 +51,7 @@ pub enum Subcommands {
     ToHexdata { input: Option<String> },
     #[clap(aliases = &["--to-checksum"])] // Compatibility with dapptools' cast
     #[clap(name = "--to-checksum-address")]
-    #[clap(about = "Convert an address to a checksummed format (EIP-55)")]
+    #[clap(about = "Convert an address to a checksummed format (EIP-55).")]
     ToCheckSumAddress { address: Option<Address> },
     #[clap(name = "--to-ascii")]
     #[clap(about = "Convert hex data to an ASCII string.")]
@@ -115,13 +115,21 @@ pub enum Subcommands {
         unit: Option<String>,
     },
     #[clap(name = "access-list")]
-    #[clap(about = "Create an access list for a transaction")]
+    #[clap(about = "Create an access list for a transaction.")]
     AccessList {
-        #[clap(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "The destination of the transaction.", parse(try_from_str = parse_name_or_address))]
         address: NameOrAddress,
+        #[clap(help = "The signature of the function to call.")]
         sig: String,
+        #[clap(help = "The arguments of the function to call.")]
         args: Vec<String>,
-        #[clap(long, short, help = "the block you want to query, can also be earliest/latest/pending", parse(try_from_str = parse_block_id))]
+        #[clap(
+            long,
+            short = 'B',
+            help = "The block height you want to query at.",
+            long_help = "The block height you want to query at. Can also be the tags earliest, latest, or pending.",
+            parse(try_from_str = parse_block_id)
+        )]
         block: Option<BlockId>,
         #[clap(flatten)]
         eth: EthereumOpts,
@@ -189,13 +197,13 @@ pub enum Subcommands {
         rpc_url: String,
     },
     #[clap(name = "compute-address")]
-    #[clap(about = "Returns the computed address from a given address and nonce pair")]
+    #[clap(about = "Compute the contract address from a given nonce and deployer address.")]
     ComputeAddress {
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
-        #[clap(help = "the address to create from")]
+        #[clap(help = "The deployer address.")]
         address: String,
-        #[clap(long, help = "address nonce", parse(try_from_str = parse_u256))]
+        #[clap(long, help = "The nonce of the deployer address.", parse(try_from_str = parse_u256))]
         nonce: Option<U256>,
     },
     #[clap(name = "namehash")]
@@ -355,17 +363,15 @@ pub enum Subcommands {
         args: Vec<String>,
     },
     #[clap(name = "index")]
-    #[clap(
-        about = "Get storage slot of value from mapping type, mapping slot number and input value"
-    )]
+    #[clap(about = "Compute the storage slot for an entry in a mapping.")]
     Index {
-        #[clap(help = "mapping key type")]
+        #[clap(help = "The mapping key type.")]
         from_type: String,
-        #[clap(help = "mapping value type")]
+        #[clap(help = "The mapping value type.")]
         to_type: String,
-        #[clap(help = "the value")]
+        #[clap(help = "The mapping key.")]
         from_value: String,
-        #[clap(help = "storage slot of the mapping")]
+        #[clap(help = "The storage slot of the mapping.")]
         slot_number: String,
     },
     #[clap(name = "4byte")]
@@ -476,7 +482,7 @@ pub enum Subcommands {
         rpc_url: String,
     },
     #[clap(name = "keccak")]
-    #[clap(about = "Keccak-256 hashes arbitrary data")]
+    #[clap(about = "Hash arbitrary data using keccak-256.")]
     Keccak { data: String },
     #[clap(name = "resolve-name")]
     #[clap(about = "Perform an ENS lookup.")]
@@ -571,23 +577,33 @@ pub enum Subcommands {
     },
     #[clap(
         name = "interface",
-        about = "Generate contract's interface from ABI. Currently it doesn't support ABI encoder V2"
+        about = "Generate a Solidity interface from a given ABI.",
+        long_about = "Generate a Solidity interface from a given ABI. Currently does not support ABI encoder v2."
     )]
     Interface {
-        #[clap(help = "The contract address or path to ABI file")]
+        #[clap(
+            help = "The contract address, or the path to an ABI file.",
+            long_help = "The contract address, or the path to an ABI file.
+
+            If an address is specified, then the ABI is fetched from Etherscan."
+        )]
         path_or_address: String,
-        #[clap(long, short, default_value = "^0.8.10", help = "pragma version")]
+        #[clap(long, short, default_value = "^0.8.10", help = "Solidity pragma version.")]
         pragma: String,
-        #[clap(short, help = "Path to output file. Defaults to stdout")]
+        #[clap(
+            short,
+            help = "The path to the output file.",
+            long_help = "The path to the output file. If not specified, the interface will be output to stdout."
+        )]
         output_location: Option<PathBuf>,
         #[clap(short, env = "ETHERSCAN_API_KEY", help = "etherscan API key")]
         etherscan_api_key: Option<String>,
         #[clap(flatten)]
         chain: ClapChain,
     },
-    #[clap(name = "sig", about = "Print a function's 4-byte selector")]
+    #[clap(name = "sig", about = "Get the selector for a function.")]
     Sig {
-        #[clap(help = "The human-readable function signature, e.g. 'transfer(address,uint256)'")]
+        #[clap(help = "The function signature, e.g. transfer(address,uint256).")]
         sig: String,
     },
     #[clap(name = "find-block", about = "Get the block number closest to the provided timestamp.")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -132,6 +132,7 @@ pub enum Subcommands {
         )]
         block: Option<BlockId>,
         #[clap(flatten)]
+        // TODO: We only need RPC URL + etherscan stuff from this struct
         eth: EthereumOpts,
         #[clap(long = "json", short = 'j')]
         to_json: bool,
@@ -595,7 +596,7 @@ pub enum Subcommands {
             long_help = "The path to the output file. If not specified, the interface will be output to stdout."
         )]
         output_location: Option<PathBuf>,
-        #[clap(short, env = "ETHERSCAN_API_KEY", help = "etherscan API key")]
+        #[clap(long, short, env = "ETHERSCAN_API_KEY", help = "etherscan API key")]
         etherscan_api_key: Option<String>,
         #[clap(flatten)]
         chain: ClapChain,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -639,13 +639,17 @@ pub enum WalletSubcommands {
     },
     #[clap(name = "vanity", about = "Generate a vanity address.")]
     Vanity {
-        #[clap(long, help = "Prefix for vanity address.", required_unless_present = "ends-with")]
+        #[clap(
+            long,
+            help = "Prefix for the vanity address.",
+            required_unless_present = "ends-with"
+        )]
         starts_with: Option<String>,
-        #[clap(long, help = "Suffix for vanity address.")]
+        #[clap(long, help = "Suffix for the vanity address.")]
         ends_with: Option<String>,
         #[clap(
             long,
-            help = "Generate a vanity contract address created by the generated account with specified nonce."
+            help = "Generate a vanity contract address created by the generated keypair with the specified nonce."
         )]
         nonce: Option<u64>, /* 2^64-1 is max possible nonce per https://eips.ethereum.org/EIPS/eip-2681 */
     },
@@ -667,7 +671,7 @@ pub enum WalletSubcommands {
         message: String,
         #[clap(help = "The signature to verify.")]
         signature: String,
-        #[clap(long, short, help = "The public key of the message signer.")]
+        #[clap(long, short, help = "The address of the message signer.")]
         address: String,
     },
 }

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -169,10 +169,7 @@ pub enum Subcommands {
     Calldata {
         #[clap(
             help = "The function signature.",
-            long_help = "
-            The function signature in the form <name>(<types>...), or if the value given contains at least one slash character, then it is treated the path to a file.
-
-            The file is treated as if the contents were passed as hexadecimal data."
+            long_help = "The function signature in the form <name>(<types...>)"
         )]
         sig: String,
         #[clap(allow_hyphen_values = true)]
@@ -306,6 +303,7 @@ pub enum Subcommands {
         raw_tx: String,
         #[clap(long, env = "CAST_ASYNC")]
         cast_async: bool,
+        // FIXME: We only need the RPC URL and `--flashbots` options from this.
         #[clap(flatten)]
         eth: EthereumOpts,
     },
@@ -328,6 +326,7 @@ pub enum Subcommands {
         )]
         value: Option<U256>,
         #[clap(flatten)]
+        // TODO: We only need RPC URL and Etherscan API key here.
         eth: EthereumOpts,
     },
     #[clap(name = "--calldata-decode")]
@@ -350,7 +349,7 @@ pub enum Subcommands {
         sig: String,
         #[clap(help = "The ABI-encoded calldata.")]
         calldata: String,
-        #[clap(long, short, help = "The ABI-encoded output data.")]
+        #[clap(long, short, help = "Decode input data.")]
         input: bool,
     },
     #[clap(name = "abi-encode")]
@@ -375,7 +374,7 @@ pub enum Subcommands {
         slot_number: String,
     },
     #[clap(name = "4byte")]
-    #[clap(about = "Get the function signatures for the given the selector from 4byte.directory.")]
+    #[clap(about = "Get the function signatures for the given selector from 4byte.directory.")]
     FourByte {
         #[clap(help = "The function selector.")]
         selector: String,
@@ -553,7 +552,7 @@ pub enum Subcommands {
             parse(try_from_str = parse_block_id)
         )]
         block: Option<BlockId>,
-        #[clap(help = "the address you want to query", parse(try_from_str = parse_name_or_address))]
+        #[clap(help = "The address you want to get the nonce for.", parse(try_from_str = parse_name_or_address))]
         who: NameOrAddress,
         #[clap(short, long, env = "ETH_RPC_URL")]
         rpc_url: String,

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -147,16 +147,17 @@ pub enum Subcommands {
     #[clap(name = "call")]
     #[clap(about = "Perform a call on an account without publishing a transaction.")]
     Call(CallArgs),
-    #[clap(about = "Pack a signature and an argument list into hexadecimal calldata.")]
+    #[clap(about = "ABI-encode a function with arguments.")]
     Calldata {
         #[clap(
-            help = r#"When called with <sig> of the form <name>(<types>...), then perform ABI encoding to produce the hexadecimal calldata.
-        If the value given—containing at least one slash character—then treat it as a file name to read, and proceed as if the contents were passed as hexadecimal data.
-        Given data, ensure it is hexadecimal calldata starting with 0x and normalize it to lowercase.
-        "#
+            help = "The function signature.",
+            long_help = "
+            The function signature in the form <name>(<types>...), or if the value given contains at least one slash character, then it is treated the path to a file.
+
+            The file is treated as if the contents were passed as hexadecimal data."
         )]
         sig: String,
-        #[clap(allow_hyphen_values = true)] // negative values not yet supported internally
+        #[clap(allow_hyphen_values = true)]
         args: Vec<String>,
     },
     #[clap(name = "chain")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -1,13 +1,10 @@
 use super::{ClapChain, EthereumOpts, Wallet};
 use crate::{
     cmd::cast::{call::CallArgs, find_block::FindBlockArgs},
-    utils::parse_u256,
+    utils::{parse_ether_value, parse_u256},
 };
 use clap::{Parser, Subcommand, ValueHint};
-use ethers::{
-    abi::token::{LenientTokenizer, Tokenizer},
-    types::{Address, BlockId, BlockNumber, NameOrAddress, H256, U256},
-};
+use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H256, U256};
 use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, Subcommand)]
@@ -134,7 +131,7 @@ Examples:
         #[clap(flatten)]
         // TODO: We only need RPC URL + etherscan stuff from this struct
         eth: EthereumOpts,
-        #[clap(long = "json", short = 'j')]
+        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
         to_json: bool,
     },
     #[clap(name = "block")]
@@ -152,7 +149,7 @@ Examples:
         full: bool,
         #[clap(long, short, help = "If specified, only get the given field of the block.")]
         field: Option<String>,
-        #[clap(long = "json", short = 'j')]
+        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
@@ -212,7 +209,7 @@ Examples:
     Tx {
         hash: String,
         field: Option<String>,
-        #[clap(long = "json", short = 'j')]
+        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
@@ -232,7 +229,7 @@ Examples:
         confirmations: usize,
         #[clap(long, env = "CAST_ASYNC")]
         cast_async: bool,
-        #[clap(long = "json", short = 'j')]
+        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
         to_json: bool,
         #[clap(long, env = "ETH_RPC_URL")]
         rpc_url: String,
@@ -253,7 +250,7 @@ Examples:
         gas: Option<U256>,
         #[clap(
             long = "gas-price",
-            help = "Gas price for the transaction.",
+            help = "Gas price for legacy transactions, or max fee per gas for EIP1559 transactions.",
             env = "ETH_GAS_PRICE",
             parse(try_from_str = parse_ether_value)
         )]
@@ -288,7 +285,7 @@ This is automatically enabled for common networks without EIP1559."#
             default_value = "1"
         )]
         confirmations: usize,
-        #[clap(long = "json", short = 'j')]
+        #[clap(long = "json", short = 'j', help_heading = "DISPLAY OPTIONS")]
         to_json: bool,
         #[clap(
             long = "resend",
@@ -700,14 +697,6 @@ fn parse_slot(s: &str) -> eyre::Result<H256> {
         H256::from_str(&padded)?
     } else {
         H256::from_low_u64_be(u64::from_str(s)?)
-    })
-}
-
-fn parse_ether_value(value: &str) -> eyre::Result<U256> {
-    Ok(if value.starts_with("0x") {
-        U256::from_str(value)?
-    } else {
-        U256::from(LenientTokenizer::tokenize_uint(value)?)
     })
 }
 

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -11,7 +11,10 @@ use ethers::{
 use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, Subcommand)]
-#[clap(about = "Perform Ethereum RPC calls from the comfort of your command line.")]
+#[clap(
+    about = "Perform Ethereum RPC calls from the comfort of your command line.",
+    after_help = "Find more information in the book: http://book.getfoundry.sh/reference/cast/cast.html"
+)]
 pub enum Subcommands {
     #[clap(name = "--max-int")]
     #[clap(about = "Get the maximum i256 value.")]

--- a/cli/src/opts/cast.rs
+++ b/cli/src/opts/cast.rs
@@ -40,16 +40,14 @@ pub enum Subcommands {
     FromBin,
     #[clap(name = "--to-hexdata")]
     #[clap(
-        about = "
-    Normalize the input to lowercase, 0x-prefixed hex. See --help for more info.",
-        long_about = "Normalize the input to lowercase, 0x-prefixed hex.
+        about = "Normalize the input to lowercase, 0x-prefixed hex. See --help for more info.",
+        long_about = r#"Normalize the input to lowercase, 0x-prefixed hex.
 
-    The input can be:
-      - mixed case hex with or without 0x prefix
-      - 0x prefixed hex, concatenated with a ':'
-      - an absolute path to file
-      - @tag, where the tag is defined in an environment variable
-    "
+The input can be:
+- mixed case hex with or without 0x prefix
+- 0x prefixed hex, concatenated with a ':'
+- an absolute path to file
+- @tag, where the tag is defined in an environment variable"#
     )]
     ToHexdata { input: Option<String> },
     #[clap(aliases = &["--to-checksum"])] // Compatibility with dapptools' cast
@@ -88,15 +86,14 @@ pub enum Subcommands {
     #[clap(name = "--to-unit")]
     #[clap(
         about = "Convert an ETH amount into another unit (ether, gwei or wei).",
-        long_about = r#"Convert an ETH amount into another unit (ether, gwei or wei).
+        long_about = r#"Convert an ETH amount into another unit (ether, gwei or wei).\
 
-    Examples:
-      - 1ether wei     | converts 1 ether to wei
-      - "1 ether" wei  | converts 1 ether to wei
-      - 1ether         | converts 1 ether to wei
-      - 1 gwei         | converts 1 wei to gwei
-      - 1gwei ether    | converts 1 gwei to ether
-    "#
+Examples:
+- 1ether wei
+- "1 ether" wei
+- 1ether
+- 1 gwei
+- 1gwei ether"#
     )]
     ToUnit {
         value: Option<String>,
@@ -264,9 +261,9 @@ pub enum Subcommands {
         #[clap(
             long,
             help = "Ether to send in the transaction.",
-            long_help = "Ether to send in the transaction, either specified in wei, or as a string with a unit type.
+            long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
 
-            Examples: 1ether, 10gwei, 0.01ether",
+Examples: 1ether, 10gwei, 0.01ether"#,
             parse(try_from_str = parse_ether_value)
         )]
         value: Option<U256>,
@@ -279,9 +276,9 @@ pub enum Subcommands {
         #[clap(
             long,
             help = "Send a legacy transaction instead of an EIP1559 transaction.",
-            long_help = "Send a legacy transaction instead of an EIP1559 transaction.
+            long_help = r#"Send a legacy transaction instead of an EIP1559 transaction.
 
-            This is automatically enabled for common networks without EIP1559."
+This is automatically enabled for common networks without EIP1559."#
         )]
         legacy: bool,
         #[clap(
@@ -323,9 +320,9 @@ pub enum Subcommands {
         #[clap(
             long,
             help = "Ether to send in the transaction.",
-            long_help = "Ether to send in the transaction, either specified in wei, or as a string with a unit type.
+            long_help = r#"Ether to send in the transaction, either specified in wei, or as a string with a unit type.
 
-            Examples: 1ether, 10gwei, 0.01ether",
+Examples: 1ether, 10gwei, 0.01ether"#,
             parse(try_from_str = parse_ether_value)
         )]
         value: Option<U256>,
@@ -344,9 +341,9 @@ pub enum Subcommands {
     #[clap(name = "--abi-decode")]
     #[clap(
         about = "Decode ABI-encoded input or output data",
-        long_about = "Decode ABI-encoded input or output data.
+        long_about = r#"Decode ABI-encoded input or output data.
 
-        Defaults to decoding output data. To decode input data pass --input or use cast --calldata-decode."
+Defaults to decoding output data. To decode input data pass --input or use cast --calldata-decode."#
     )]
     AbiDecode {
         #[clap(help = "The function signature in the format `<name>(<in-types>)(<out-types>)`.")]
@@ -391,11 +388,11 @@ pub enum Subcommands {
         #[clap(
             long,
             help = "The index of the resolved signature to use.",
-            long_help = "The index of the resolved signature to use.
+            long_help = r#"The index of the resolved signature to use.
 
-            4byte.directory can have multiple possible signatures for a given selector.
+4byte.directory can have multiple possible signatures for a given selector.
 
-            The index can also be earliest or latest."
+The index can also be earliest or latest."#
         )]
         id: Option<String>,
     },
@@ -408,9 +405,9 @@ pub enum Subcommands {
     #[clap(name = "pretty-calldata")]
     #[clap(
         about = "Pretty print calldata.",
-        long_about = "Pretty print calldata.
+        long_about = r#"Pretty print calldata.
 
-        Tries to decode the calldata using 4byte.directory unless --offline is passed."
+Tries to decode the calldata using 4byte.directory unless --offline is passed."#
     )]
     PrettyCalldata {
         #[clap(help = "The calldata.")]
@@ -586,9 +583,9 @@ pub enum Subcommands {
     Interface {
         #[clap(
             help = "The contract address, or the path to an ABI file.",
-            long_help = "The contract address, or the path to an ABI file.
+            long_help = r#"The contract address, or the path to an ABI file.
 
-            If an address is specified, then the ABI is fetched from Etherscan."
+If an address is specified, then the ABI is fetched from Etherscan."#
         )]
         path_or_address: String,
         #[clap(long, short, default_value = "^0.8.10", help = "Solidity pragma version.")]

--- a/cli/src/opts/evm.rs
+++ b/cli/src/opts/evm.rs
@@ -49,15 +49,14 @@ pub struct EvmArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fork_block_number: Option<u64>,
 
-    /// Disables storage caching entirely. This overrides any settings made in
-    /// [foundry_config::caching::StorageCachingConfig]
+    /// Explicitly disables the use of RPC caching.
+    ///
+    /// All storage slots are read entirely from the endpoint.
+    ///
+    /// This flag overrides the project's configuration file.
     ///
     /// See --fork-url.
-    #[clap(
-        long,
-        requires = "fork-url",
-        help = "Explicitly disables the use of storage. All storage slots are read entirely from the endpoint."
-    )]
+    #[clap(long, requires = "fork-url")]
     #[serde(skip)]
     pub no_storage_caching: bool,
 
@@ -72,7 +71,7 @@ pub struct EvmArgs {
     pub sender: Option<Address>,
 
     /// Enable the FFI cheatcode.
-    #[clap(help = "enables the FFI cheatcode", long)]
+    #[clap(help = "Enables the FFI cheatcode.", long)]
     #[serde(skip)]
     pub ffi: bool,
 
@@ -81,11 +80,11 @@ pub struct EvmArgs {
     /// Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
     ///
     /// Verbosity levels:
-    ///   2: Print logs for all tests
-    ///   3: Print execution traces for failing tests
-    ///   4: Print execution traces for all tests, and setup traces for failing tests
-    ///   5: Print execution and setup traces for all tests
-    #[clap(long, short, parse(from_occurrences))]
+    /// - 2: Print logs for all tests
+    /// - 3: Print execution traces for failing tests
+    /// - 4: Print execution traces for all tests, and setup traces for failing tests
+    /// - 5: Print execution and setup traces for all tests
+    #[clap(long, short, parse(from_occurrences), verbatim_doc_comment)]
     #[serde(skip)]
     pub verbosity: u8,
 

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -107,7 +107,7 @@ pub enum Subcommands {
     #[clap(about = "Remove the build artifacts and cache directories.")]
     Clean {
         #[clap(
-            help = "The project's root path, default being the current working directory",
+            help = "The project's root path. Defaults to the current working directory.",
             long,
             value_hint = ValueHint::DirPath
         )]

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -33,28 +33,32 @@ pub struct Opts {
 }
 
 #[derive(Debug, Subcommand)]
-#[clap(about = "Build, test, fuzz, formally verify, debug & deploy solidity contracts.")]
+#[clap(about = "Build, test, fuzz, debug and deploy Solidity contracts.")]
 #[allow(clippy::large_enum_variant)]
 pub enum Subcommands {
-    #[clap(about = "Test your smart contracts")]
+    #[clap(about = "Run the project's tests.")]
     #[clap(alias = "t")]
     Test(test::TestArgs),
 
-    #[clap(about = "Generate rust bindings for your smart contracts")]
+    #[clap(about = "Generate Rust bindings for smart contracts.")]
     Bind(BindArgs),
 
-    #[clap(about = "Build your smart contracts")]
+    #[clap(about = "Build the project's smart contracts.")]
     #[clap(alias = "b")]
     Build(BuildArgs),
 
-    #[clap(about = "Run a single smart contract as a script")]
+    #[clap(about = "Run a single smart contract as a script.")]
     #[clap(alias = "r")]
     Run(RunArgs),
 
-    #[clap(alias = "u", about = "Fetches all upstream lib changes")]
+    #[clap(
+        alias = "u",
+        about = "Update one or multiple dependencies.",
+        long_about = "Update one or multiple dependencies. If no arguments are provided, then all dependencies are updated."
+    )]
     Update {
         #[clap(
-            help = "The submodule name of the library you want to update (will update all if none is provided)",
+            help = "The path to the dependency you want to update.",
             value_hint = ValueHint::DirPath
         )]
         lib: Option<PathBuf>,
@@ -62,33 +66,36 @@ pub enum Subcommands {
 
     #[clap(
         alias = "i",
-        about = "Installs one or more dependencies as git submodules (will install existing dependencies if no arguments are provided)"
+        about = "Install one or multiple dependencies.",
+        long_about = "Install one or more dependencies as git submodules. If no arguments are provided, then existing dependencies will be installed."
     )]
     Install(InstallArgs),
 
-    #[clap(alias = "rm", about = "Removes one or more dependencies from git submodules")]
+    #[clap(alias = "rm", about = "Remove one or multiple dependencies.")]
     Remove {
-        #[clap(help = "The submodule name of the library you want to remove")]
+        #[clap(help = "The path to the dependency you want to remove.")]
         dependencies: Vec<Dependency>,
     },
 
-    #[clap(about = "Prints the automatically inferred remappings for this repository")]
+    #[clap(about = "Get the automatically inferred remappings for this project.")]
     Remappings(RemappingArgs),
 
     #[clap(
-        about = "Verify your smart contracts source code on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
+        about = "Verify smart contracts on Etherscan.",
+        long_about = "Verify smart contracts on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
     )]
     VerifyContract(VerifyArgs),
 
     #[clap(
-        about = "Check verification status on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
+        about = "Check verification status on Etherscan.",
+        long_about = "Check verification status on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
     )]
     VerifyCheck(VerifyCheckArgs),
 
-    #[clap(alias = "c", about = "Deploy a compiled contract")]
+    #[clap(alias = "c", about = "Deploy a smart contract.")]
     Create(CreateArgs),
 
-    #[clap(alias = "i", about = "Initializes a new forge sample project")]
+    #[clap(alias = "i", about = "Create a new Forge project.")]
     Init(InitArgs),
 
     #[clap(about = "Generate shell completions script")]
@@ -97,7 +104,7 @@ pub enum Subcommands {
         shell: clap_complete::Shell,
     },
 
-    #[clap(about = "Removes the build artifacts and cache directories")]
+    #[clap(about = "Remove the build artifacts and cache directories.")]
     Clean {
         #[clap(
             help = "The project's root path, default being the current working directory",
@@ -107,19 +114,19 @@ pub enum Subcommands {
         root: Option<PathBuf>,
     },
 
-    #[clap(about = "Creates a snapshot of each test's gas usage")]
+    #[clap(about = "Create a snapshot of each test's gas usage.")]
     Snapshot(snapshot::SnapshotArgs),
 
-    #[clap(about = "Shows the currently set config values")]
+    #[clap(about = "Display the current config.")]
     Config(config::ConfigArgs),
 
-    #[clap(about = "Concats a file with all of its imports")]
+    #[clap(about = "Flatten a source file and all of its imports into one file.")]
     Flatten(flatten::FlattenArgs),
     // #[clap(about = "formats Solidity source files")]
     // Fmt(FmtArgs),
-    #[clap(about = "Outputs a contract in a specified format (ir, assembly, ...)")]
+    #[clap(about = "Get specialized information about a smart contract")]
     Inspect(inspect::InspectArgs),
-    #[clap(about = "Display a tree visualization of the project's dependency graph")]
+    #[clap(about = "Display a tree visualization of the project's dependency graph.")]
     Tree(tree::TreeArgs),
 }
 

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -64,11 +64,10 @@ pub enum Subcommands {
         lib: Option<PathBuf>,
     },
 
-    #[clap(
-        alias = "i",
-        about = "Install one or multiple dependencies.",
-        long_about = "Install one or more dependencies as git submodules. If no arguments are provided, then existing dependencies will be installed."
-    )]
+    /// Install one or multiple dependencies.
+    ///
+    /// If no arguments are provided, then existing dependencies will be installed.
+    #[clap(alias = "i")]
     Install(InstallArgs),
 
     #[clap(alias = "rm", about = "Remove one or multiple dependencies.")]

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -33,7 +33,10 @@ pub struct Opts {
 }
 
 #[derive(Debug, Subcommand)]
-#[clap(about = "Build, test, fuzz, debug and deploy Solidity contracts.")]
+#[clap(
+    about = "Build, test, fuzz, debug and deploy Solidity contracts.",
+    after_help = "Find more information in the book: http://book.getfoundry.sh/reference/forge/forge.html"
+)]
 #[allow(clippy::large_enum_variant)]
 pub enum Subcommands {
     #[clap(about = "Run the project's tests.")]

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -76,7 +76,7 @@ pub enum Subcommands {
         dependencies: Vec<Dependency>,
     },
 
-    #[clap(about = "Get the automatically inferred remappings for this project.")]
+    #[clap(about = "Get the automatically inferred remappings for the project.")]
     Remappings(RemappingArgs),
 
     #[clap(

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -161,7 +161,7 @@ pub struct CompilerArgs {
 
     /// Extra output to write to separate files.
     ///
-    /// Valid values: metadata, ir, irOptimized, ewasm, assembly
+    /// Valid values: metadata, ir, irOptimized, ewasm, evm.assembly
     #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_output_files: Option<Vec<ContractOutputSelection>>,

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -81,13 +81,13 @@ pub enum Subcommands {
 
     #[clap(
         about = "Verify smart contracts on Etherscan.",
-        long_about = "Verify smart contracts on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
+        long_about = "Verify smart contracts on Etherscan."
     )]
     VerifyContract(VerifyArgs),
 
     #[clap(
         about = "Check verification status on Etherscan.",
-        long_about = "Check verification status on Etherscan. Requires `ETHERSCAN_API_KEY` to be set."
+        long_about = "Check verification status on Etherscan."
     )]
     VerifyCheck(VerifyCheckArgs),
 

--- a/cli/src/opts/forge.rs
+++ b/cli/src/opts/forge.rs
@@ -138,30 +138,31 @@ pub enum Subcommands {
 // See also [`BuildArgs`]
 #[derive(Default, Debug, Clone, Parser, Serialize)]
 pub struct CompilerArgs {
-    #[clap(help = "Choose the evm version", long)]
+    #[clap(help = "The target EVM version.", long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evm_version: Option<EvmVersion>,
 
-    #[clap(help = "Activate the solidity optimizer", long)]
-    // skipped because, optimize is opt-in
+    #[clap(help = "Activate the Solidity optimizer.", long)]
     #[serde(skip)]
     pub optimize: bool,
 
-    #[clap(help = "Optimizer parameter runs", long)]
+    #[clap(help = "The number of optimizer runs.", long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optimize_runs: Option<usize>,
 
-    #[clap(
-        help = "Extra output types to include in the contract's json artifact [evm.assembly, ewasm, ir, irOptimized, metadata] eg: `--extra-output evm.assembly`",
-        long
-    )]
+    /// Extra output to include in the contract's artifact.
+    ///
+    /// Example keys: evm.assembly, ewasm, ir, irOptimized, metadata
+    ///
+    /// For a full description, see https://docs.soliditylang.org/en/v0.8.13/using-the-compiler.html#input-description
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_output: Option<Vec<ContractOutputSelection>>,
 
-    #[clap(
-        help = "Extra output types to write to a separate file [metadata, ir, irOptimized, ewasm] eg: `--extra-output-files metadata`",
-        long
-    )]
+    /// Extra output to write to separate files.
+    ///
+    /// Valid values: metadata, ir, irOptimized, ewasm, assembly
+    #[clap(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_output_files: Option<Vec<ContractOutputSelection>>,
 }

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -189,28 +189,32 @@ The wallet options can either be:
 "#
 )]
 pub struct Wallet {
-    #[clap(long, short, help = "Interactive prompt to insert your private key")]
+    #[clap(long, short, help = "Open an interactive prompt to enter your private key.")]
     pub interactive: bool,
 
     #[clap(long = "private-key", help = "Your private key string")]
     pub private_key: Option<String>,
 
-    #[clap(env = "ETH_KEYSTORE", long = "keystore", help = "Path to your keystore folder / file")]
+    #[clap(
+        env = "ETH_KEYSTORE",
+        long = "keystore",
+        help = "The path to a keystore folder or file."
+    )]
     pub keystore_path: Option<String>,
 
     #[clap(long = "password", help = "Your keystore password", requires = "keystore-path")]
     pub keystore_password: Option<String>,
 
-    #[clap(long = "mnemonic-path", help = "Path to your mnemonic file")]
+    #[clap(long = "mnemonic-path", help = "Path to a mnemonic file.")]
     pub mnemonic_path: Option<String>,
 
-    #[clap(short, long = "ledger", help = "Use your Ledger hardware wallet")]
+    #[clap(short, long = "ledger", help = "Use your Ledger hardware wallet.")]
     pub ledger: bool,
 
-    #[clap(short, long = "trezor", help = "Use your Trezor hardware wallet")]
+    #[clap(short, long = "trezor", help = "Use your Trezor hardware wallet.")]
     pub trezor: bool,
 
-    #[clap(long = "hd-path", help = "Derivation path for your hardware wallet (trezor or ledger)")]
+    #[clap(long = "hd-path", help = "Derivation path for your hardware wallet.")]
     pub hd_path: Option<String>,
 
     #[clap(

--- a/cli/src/opts/mod.rs
+++ b/cli/src/opts/mod.rs
@@ -29,6 +29,7 @@ use serde::Serialize;
 const FLASHBOTS_URL: &str = "https://rpc.flashbots.net";
 
 // Helper for exposing enum values for `Chain`
+// TODO: Is this a duplicate of config/src/chain.rs?
 #[derive(Debug, Clone, Parser)]
 pub struct ClapChain {
     #[clap(
@@ -60,15 +61,8 @@ pub struct ClapChain {
 
 #[derive(Parser, Debug, Clone, Serialize)]
 pub struct EthereumOpts {
-    #[clap(env = "ETH_RPC_URL", long = "rpc-url", help = "The tracing / archival node's URL")]
+    #[clap(env = "ETH_RPC_URL", long = "rpc-url", help = "The RPC endpoint.")]
     pub rpc_url: Option<String>,
-
-    #[clap(env = "ETH_FROM", short, long = "from", help = "The sender account")]
-    pub from: Option<Address>,
-
-    #[clap(flatten)]
-    #[serde(skip)]
-    pub wallet: Wallet,
 
     #[clap(long, help = "Use the flashbots RPC URL (https://rpc.flashbots.net)")]
     pub flashbots: bool,
@@ -79,6 +73,10 @@ pub struct EthereumOpts {
     #[clap(long, env = "CHAIN", default_value = "mainnet")]
     #[serde(skip)]
     pub chain: Chain,
+
+    #[clap(flatten, next_help_heading = "WALLET OPTIONS")]
+    #[serde(skip)]
+    pub wallet: Wallet,
 }
 
 impl EthereumOpts {
@@ -92,7 +90,7 @@ impl EthereumOpts {
                 WalletType::Trezor(signer) => signer.address(),
             }
         } else {
-            self.from.unwrap_or_else(Address::zero)
+            self.wallet.from.unwrap_or_else(Address::zero)
         }
     }
 
@@ -189,40 +187,83 @@ The wallet options can either be:
 "#
 )]
 pub struct Wallet {
-    #[clap(long, short, help = "Open an interactive prompt to enter your private key.")]
+    #[clap(
+        long,
+        short,
+        help_heading = "WALLET OPTIONS - RAW",
+        help = "Open an interactive prompt to enter your private key."
+    )]
     pub interactive: bool,
 
-    #[clap(long = "private-key", help = "Your private key string")]
+    #[clap(
+        long = "private-key",
+        help_heading = "WALLET OPTIONS - RAW",
+        help = "Use the provided private key."
+    )]
     pub private_key: Option<String>,
+
+    #[clap(
+        long = "mnemonic-path",
+        help_heading = "WALLET OPTIONS - RAW",
+        help = "Use the mnemonic file at the specified path."
+    )]
+    pub mnemonic_path: Option<String>,
+
+    #[clap(
+        long = "mnemonic-index",
+        help_heading = "WALLET OPTIONS - RAW",
+        help = "Use the private key from the given mnemonic index. Used with --mnemonic-path.",
+        default_value = "0"
+    )]
+    pub mnemonic_index: u32,
 
     #[clap(
         env = "ETH_KEYSTORE",
         long = "keystore",
-        help = "The path to a keystore folder or file."
+        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help = "Use the keystore in the given folder or file."
     )]
     pub keystore_path: Option<String>,
 
-    #[clap(long = "password", help = "Your keystore password", requires = "keystore-path")]
+    #[clap(
+        long = "password",
+        help_heading = "WALLET OPTIONS - KEYSTORE",
+        help = "The keystore password. Used with --keystore.",
+        requires = "keystore-path"
+    )]
     pub keystore_password: Option<String>,
 
-    #[clap(long = "mnemonic-path", help = "Path to a mnemonic file.")]
-    pub mnemonic_path: Option<String>,
-
-    #[clap(short, long = "ledger", help = "Use your Ledger hardware wallet.")]
+    #[clap(
+        short,
+        long = "ledger",
+        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
+        help = "Use a Ledger hardware wallet."
+    )]
     pub ledger: bool,
 
-    #[clap(short, long = "trezor", help = "Use your Trezor hardware wallet.")]
+    #[clap(
+        short,
+        long = "trezor",
+        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
+        help = "Use a Trezor hardware wallet."
+    )]
     pub trezor: bool,
 
-    #[clap(long = "hd-path", help = "Derivation path for your hardware wallet.")]
+    #[clap(
+        long = "hd-path",
+        help_heading = "WALLET OPTIONS - HARDWARE WALLET",
+        help = "The derivation path to use with hardware wallets."
+    )]
     pub hd_path: Option<String>,
 
     #[clap(
-        long = "mnemonic-index",
-        help = "your index in the standard hd path",
-        default_value = "0"
+        env = "ETH_FROM",
+        short,
+        long = "from",
+        help_heading = "WALLET OPTIONS - REMOTE",
+        help = "The sender account."
     )]
-    pub mnemonic_index: u32,
+    pub from: Option<Address>,
 }
 
 impl Wallet {
@@ -283,6 +324,7 @@ mod tests {
     #[test]
     fn illformed_private_key_generates_user_friendly_error() {
         let wallet = Wallet {
+            from: None,
             interactive: false,
             private_key: Some("123".to_string()),
             keystore_path: None,

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,13 +1,16 @@
+use ethers::{
+    abi::token::{LenientTokenizer, Tokenizer},
+    solc::EvmVersion,
+    types::U256,
+};
+use forge::executor::{opts::EvmOpts, Fork, SpecId};
+use foundry_config::{caching::StorageCachingConfig, Config};
 use std::{
     future::Future,
     path::{Path, PathBuf},
     str::FromStr,
     time::Duration,
 };
-
-use ethers::{solc::EvmVersion, types::U256};
-use forge::executor::{opts::EvmOpts, Fork, SpecId};
-use foundry_config::{caching::StorageCachingConfig, Config};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
 
@@ -124,6 +127,20 @@ pub fn get_file_name(id: &str) -> &str {
 /// parse a hex str or decimal str as U256
 pub fn parse_u256(s: &str) -> eyre::Result<U256> {
     Ok(if s.starts_with("0x") { U256::from_str(s)? } else { U256::from_dec_str(s)? })
+}
+
+/// Parses an ether value from a string.
+///
+/// The amount can be tagged with a unit, e.g. "1ether".
+///
+/// If the string represents an untagged amount (e.g. "100") then
+/// it is interpreted as wei.
+pub fn parse_ether_value(value: &str) -> eyre::Result<U256> {
+    Ok(if value.starts_with("0x") {
+        U256::from_str(value)?
+    } else {
+        U256::from(LenientTokenizer::tokenize_uint(value)?)
+    })
 }
 
 /// Parses a `Duration` from a &str


### PR DESCRIPTION
## Motivation

The output of `-h` and `--help` is inconsistent and sometimes not super helpful.

## Solution

Goes through all help text and updates the wording. I also move some of the longer-form help text into `long_help` to shorten the output of `-h`.

I'm going through this as I am rewriting the command references in the book.

**Tasks**

- [x] Go through the rest of Cast
- [x] Go through the rest of Forge
- [x] Be consistent with the help text of function signatures and block tags
- [x] Note down commands that are good candidates for merging
- [x] Improve docs on `Wallet` struct
- [x] Remove unused options in each command (deferred to #1274)
- [x] Link to the book at the end of `-h`/`--help`