### PR TITLE
Support case insensitive setup method

### DIFF
--- a/evm/src/executor/mod.rs
+++ b/evm/src/executor/mod.rs
@@ -216,8 +216,19 @@ where
     }
 
     /// Calls the `setUp()` function on a contract.
-    pub fn setup(&mut self, address: Address) -> std::result::Result<CallResult<()>, EvmError> {
-        self.call_committing::<(), _, _>(*CALLER, address, "setUp()", (), 0.into(), None)
+    pub fn setup(
+        &mut self,
+        address: Address,
+        func_name: &str,
+    ) -> std::result::Result<CallResult<()>, EvmError> {
+        self.call_committing::<(), _, _>(
+            *CALLER,
+            address,
+            format!("{}()", func_name),
+            (),
+            0.into(),
+            None,
+        )
     }
 
     /// Performs a call to an account on the current state of the VM.

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -367,6 +367,7 @@ mod tests {
                         None,
                     )],
                 ),
+                ("core/LowercaseSetup.t.sol:LowercaseSetup", vec![("testSetup()", true, None, None)]),
                 (
                     "core/Reverting.t.sol:RevertingTest",
                     vec![("testFailRevert()", true, None, None)],

--- a/testdata/core/LowercaseSetup.t.sol
+++ b/testdata/core/LowercaseSetup.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+
+contract LowercaseSetup is DSTest {
+    uint256 two;
+
+    function setup() public {
+        two = 2;
+    }
+
+    function testSetup() public {
+        assertEq(two, 2);
+    }
+}


### PR DESCRIPTION
## Motivation

Consensus on this issue seemed to be to make setup case insensitive. Seemed like reasonable approach.

https://github.com/gakonst/foundry/issues/1167

## Solution

Match against the lower case method name for "setup", then pass the matched function name into the executor.
NB: not really a rust guy so pray tell if this is not a good solution 🖖😅
