### PR TITLE
Feature: warning for miss-cased setUp function

### DIFF
--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -106,7 +106,7 @@ impl Cmd for RunArgs {
         });
 
         if let Some(func_name) = invalid_setup_fn {
-            println!(
+            eprintln!(
                 "{} Found invalid setup function \"{}\" did you mean \"setUp()\"?",
                 Colour::Yellow.bold().paint("Warning:"),
                 func_name

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -96,25 +96,17 @@ impl Cmd for RunArgs {
         let CompactContractBytecode { abi, bytecode, .. } = contract;
         let abi = abi.expect("no ABI for contract");
         let bytecode = bytecode.expect("no bytecode for contract").object.into_bytes().unwrap();
-        let setup_fns: Vec<_> = abi
-            .functions()
-            .filter_map(|func| {
-                if func.name.to_lowercase() == "setup" {
-                    Some(func.signature())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let setup_fns: Vec<_> =
+            abi.functions().filter(|func| func.name.to_lowercase() == "setup").collect();
 
-        let needs_setup = setup_fns.len() == 1 && setup_fns[0] == "setUp";
+        let needs_setup = setup_fns.len() == 1 && setup_fns[0].name == "setUp";
 
         for setup_fn in setup_fns.iter() {
-            if setup_fn != "setUp" {
+            if setup_fn.name != "setUp" {
                 println!(
                     "{} Found invalid setup function \"{}\" did you mean \"setUp()\"?",
                     Colour::Yellow.bold().paint("Warning:"),
-                    setup_fn
+                    setup_fn.signature()
                 );
             }
         }

--- a/cli/src/cmd/forge/run.rs
+++ b/cli/src/cmd/forge/run.rs
@@ -97,6 +97,21 @@ impl Cmd for RunArgs {
         let abi = abi.expect("no ABI for contract");
         let bytecode = bytecode.expect("no bytecode for contract").object.into_bytes().unwrap();
         let needs_setup = abi.functions().any(|func| func.name == "setUp");
+        let invalid_setup_fn = abi.functions().find_map(|func| {
+            if func.name.to_lowercase() == "setup" && func.name != "setUp" {
+                Some(func.signature())
+            } else {
+                None
+            }
+        });
+
+        if let Some(func_name) = invalid_setup_fn {
+            println!(
+                "{} Found invalid setup function \"{}\" did you mean \"setUp()\"?",
+                Colour::Yellow.bold().paint("Warning:"),
+                func_name
+            );
+        }
 
         let runtime = RuntimeOrHandle::new();
         let env = runtime.block_on(evm_opts.evm_env());

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -481,6 +481,9 @@ fn test(
         for (contract_name, suite_result) in rx {
             let mut tests = suite_result.test_results.clone();
             println!();
+            for warning in suite_result.warnings.iter() {
+                println!("{} {}", Colour::Yellow.bold().paint("Warning:"), warning);
+            }
             if !tests.is_empty() {
                 let term = if tests.len() > 1 { "tests" } else { "test" };
                 println!("Running {} {} for {}", tests.len(), term, contract_name);

--- a/cli/src/cmd/forge/test.rs
+++ b/cli/src/cmd/forge/test.rs
@@ -482,7 +482,7 @@ fn test(
             let mut tests = suite_result.test_results.clone();
             println!();
             for warning in suite_result.warnings.iter() {
-                println!("{} {}", Colour::Yellow.bold().paint("Warning:"), warning);
+                eprintln!("{} {}", Colour::Yellow.bold().paint("Warning:"), warning);
             }
             if !tests.is_empty() {
                 let term = if tests.len() > 1 { "tests" } else { "test" };

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -369,12 +369,7 @@ mod tests {
                 ),
                 (
                     "core/MultipleSetup.t.sol:MultipleSetup",
-                    vec![(
-                        "setUp()",
-                        false,
-                        Some("Multiple setUp functions".to_string()),
-                        None,
-                    )],
+                    vec![("setUp()", false, Some("Multiple setUp functions".to_string()), None)],
                 ),
                 (
                     "core/Reverting.t.sol:RevertingTest",

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -297,7 +297,10 @@ mod tests {
     /// A helper to assert the outcome of multiple tests with helpful assert messages
     fn assert_multiple(
         actuals: &BTreeMap<String, SuiteResult>,
-        expecteds: BTreeMap<&str, Vec<(&str, bool, Option<String>, Option<Vec<String>>)>>,
+        expecteds: BTreeMap<
+            &str,
+            Vec<(&str, bool, Option<String>, Option<Vec<String>>, Option<usize>)>,
+        >,
     ) {
         assert_eq!(
             actuals.len(),
@@ -311,9 +314,11 @@ mod tests {
                 "We did not run as many test functions as we expected for {}",
                 contract_name
             );
-            for (test_name, should_pass, reason, expected_logs) in tests {
+            for (test_name, should_pass, reason, expected_logs, expected_warning_count) in tests {
                 let logs =
                     decode_console_logs(&actuals[*contract_name].test_results[*test_name].logs);
+
+                let warnings_count = &actuals[*contract_name].warnings.len();
 
                 if *should_pass {
                     assert!(
@@ -346,6 +351,14 @@ mod tests {
                         expected_logs.join("\n")
                     );
                 }
+
+                if let Some(expected_warning_count) = expected_warning_count {
+                    assert_eq!(
+                        warnings_count, expected_warning_count,
+                        "Test {} did not pass as expected. Expected:\n{}Got:\n{}",
+                        test_name, warnings_count, expected_warning_count
+                    );
+                }
             }
         }
     }
@@ -365,40 +378,56 @@ mod tests {
                         false,
                         Some("Setup failed: setup failed predictably".to_string()),
                         None,
+                        None,
                     )],
                 ),
                 (
                     "core/MultipleSetup.t.sol:MultipleSetup",
-                    vec![("setUp()", false, Some("Multiple setUp functions".to_string()), None)],
+                    vec![(
+                        "setUp()",
+                        false,
+                        Some("Multiple setUp functions".to_string()),
+                        None,
+                        Some(1),
+                    )],
                 ),
                 (
                     "core/Reverting.t.sol:RevertingTest",
-                    vec![("testFailRevert()", true, None, None)],
+                    vec![("testFailRevert()", true, None, None, None)],
                 ),
                 (
                     "core/SetupConsistency.t.sol:SetupConsistencyCheck",
-                    vec![("testAdd()", true, None, None), ("testMultiply()", true, None, None)],
+                    vec![
+                        ("testAdd()", true, None, None, None),
+                        ("testMultiply()", true, None, None, None),
+                    ],
                 ),
                 (
                     "core/DSStyle.t.sol:DSStyleTest",
-                    vec![("testFailingAssertions()", true, None, None)],
+                    vec![("testFailingAssertions()", true, None, None, None)],
                 ),
                 (
                     "core/DappToolsParity.t.sol:DappToolsParityTest",
                     vec![
-                        ("testAddresses()", true, None, None),
-                        ("testEnvironment()", true, None, None),
+                        ("testAddresses()", true, None, None, None),
+                        ("testEnvironment()", true, None, None, None),
                     ],
                 ),
                 (
                     "core/PaymentFailure.t.sol:PaymentFailureTest",
-                    vec![("testCantPay()", false, Some("Revert".to_string()), None)],
+                    vec![("testCantPay()", false, Some("Revert".to_string()), None, None)],
                 ),
                 (
                     "core/LibraryLinking.t.sol:LibraryLinkingTest",
-                    vec![("testDirect()", true, None, None), ("testNested()", true, None, None)],
+                    vec![
+                        ("testDirect()", true, None, None, None),
+                        ("testNested()", true, None, None, None),
+                    ],
                 ),
-                ("core/Abstract.t.sol:AbstractTest", vec![("testSomething()", true, None, None)]),
+                (
+                    "core/Abstract.t.sol:AbstractTest",
+                    vec![("testSomething()", true, None, None, None)],
+                ),
             ]),
         );
     }
@@ -414,19 +443,33 @@ mod tests {
                 (
                     "logs/DebugLogs.t.sol:DebugLogsTest",
                     vec![
-                        ("test1()", true, None, Some(vec!["0".into(), "1".into(), "2".into()])),
-                        ("test2()", true, None, Some(vec!["0".into(), "1".into(), "3".into()])),
+                        (
+                            "test1()",
+                            true,
+                            None,
+                            Some(vec!["0".into(), "1".into(), "2".into()]),
+                            None,
+                        ),
+                        (
+                            "test2()",
+                            true,
+                            None,
+                            Some(vec!["0".into(), "1".into(), "3".into()]),
+                            None,
+                        ),
                         (
                             "testFailWithRequire()",
                             true,
                             None,
                             Some(vec!["0".into(), "1".into(), "5".into()]),
+                            None,
                         ),
                         (
                             "testFailWithRevert()",
                             true,
                             None,
                             Some(vec!["0".into(), "1".into(), "4".into(), "100".into()]),
+                            None,
                         ),
                     ],
                 ),
@@ -444,6 +487,7 @@ mod tests {
                                 "2".into(),
                                 "3".into(),
                             ]),
+                            None,
                         ),
                         (
                             "testMisc()",
@@ -454,12 +498,14 @@ mod tests {
                                 "testMisc, 0x0000000000000000000000000000000000000001".into(),
                                 "testMisc, 42".into(),
                             ]),
+                            None,
                         ),
                         (
                             "testStrings()",
                             true,
                             None,
                             Some(vec!["constructor".into(), "testStrings".into()]),
+                            None,
                         ),
                     ],
                 ),

--- a/forge/src/multi_runner.rs
+++ b/forge/src/multi_runner.rs
@@ -368,6 +368,15 @@ mod tests {
                     )],
                 ),
                 (
+                    "core/MultipleSetup.t.sol:MultipleSetup",
+                    vec![(
+                        "setUp()",
+                        false,
+                        Some("Multiple setUp functions".to_string()),
+                        None,
+                    )],
+                ),
+                (
                     "core/Reverting.t.sol:RevertingTest",
                     vec![("testFailRevert()", true, None, None)],
                 ),

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -26,11 +26,17 @@ pub struct SuiteResult {
     pub duration: Duration,
     /// Individual test results. `test method name -> TestResult`
     pub test_results: BTreeMap<String, TestResult>,
+    // Warnings
+    pub warnings: Vec<String>,
 }
 
 impl SuiteResult {
-    pub fn new(duration: Duration, test_results: BTreeMap<String, TestResult>) -> Self {
-        Self { duration, test_results }
+    pub fn new(
+        duration: Duration,
+        test_results: BTreeMap<String, TestResult>,
+        warnings: Vec<String>,
+    ) -> Self {
+        Self { duration, test_results, warnings }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -268,7 +274,44 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
     ) -> Result<SuiteResult> {
         tracing::info!("starting tests");
         let start = Instant::now();
+        let mut warnings = Vec::new();
         let needs_setup = self.contract.functions().any(|func| func.name == "setUp");
+
+        let setup_fns: Vec<_> = self.contract.functions().filter_map(|func| {
+            if func.name.to_lowercase() == "setup" {
+                Some(func.signature())
+            } else {
+                None
+            }}).collect();
+
+        // There are multiple setUp function, so we return a single test result for `setUp`
+        if setup_fns.len() > 1 {
+            return Ok(SuiteResult::new(
+                start.elapsed(),
+                [(
+                    "setUp()".to_string(),
+                    TestResult {
+                        success: false,
+                        reason: Some("Multiple setUp functions".to_string()),
+                        counterexample: None,
+                        logs: vec![],
+                        kind: TestKind::Standard(0),
+                        traces: vec![],
+                        labeled_addresses: BTreeMap::new()
+                    },
+                )]
+                .into(),
+                warnings,
+            ))
+        }
+
+        // There is a single miss-cased `setUp` function, so we add a warning
+        if !needs_setup && setup_fns.len() == 1 {
+            warnings.push(format!(
+                "Found invalid setup function \"{}\" did you mean \"setUp()\"?",
+                setup_fns[0]
+            ));
+        }
 
         let setup = self.setup(needs_setup)?;
         if setup.setup_failed {
@@ -288,6 +331,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                     },
                 )]
                 .into(),
+                warnings,
             ))
         }
 
@@ -329,7 +373,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                 test_results.len()
             );
         }
-        Ok(SuiteResult::new(duration, test_results))
+        Ok(SuiteResult::new(duration, test_results, warnings))
     }
 
     #[tracing::instrument(name = "test", skip_all, fields(name = %func.signature(), %should_fail))]

--- a/forge/src/runner.rs
+++ b/forge/src/runner.rs
@@ -277,12 +277,17 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
         let mut warnings = Vec::new();
         let needs_setup = self.contract.functions().any(|func| func.name == "setUp");
 
-        let setup_fns: Vec<_> = self.contract.functions().filter_map(|func| {
-            if func.name.to_lowercase() == "setup" {
-                Some(func.signature())
-            } else {
-                None
-            }}).collect();
+        let setup_fns: Vec<_> = self
+            .contract
+            .functions()
+            .filter_map(|func| {
+                if func.name.to_lowercase() == "setup" {
+                    Some(func.signature())
+                } else {
+                    None
+                }
+            })
+            .collect();
 
         // There are multiple setUp function, so we return a single test result for `setUp`
         if setup_fns.len() > 1 {
@@ -297,7 +302,7 @@ impl<'a, DB: DatabaseRef + Send + Sync> ContractRunner<'a, DB> {
                         logs: vec![],
                         kind: TestKind::Standard(0),
                         traces: vec![],
-                        labeled_addresses: BTreeMap::new()
+                        labeled_addresses: BTreeMap::new(),
                     },
                 )]
                 .into(),

--- a/testdata/core/MultipleSetup.t.sol
+++ b/testdata/core/MultipleSetup.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import "ds-test/test.sol";
+
+contract MultipleSetup is DSTest {
+    function setUp() public { }
+
+    function setup() public { }
+
+    function testFailShouldBeMarkedAsFailedBecauseOfSetup() public {
+      assert(true);
+    }
+}


### PR DESCRIPTION
## Motivation

Following conversation on https://github.com/gakonst/foundry/issues/1167 and https://github.com/gakonst/foundry/pull/1276 this PR adds:
- warnings for when there is a single miss-cased `setUp` function
- returns test run error when there are multiple `setUp` functions with different cases

## Solution

- return single `SuiteResult` if we detect multiple setUp functions
- Added warnings to `SuiteResult` and pushes a warning if there is a single miss-cased `setUp` function