### PR TITLE
test(verify): add testing support for etherscan verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ name = "foundry-cli-test-utils"
 version = "0.1.0"
 dependencies = [
  "ethers-solc",
+ "eyre",
  "foundry-config",
  "once_cell",
  "parking_lot 0.12.0",

--- a/cli/test-utils/Cargo.toml
+++ b/cli/test-utils/Cargo.toml
@@ -16,3 +16,4 @@ once_cell = "1.9.0"
 foundry-config = { path = "../../config" }
 serde_json = "1.0.67"
 parking_lot = "0.12.0"
+eyre = "0.6"

--- a/cli/test-utils/src/lib.rs
+++ b/cli/test-utils/src/lib.rs
@@ -5,6 +5,6 @@ mod macros;
 
 // Utilities for making it easier to handle tests.
 pub mod util;
-pub use util::{TestCommand, TestProject};
+pub use util::{Retry, TestCommand, TestProject};
 
 pub use ethers_solc;

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -4,7 +4,9 @@ use ethers::types::Chain;
 use foundry_cli_test_utils::{
     forgetest,
     util::{TestCommand, TestProject},
+    Retry,
 };
+use std::time::Duration;
 
 fn etherscan_key() -> Option<String> {
     std::env::var("ETHERSCAN_API_KEY").ok()
@@ -25,32 +27,31 @@ struct VerifyExternalities {
     chain: Chain,
     rpc: String,
     pk: String,
-    etherscan: String
+    etherscan: String,
 }
 
 impl VerifyExternalities {
-
     fn goerli() -> Option<Self> {
         Some(Self {
             chain: Chain::Goerli,
             rpc: network_rpc_key("goerli")?,
             pk: network_private_key("goerli")?,
-            etherscan: etherscan_key()?
+            etherscan: etherscan_key()?,
         })
     }
 
-    fn commands(&self) -> Vec<String> {
+    /// Returns the arguments required to deploy the contract
+    fn create_args(&self) -> Vec<String> {
         vec![
             "--chain".to_string(),
             self.chain.to_string(),
-            "--rpc-url",
+            "--rpc-url".to_string(),
             self.rpc.clone(),
             "--private-key".to_string(),
             self.pk.clone(),
         ]
     }
 }
-
 
 /// Returns the current millis since unix epoch.
 ///
@@ -66,10 +67,11 @@ fn millis_since_epoch() -> u128 {
 /// `import {Unique} from "./unique.sol";`
 fn add_unique(prj: &TestProject) {
     let timestamp = millis_since_epoch();
-    prj.inner().add_source(
-        "unique",
-        format!(
-            r#"
+    prj.inner()
+        .add_source(
+            "unique",
+            format!(
+                r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.4.0;
 
@@ -77,17 +79,16 @@ contract Unique {{
     uint public _timpestamp = {};
 }}
 "#,
-            timestamp
-        ),
-    ).unwrap();
+                timestamp
+            ),
+        )
+        .unwrap();
 }
 
 // tests that direct import paths are handled correctly
 forgetest!(can_verify_random_contract, |prj: TestProject, mut cmd: TestCommand| {
     // only execute if keys present
     if let Some(info) = VerifyExternalities::goerli() {
-        let VerifyExternalities{rpc, pk, etherscan} = info;
-
         add_unique(&prj);
 
         prj.inner()
@@ -95,18 +96,99 @@ forgetest!(can_verify_random_contract, |prj: TestProject, mut cmd: TestCommand| 
                 "Verify.sol",
                 r#"
     // SPDX-License-Identifier: UNLICENSED
-    pragma solidity 0.8.10;
+    pragma solidity =0.8.10;
     import {Unique} from "./unique.sol";
-    contract ToVerify is Unique {
+    contract Verify is Unique {
         function doStuff() external {}
     }
        "#,
             )
             .unwrap();
 
-        cmd.arg("build");
-        cmd.print_output();
+        let contract_path = "src/Verify.sol:Verify";
 
+        cmd.arg("create");
+        cmd.args(info.create_args()).arg(contract_path);
+
+        let out = cmd.stdout_lossy();
+        let address = parse_deployed_address(out.as_str())
+            .unwrap_or_else(|| panic!("Failed to parse deployer {}", out));
+
+        cmd.forge_fuse().arg("verify-contract").root_arg().args([
+            "--chain-id".to_string(),
+            info.chain.to_string(),
+            "--compiler-version".to_string(),
+            "v0.8.10+commit.fc410830".to_string(),
+            "--optimizer-runs".to_string(),
+            "200".to_string(),
+            address.clone(),
+            contract_path.to_string(),
+            info.etherscan.to_string(),
+        ]);
+
+        // `verify-contract`
+        let guid = {
+            // give etherscan some time to detect the transaction
+            let retry = Retry::new(5, Some(Duration::from_secs(60)));
+            retry
+                .run(|| -> eyre::Result<String> {
+                    let output = cmd.unchecked_output();
+                    let out = String::from_utf8_lossy(&output.stdout);
+                    parse_verification_guid(&out).ok_or_else(|| {
+                        eyre::eyre!(
+                            "Failed to get guid, stdout: {}, stderr: {}",
+                            out,
+                            String::from_utf8_lossy(&output.stderr)
+                        )
+                    })
+                })
+                .expect("Failed to get verify guid")
+        };
+
+        // verify-check
+        {
+            cmd.forge_fuse()
+                .arg("verify-check")
+                .arg("--chain-id")
+                .arg(info.chain.to_string())
+                .arg(guid)
+                .arg(info.etherscan);
+
+            // give etherscan some time to verify the contract
+            let retry = Retry::new(6, Some(Duration::from_secs(30)));
+            retry
+                .run(|| -> eyre::Result<()> {
+                    let output = cmd.unchecked_output();
+                    let out = String::from_utf8_lossy(&output.stdout);
+                    if out.contains("Contract successfully verified") {
+                        return Ok(())
+                    }
+                    eyre::bail!(
+                        "Failed to get verfiication, stdout: {}, stderr: {}",
+                        out,
+                        String::from_utf8_lossy(&output.stderr)
+                    )
+                })
+                .expect("Failed to verify check")
+        }
     }
-
 });
+
+/// Parses the address the contract was deployed to
+fn parse_deployed_address(out: &str) -> Option<String> {
+    for line in out.lines() {
+        if line.starts_with("Deployed to") {
+            return Some(line.trim_start_matches("Deployed to: ").to_string())
+        }
+    }
+    None
+}
+
+fn parse_verification_guid(out: &str) -> Option<String> {
+    for line in out.lines() {
+        if line.contains("GUID") {
+            return Some(line.replace("GUID:", "").replace("`", "").trim().to_string())
+        }
+    }
+    None
+}

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -1,1 +1,109 @@
 //! Contains various tests for checking forge commands related to verifying contracts on etherscan
+
+use ethers::types::Chain;
+use foundry_cli_test_utils::{
+    forgetest,
+    util::{TestCommand, TestProject},
+};
+
+fn etherscan_key() -> Option<String> {
+    std::env::var("ETHERSCAN_API_KEY").ok()
+}
+
+fn network_rpc_key(chain: &str) -> Option<String> {
+    let key = format!("{}_RPC_URL", chain.to_uppercase());
+    std::env::var(&key).ok()
+}
+
+fn network_private_key(chain: &str) -> Option<String> {
+    let key = format!("{}_PRIVATE_KEY", chain.to_uppercase());
+    std::env::var(&key).ok()
+}
+
+/// Represents external input required for executing verification requests
+struct VerifyExternalities {
+    chain: Chain,
+    rpc: String,
+    pk: String,
+    etherscan: String
+}
+
+impl VerifyExternalities {
+
+    fn goerli() -> Option<Self> {
+        Some(Self {
+            chain: Chain::Goerli,
+            rpc: network_rpc_key("goerli")?,
+            pk: network_private_key("goerli")?,
+            etherscan: etherscan_key()?
+        })
+    }
+
+    fn commands(&self) -> Vec<String> {
+        vec![
+            "--chain".to_string(),
+            self.chain.to_string(),
+            "--rpc-url",
+        ]
+    }
+}
+
+
+/// Returns the current millis since unix epoch.
+///
+/// This way we generate unique contracts so, etherscan will always have to verify them
+fn millis_since_epoch() -> u128 {
+    let now = std::time::SystemTime::now();
+    now.duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_else(|err| panic!("Current time {:?} is invalid: {:?}", now, err))
+        .as_millis()
+}
+
+/// Adds a `Unique` contract to the source directory of the project that can be imported as
+/// `import {Unique} from "./unique.sol";`
+fn add_unique(prj: &TestProject) {
+    let timestamp = millis_since_epoch();
+    prj.inner().add_source(
+        "unique",
+        format!(
+            r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.4.0;
+
+contract Unique {{
+    uint public _timpestamp = {};
+}}
+"#,
+            timestamp
+        ),
+    ).unwrap();
+}
+
+// tests that direct import paths are handled correctly
+forgetest!(can_verify_random_contract, |prj: TestProject, mut cmd: TestCommand| {
+    // only execute if keys present
+    if let Some(info) = VerifyExternalities::goerli() {
+        let VerifyExternalities{rpc, pk, etherscan} = info;
+
+        add_unique(&prj);
+
+        prj.inner()
+            .add_source(
+                "Verify.sol",
+                r#"
+    // SPDX-License-Identifier: UNLICENSED
+    pragma solidity 0.8.10;
+    import {Unique} from "./unique.sol";
+    contract ToVerify is Unique {
+        function doStuff() external {}
+    }
+       "#,
+            )
+            .unwrap();
+
+        cmd.arg("build");
+        cmd.print_output();
+
+    }
+
+});

--- a/cli/tests/it/verify.rs
+++ b/cli/tests/it/verify.rs
@@ -44,6 +44,9 @@ impl VerifyExternalities {
             "--chain".to_string(),
             self.chain.to_string(),
             "--rpc-url",
+            self.rpc.clone(),
+            "--private-key".to_string(),
+            self.pk.clone(),
         ]
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
test
1. create
2. verify-contract
3. verify-chec

this is only executed if some env vars are set, currently only goerli is supported, but can easily be refactored once we figured out how to supply keys for this.

first this will deploy a new contract, we need to ensure that the bytecode is always different so we simply inject the current epoch milliseconds as var.

then try to to run the verify commands with retries configured, this can take a couple minutes.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
