### PR TITLE
chore: Fix broken link to cast documentation

### DIFF
--- a/cast/README.md
+++ b/cast/README.md
@@ -2,7 +2,7 @@
 
 **Need help with Cast? Read the [📖 Foundry Book (Cast Guide)][foundry-book-cast-guide] (WIP)!**
 
-[foundry-book-cast-guide]: https://onbjerg.github.io/foundry-book/cast/
+[foundry-book-cast-guide]: https://book.getfoundry.sh/cast/index.html
 
 ## Features
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Link to Cast section of foundry-book was dead / outdated. (error 404)
See screenshot:
<img width="919" alt="image" src="https://user-images.githubusercontent.com/15629702/163354220-d322ee11-9b6e-4401-83ed-c36683e4e435.png">


## Solution
Fix by adding link to: https://book.getfoundry.sh/cast/index.html
